### PR TITLE
BUGFIX for leak rates sampling from file

### DIFF
--- a/LDAR_Sim/src/initialization/sites.py
+++ b/LDAR_Sim/src/initialization/sites.py
@@ -165,7 +165,6 @@ def generate_sites(program, in_dir, pregen_leaks):
             site_timeseries = generate_leak_timeseries(program, site)
             leak_timeseries.update({site['facility_ID']: site_timeseries})
             del site['leak_rate_dist']
-            program['emissions'].pop('empirical_leaks', None)
 
     if pregen_leaks:
         return sites, leak_timeseries, initial_leaks


### PR DESCRIPTION
Removed line of code that would pop empirical_emissions from program state, as program state is shared between simulations during leak creation.