### PR TITLE
Bugfix to interaction_priority to remove error when using a value of "proportion"

### DIFF
--- a/LDAR_Sim/src/methods/company.py
+++ b/LDAR_Sim/src/methods/company.py
@@ -280,10 +280,11 @@ class BaseCompany:
                 prop_to_flag = int(math.ceil(
                     len(site_wl) * self.config['follow_up']['proportion']))
                 # site_wl is an ordered by leak size.
-                site_wl_subset = site_wl.items()[:prop_to_flag]
-                target_sites = [site for sdx, site in site_wl_subset
-                                if site['site_measured_rate']
-                                > self.config['follow_up']['threshold']]
+                if prop_to_flag > 0.0:
+                    site_wl_subset = list(site_wl.values())[:prop_to_flag]
+                    target_sites = [site for site in site_wl_subset
+                                    if site['site_measured_rate']
+                                    > self.config['follow_up']['threshold']]
             if self.config['follow_up']['interaction_priority'] == 'threshold':
                 sites_above_thresh = [site for sdx, site in site_wl.items()
                                       if site['site_measured_rate']


### PR DESCRIPTION
Previously, interaction_priority would result in an error when the interaction priority was set to "proportion". This was the result of dict.items() being unsubscriptable, resulting in an error when indexing was attempted on the result of a dictionary.items() call. Now the return value from dictionary.items() is converted to a list to allow for indexing. A check to ensure the dictionary is populated was also added.

Testing was performing by adding/altering the following parameters in M_Air.yaml for the default sample simulation. n_processes for G_.yaml was also set to 1 to allow the use of a print statement to print the length of target_sites under line 287 in company.py for verification against the timeseries output of OGI_FU_sites_visited.

M_Air testing changes:

Added:
follow_up:
  interaction_priority: 'proportion'
  proportion: 0.5

Altered:
MDL: [10.55] -- was previously [5.55]