### PR TITLE
docs: update E2E testing README.md

### DIFF
--- a/LDAR_Sim/testing/end_to_end_testing/README.md
+++ b/LDAR_Sim/testing/end_to_end_testing/README.md
@@ -8,7 +8,7 @@
 2. Run the test suite creator using the command:
 
     ```cmd
-    python LDAR_Sim/LDAR_Sim/testing/end_to_end_testing/e2e_test_case_creator.py <inputs folder> <parameters folder> <test_name> <Global parameter file name>
+    python LDAR_Sim/testing/end_to_end_testing/e2e_test_case_creator.py <inputs folder> <parameters folder> <test_name> <Global parameter file name>
     ```
 
     from a conda terminal inside the LDAR-Sim repository at the highest level directory, where "inputs folder" and "parameters folder" are paths to the inputs and parameters folders from base LDAR-Sim (the LDAR_Sim folder containing code) respectively. An example of this would be "inputs" and "simulations" respectively. <test_name> is a user input indicating what the end to end test case folder should be named. "Global parameter file is name of the global parameters file, for example: "G_.yaml".
@@ -22,7 +22,7 @@
 Run the End-To-End suite runner by running the command:
 
 ```cmd
-python LDAR_Sim/LDAR_Sim/testing/end_to_end_testing/e2e_suite_runner.py
+python LDAR_Sim/testing/end_to_end_testing/e2e_suite_runner.py
 ```
 
 from a conda terminal inside the LDAR-Sim repository at the highest level directory.


### PR DESCRIPTION
Reason for change: Previous documentation had an extra LDAR-Sim directory in the sample commands

Resolution: Removed extra LDAR-Sim from commands

Effect of change: N/A