### PR TITLE
Add site level follow ups

### DIFF
--- a/LDAR_Sim/src/methods/crew.py
+++ b/LDAR_Sim/src/methods/crew.py
@@ -123,6 +123,13 @@ class BaseCrew:
             site['last_component_survey'] = cur_ts
             if site_detect_results['found_leak']:
                 self.timeseries['{}_sites_vis_w_leaks'.format(m_name)][cur_ts] += 1
+        elif self.config['is_follow_up']:
+            site.update({'currently_flagged': False})
+            if site_detect_results['found_leak'] and \
+                    (self.config['measurement_scale'].lower() == 'site' or
+                     self.config['measurement_scale'].lower() == "equipment"):
+                self.timeseries['{}_sites_vis_w_leaks'.format(m_name)][cur_ts] += 1
+                self.candidate_flags.append(site_detect_results)
         elif site_detect_results['found_leak']:
             # all other sites flag
             self.timeseries['{}_sites_vis_w_leaks'.format(m_name)][cur_ts] += 1

--- a/LDAR_Sim/testing/unit_testing/test_methods/test_crew/crew_testing_fixtures.py
+++ b/LDAR_Sim/testing/unit_testing/test_methods/test_crew/crew_testing_fixtures.py
@@ -114,3 +114,604 @@ def mock_state_for_crew_testing_2_fix() -> 'dict[str,Any]':
     return {
         'empirical_vents': [1]
     }
+
+
+@pytest.fixture(name="mock_config_for_site_level_FU_visit_site_testing")
+def mock_config_for_site_level_FU_visit_site_testing_fix() -> 'dict[str, Any]':
+    return {
+        'scheduling': {
+            'LDAR_crew_init_location': [-114.062, 51.044],
+            'route_planning': False
+        },
+        'deployment_type': 'mobile',
+        'label': 'M_sl_FU',
+        'coverage': {
+            'spatial': 1.0,
+            'temporal': 1.0,
+        },
+        'sensor': {
+            'mod_loc': None,
+            'type': 'default',
+            'MDL': [1.0],
+            'QE': 0
+        },
+        'measurement_scale': 'site',
+        'is_follow_up': True
+    }
+
+
+@pytest.fixture(name="mock_timeseries_for_site_level_FU_visit_site_testing")
+def mock_timeseries_for_site_level_FU_visit_site_testing_fix() -> 'dict[str, Any]':
+    return {
+        'M_sl_FU_sites_vis_w_leaks': [0, 0],
+        'M_sl_FU_sites_visited': [0, 0],
+    }
+
+
+@pytest.fixture(name="mock_state_for_site_level_FU_visit_site_testing")
+def mock_state_for_site_level_FU_visit_site_testing_fix(mocker) -> 'dict[str, Any]':
+    # Create a mock object to replace the TimeCounter object
+    mock_tc = mocker.Mock(TimeCounter)
+
+    mock_tc.current_date = datetime.datetime(2017, 1, 1, 8, 0)
+    mock_tc.current_timestep = 1
+    return {
+        'site_visits': {'M_sl_FU': []},
+        't': mock_tc
+    }
+
+
+@pytest.fixture(name="mock_site_for_site_level_FU_visit_site_testing")
+def mock_site_for_site_level_FU_visit_site_testing_fix() -> tuple[dict]:
+    return {
+        'equipment_groups': 1,
+        'facility_ID': 1,
+        'subtype_code': 1,
+        'active_leaks': [
+            {
+                'leak_ID': 1,
+                'rate': 3,
+                'equipment_group': 1,
+                'M_test_sp_covered': 1
+            }
+        ],
+        'M_sl_FU_surveys_conducted': 0,
+        'M_sl_FU_surveys_done_this_year': 0,
+        'M_sl_FU_t_since_last_LDAR': 0,
+        'currently_flagged': True
+    }
+
+
+@pytest.fixture(name="mock_results_for_site_level_FU_visit_site_testing")
+def mock_results_for_site_level_FU_visit_site_testing_fix() -> tuple[dict]:
+    return (
+        {
+            'found_leak': True
+        },
+        [{
+            'found_leak': True,
+        }],
+        {
+            'equipment_groups': 1,
+            'facility_ID': 1,
+            'subtype_code': 1,
+            'active_leaks': [
+                {
+                    'leak_ID': 1,
+                    'rate': 3,
+                    'equipment_group': 1,
+                    'M_test_sp_covered': 1
+                }
+            ],
+            'M_sl_FU_surveys_conducted': 1,
+            'M_sl_FU_surveys_done_this_year': 1,
+            'M_sl_FU_t_since_last_LDAR': 0,
+            'historic_t_since_LDAR': 0,
+            'currently_flagged': False
+        },
+        {
+            'M_sl_FU_sites_vis_w_leaks': [0, 1],
+            'M_sl_FU_sites_visited': [0, 1],
+        }
+
+    )
+
+
+@pytest.fixture(name="mock_config_for_component_level_FU_visit_site_testing")
+def mock_config_for_component_level_FU_visit_site_testing_fix() -> 'dict[str, Any]':
+    return {
+        'scheduling': {
+            'LDAR_crew_init_location': [-114.062, 51.044],
+            'route_planning': False
+        },
+        'deployment_type': 'mobile',
+        'label': 'M_cl_FU',
+        'coverage': {
+            'spatial': 1.0,
+            'temporal': 1.0,
+        },
+        'sensor': {
+            'mod_loc': None,
+            'type': 'default',
+            'MDL': [1.0],
+            'QE': 0
+        },
+        'measurement_scale': 'component',
+        'is_follow_up': True
+    }
+
+
+@pytest.fixture(name="mock_timeseries_for_component_level_FU_visit_site_testing")
+def mock_timeseries_for_component_level_FU_visit_site_testing_fix() -> 'dict[str, Any]':
+    return {
+        'M_cl_FU_sites_vis_w_leaks': [0, 0],
+        'M_cl_FU_sites_visited': [0, 0],
+    }
+
+
+@pytest.fixture(name="mock_state_for_component_level_FU_visit_site_testing")
+def mock_state_for_component_level_FU_visit_site_testing_fix(mocker) -> 'dict[str, Any]':
+    # Create a mock object to replace the TimeCounter object
+    mock_tc = mocker.Mock(TimeCounter)
+
+    mock_tc.current_date = datetime.datetime(2017, 1, 1, 8, 0)
+    mock_tc.current_timestep = 1
+    return {
+        'site_visits': {'M_cl_FU': []},
+        't': mock_tc
+    }
+
+
+@pytest.fixture(name="mock_site_for_component_level_FU_visit_site_testing")
+def mock_site_for_component_level_follow_up_visit_site_testing_fix() -> tuple[dict]:
+    return {
+        'equipment_groups': 1,
+        'facility_ID': 1,
+        'subtype_code': 1,
+        'active_leaks': [
+            {
+                'leak_ID': 1,
+                'rate': 3,
+                'equipment_group': 1,
+                'M_test_sp_covered': 1
+            }
+        ],
+        'M_cl_FU_surveys_conducted': 0,
+        'M_cl_FU_surveys_done_this_year': 0,
+        'M_cl_FU_t_since_last_LDAR': 0,
+        'currently_flagged': True
+    }
+
+
+@pytest.fixture(name="mock_results_for_component_level_FU_visit_site_testing")
+def mock_results_for_component_level_FU_visit_site_testing_fix() -> tuple[dict]:
+    return (
+        {
+            'found_leak': True
+        },
+        [],
+        {
+            'equipment_groups': 1,
+            'facility_ID': 1,
+            'subtype_code': 1,
+            'active_leaks': [
+                {
+                    'leak_ID': 1,
+                    'rate': 3,
+                    'equipment_group': 1,
+                    'M_test_sp_covered': 1
+                }
+            ],
+            'M_cl_FU_surveys_conducted': 1,
+            'M_cl_FU_surveys_done_this_year': 1,
+            'M_cl_FU_t_since_last_LDAR': 0,
+            'historic_t_since_LDAR': 0,
+            'currently_flagged': False,
+            'last_component_survey': 1
+        },
+        {
+            'M_cl_FU_sites_vis_w_leaks': [0, 1],
+            'M_cl_FU_sites_visited': [0, 1],
+        }
+
+    )
+
+
+@pytest.fixture(name="mock_config_for_site_level_FU_visit_site_testing_small_leak")
+def mock_config_for_site_level_FU_visit_site_testing_small_leak_fix() -> 'dict[str, Any]':
+    return {
+        'scheduling': {
+            'LDAR_crew_init_location': [-114.062, 51.044],
+            'route_planning': False
+        },
+        'deployment_type': 'mobile',
+        'label': 'M_sl_FU',
+        'coverage': {
+            'spatial': 1.0,
+            'temporal': 1.0,
+        },
+        'sensor': {
+            'mod_loc': None,
+            'type': 'default',
+            'MDL': [1.0],
+            'QE': 0
+        },
+        'measurement_scale': 'site',
+        'is_follow_up': True
+    }
+
+
+@pytest.fixture(name="mock_timeseries_for_site_level_FU_visit_site_testing_small_leak")
+def mock_timeseries_for_site_level_FU_visit_site_testing_small_leak_fix() -> 'dict[str, Any]':
+    return {
+        'M_sl_FU_sites_vis_w_leaks': [0, 0],
+        'M_sl_FU_sites_visited': [0, 0],
+    }
+
+
+@pytest.fixture(name="mock_state_for_site_level_FU_visit_site_testing_small_leak")
+def mock_state_for_site_level_FU_visit_site_testing_small_leak_fix(mocker) -> 'dict[str, Any]':
+    # Create a mock object to replace the TimeCounter object
+    mock_tc = mocker.Mock(TimeCounter)
+
+    mock_tc.current_date = datetime.datetime(2017, 1, 1, 8, 0)
+    mock_tc.current_timestep = 1
+    return {
+        'site_visits': {'M_sl_FU': []},
+        't': mock_tc
+    }
+
+
+@pytest.fixture(name="mock_site_for_site_level_FU_visit_site_testing_small_leak")
+def mock_site_for_site_level_FU_visit_site_testing_small_leak_fix() -> tuple[dict]:
+    return {
+        'equipment_groups': 1,
+        'facility_ID': 1,
+        'subtype_code': 1,
+        'active_leaks': [
+            {
+                'leak_ID': 1,
+                'rate': 0.5,
+                'equipment_group': 1,
+                'M_test_sp_covered': 1
+            }
+        ],
+        'M_sl_FU_surveys_conducted': 0,
+        'M_sl_FU_surveys_done_this_year': 0,
+        'M_sl_FU_t_since_last_LDAR': 0,
+        'currently_flagged': True
+    }
+
+
+@pytest.fixture(name="mock_results_for_site_level_FU_visit_site_testing_small_leak")
+def mock_results_for_site_level_FU_visit_site_testing_small_leak_fix() -> tuple[dict]:
+    return (
+        {
+            'found_leak': False
+        },
+        [],
+        {
+            'equipment_groups': 1,
+            'facility_ID': 1,
+            'subtype_code': 1,
+            'active_leaks': [
+                {
+                    'leak_ID': 1,
+                    'rate': 0.5,
+                    'equipment_group': 1,
+                    'M_test_sp_covered': 1
+                }
+            ],
+            'M_sl_FU_surveys_conducted': 1,
+            'M_sl_FU_surveys_done_this_year': 1,
+            'M_sl_FU_t_since_last_LDAR': 0,
+            'historic_t_since_LDAR': 0,
+            'currently_flagged': False
+        },
+        {
+            'M_sl_FU_sites_vis_w_leaks': [0, 0],
+            'M_sl_FU_sites_visited': [0, 1],
+        }
+
+    )
+
+
+@pytest.fixture(name="mock_config_for_component_level_FU_visit_site_testing_small_leak")
+def mock_config_for_component_level_FU_visit_site_testing_small_leak_fix() -> 'dict[str, Any]':
+    return {
+        'scheduling': {
+            'LDAR_crew_init_location': [-114.062, 51.044],
+            'route_planning': False
+        },
+        'deployment_type': 'mobile',
+        'label': 'M_cl_FU',
+        'coverage': {
+            'spatial': 1.0,
+            'temporal': 1.0,
+        },
+        'sensor': {
+            'mod_loc': None,
+            'type': 'default',
+            'MDL': [1.0],
+            'QE': 0
+        },
+        'measurement_scale': 'component',
+        'is_follow_up': True
+    }
+
+
+@pytest.fixture(name="mock_timeseries_for_component_level_FU_visit_site_testing_small_leak")
+def mock_timeseries_for_component_level_FU_visit_site_testing_small_leak_fix() -> 'dict[str, Any]':
+    return {
+        'M_cl_FU_sites_vis_w_leaks': [0, 0],
+        'M_cl_FU_sites_visited': [0, 0],
+    }
+
+
+@pytest.fixture(name="mock_state_for_component_level_FU_visit_site_testing_small_leak")
+def mock_state_for_component_level_FU_visit_site_testing_small_leak_fix(mocker) -> 'dict[str, Any]':
+    # Create a mock object to replace the TimeCounter object
+    mock_tc = mocker.Mock(TimeCounter)
+
+    mock_tc.current_date = datetime.datetime(2017, 1, 1, 8, 0)
+    mock_tc.current_timestep = 1
+    return {
+        'site_visits': {'M_cl_FU': []},
+        't': mock_tc
+    }
+
+
+@pytest.fixture(name="mock_site_for_component_level_FU_visit_site_testing_small_leak")
+def mock_site_for_component_level_follow_up_visit_site_testing_small_leak_fix() -> tuple[dict]:
+    return {
+        'equipment_groups': 1,
+        'facility_ID': 1,
+        'subtype_code': 1,
+        'active_leaks': [
+            {
+                'leak_ID': 1,
+                'rate': 0.5,
+                'equipment_group': 1,
+                'M_test_sp_covered': 1
+            }
+        ],
+        'M_cl_FU_surveys_conducted': 0,
+        'M_cl_FU_surveys_done_this_year': 0,
+        'M_cl_FU_t_since_last_LDAR': 0,
+        'currently_flagged': True
+    }
+
+
+@pytest.fixture(name="mock_results_for_component_level_FU_visit_site_testing_small_leak")
+def mock_results_for_component_level_FU_visit_site_testing_small_leak_fix() -> tuple[dict]:
+    return (
+        {
+            'found_leak': False
+        },
+        [],
+        {
+            'equipment_groups': 1,
+            'facility_ID': 1,
+            'subtype_code': 1,
+            'active_leaks': [
+                {
+                    'leak_ID': 1,
+                    'rate': 0.5,
+                    'equipment_group': 1,
+                    'M_test_sp_covered': 1
+                }
+            ],
+            'M_cl_FU_surveys_conducted': 1,
+            'M_cl_FU_surveys_done_this_year': 1,
+            'M_cl_FU_t_since_last_LDAR': 0,
+            'historic_t_since_LDAR': 0,
+            'currently_flagged': False,
+            'last_component_survey': 1
+        },
+        {
+            'M_cl_FU_sites_vis_w_leaks': [0, 0],
+            'M_cl_FU_sites_visited': [0, 1],
+        }
+
+    )
+
+
+@pytest.fixture(name="mock_config_for_site_level_non_FU_visit_site_testing")
+def mock_config_for_site_level_non_FU_visit_site_testing_fix() -> 'dict[str, Any]':
+    return {
+        'scheduling': {
+            'LDAR_crew_init_location': [-114.062, 51.044],
+            'route_planning': False
+        },
+        'deployment_type': 'mobile',
+        'label': 'M_sl_FU',
+        'coverage': {
+            'spatial': 1.0,
+            'temporal': 1.0,
+        },
+        'sensor': {
+            'mod_loc': None,
+            'type': 'default',
+            'MDL': [1.0],
+            'QE': 0
+        },
+        'measurement_scale': 'site',
+        'is_follow_up': False
+    }
+
+
+@pytest.fixture(name="mock_timeseries_for_site_level_non_FU_visit_site_testing")
+def mock_timeseries_for_site_level_non_FU_visit_site_testing_fix() -> 'dict[str, Any]':
+    return {
+        'M_sl_FU_sites_vis_w_leaks': [0, 0],
+        'M_sl_FU_sites_visited': [0, 0],
+    }
+
+
+@pytest.fixture(name="mock_state_for_site_level_non_FU_visit_site_testing")
+def mock_state_for_site_level_non_FU_visit_site_testing_fix(mocker) -> 'dict[str, Any]':
+    # Create a mock object to replace the TimeCounter object
+    mock_tc = mocker.Mock(TimeCounter)
+
+    mock_tc.current_date = datetime.datetime(2017, 1, 1, 8, 0)
+    mock_tc.current_timestep = 1
+    return {
+        'site_visits': {'M_sl_FU': []},
+        't': mock_tc
+    }
+
+
+@pytest.fixture(name="mock_site_for_site_level_non_FU_visit_site_testing")
+def mock_site_for_site_level_non_FU_visit_site_testing_fix() -> tuple[dict]:
+    return {
+        'equipment_groups': 1,
+        'facility_ID': 1,
+        'subtype_code': 1,
+        'active_leaks': [
+            {
+                'leak_ID': 1,
+                'rate': 3,
+                'equipment_group': 1,
+                'M_test_sp_covered': 1
+            }
+        ],
+        'M_sl_FU_surveys_conducted': 0,
+        'M_sl_FU_surveys_done_this_year': 0,
+        'M_sl_FU_t_since_last_LDAR': 0,
+        'currently_flagged': False
+    }
+
+
+@pytest.fixture(name="mock_results_for_site_level_non_FU_visit_site_testing")
+def mock_results_for_site_level_non_FU_visit_site_testing_fix() -> tuple[dict]:
+    return (
+        {
+            'found_leak': True
+        },
+        [{
+            'found_leak': True,
+        }],
+        {
+            'equipment_groups': 1,
+            'facility_ID': 1,
+            'subtype_code': 1,
+            'active_leaks': [
+                {
+                    'leak_ID': 1,
+                    'rate': 3,
+                    'equipment_group': 1,
+                    'M_test_sp_covered': 1
+                }
+            ],
+            'M_sl_FU_surveys_conducted': 1,
+            'M_sl_FU_surveys_done_this_year': 1,
+            'M_sl_FU_t_since_last_LDAR': 0,
+            'historic_t_since_LDAR': 0,
+            'currently_flagged': False
+        },
+        {
+            'M_sl_FU_sites_vis_w_leaks': [0, 1],
+            'M_sl_FU_sites_visited': [0, 1],
+        }
+
+    )
+
+
+@pytest.fixture(name="mock_config_for_site_level_non_FU_visit_site_testing_small_leak")
+def mock_config_for_site_level_non_FU_visit_site_testing_small_leak_fix() -> 'dict[str, Any]':
+    return {
+        'scheduling': {
+            'LDAR_crew_init_location': [-114.062, 51.044],
+            'route_planning': False
+        },
+        'deployment_type': 'mobile',
+        'label': 'M_cl_FU',
+        'coverage': {
+            'spatial': 1.0,
+            'temporal': 1.0,
+        },
+        'sensor': {
+            'mod_loc': None,
+            'type': 'default',
+            'MDL': [1.0],
+            'QE': 0
+        },
+        'measurement_scale': 'component',
+        'is_follow_up': False
+    }
+
+
+@pytest.fixture(name="mock_timeseries_for_site_level_non_FU_visit_site_testing_small_leak")
+def mock_timeseries_for_site_level_non_FU_visit_site_testing_small_leak_fix() -> 'dict[str, Any]':
+    return {
+        'M_cl_FU_sites_vis_w_leaks': [0, 0],
+        'M_cl_FU_sites_visited': [0, 0],
+    }
+
+
+@pytest.fixture(name="mock_state_for_site_level_non_FU_visit_site_testing_small_leak")
+def mock_state_for_site_level_non_FU_visit_site_testing_small_leak_fix(mocker) -> 'dict[str, Any]':
+    # Create a mock object to replace the TimeCounter object
+    mock_tc = mocker.Mock(TimeCounter)
+
+    mock_tc.current_date = datetime.datetime(2017, 1, 1, 8, 0)
+    mock_tc.current_timestep = 1
+    return {
+        'site_visits': {'M_cl_FU': []},
+        't': mock_tc
+    }
+
+
+@pytest.fixture(name="mock_site_for_site_level_non_FU_visit_site_testing_small_leak")
+def mock_site_for_site_level_non_FU_visit_site_testing_small_leak_fix() -> tuple[dict]:
+    return {
+        'equipment_groups': 1,
+        'facility_ID': 1,
+        'subtype_code': 1,
+        'active_leaks': [
+            {
+                'leak_ID': 1,
+                'rate': 0.5,
+                'equipment_group': 1,
+                'M_test_sp_covered': 1
+            }
+        ],
+        'M_cl_FU_surveys_conducted': 0,
+        'M_cl_FU_surveys_done_this_year': 0,
+        'M_cl_FU_t_since_last_LDAR': 0,
+        'currently_flagged': False
+    }
+
+
+@pytest.fixture(name="mock_results_for_site_level_non_FU_visit_site_testing_small_leak")
+def mock_results_for_site_level_non_FU_visit_site_testing_small_leak_fix() -> tuple[dict]:
+    return (
+        {
+            'found_leak': False
+        },
+        [],
+        {
+            'equipment_groups': 1,
+            'facility_ID': 1,
+            'subtype_code': 1,
+            'active_leaks': [
+                {
+                    'leak_ID': 1,
+                    'rate': 0.5,
+                    'equipment_group': 1,
+                    'M_test_sp_covered': 1
+                }
+            ],
+            'M_cl_FU_surveys_conducted': 1,
+            'M_cl_FU_surveys_done_this_year': 1,
+            'M_cl_FU_t_since_last_LDAR': 0,
+            'historic_t_since_LDAR': 0,
+            'currently_flagged': False,
+            'last_component_survey': 1
+        },
+        {
+            'M_cl_FU_sites_vis_w_leaks': [0, 0],
+            'M_cl_FU_sites_visited': [0, 1],
+        }
+
+    )

--- a/LDAR_Sim/testing/unit_testing/test_methods/test_crew/test_visit_site.py
+++ b/LDAR_Sim/testing/unit_testing/test_methods/test_crew/test_visit_site.py
@@ -1,0 +1,132 @@
+"""Test file to unit test crew.py visit_site() functionality"""
+import os
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+from src.methods.crew import BaseCrew
+
+from testing.unit_testing.test_methods.test_crew.crew_testing_fixtures import (  # noqa: F401
+    mock_config_for_component_level_FU_visit_site_testing_fix,
+    mock_site_for_component_level_follow_up_visit_site_testing_fix,
+    mock_state_for_component_level_FU_visit_site_testing_fix,
+    mock_timeseries_for_component_level_FU_visit_site_testing_fix,
+    mock_results_for_component_level_FU_visit_site_testing_fix,
+    mock_config_for_site_level_FU_visit_site_testing_fix,
+    mock_site_for_site_level_FU_visit_site_testing_fix,
+    mock_state_for_site_level_FU_visit_site_testing_fix,
+    mock_timeseries_for_site_level_FU_visit_site_testing_fix,
+    mock_results_for_site_level_FU_visit_site_testing_fix,
+    mock_config_for_component_level_FU_visit_site_testing_small_leak_fix,
+    mock_site_for_component_level_follow_up_visit_site_testing_small_leak_fix,
+    mock_state_for_component_level_FU_visit_site_testing_small_leak_fix,
+    mock_timeseries_for_component_level_FU_visit_site_testing_small_leak_fix,
+    mock_results_for_component_level_FU_visit_site_testing_small_leak_fix,
+    mock_config_for_site_level_FU_visit_site_testing_small_leak_fix,
+    mock_site_for_site_level_FU_visit_site_testing_small_leak_fix,
+    mock_state_for_site_level_FU_visit_site_testing_small_leak_fix,
+    mock_timeseries_for_site_level_FU_visit_site_testing_small_leak_fix,
+    mock_results_for_site_level_FU_visit_site_testing_small_leak_fix,
+    mock_config_for_site_level_non_FU_visit_site_testing_fix,
+    mock_site_for_site_level_non_FU_visit_site_testing_fix,
+    mock_state_for_site_level_non_FU_visit_site_testing_fix,
+    mock_timeseries_for_site_level_non_FU_visit_site_testing_fix,
+    mock_results_for_site_level_non_FU_visit_site_testing_fix,
+    mock_config_for_site_level_non_FU_visit_site_testing_small_leak_fix,
+    mock_site_for_site_level_non_FU_visit_site_testing_small_leak_fix,
+    mock_state_for_site_level_non_FU_visit_site_testing_small_leak_fix,
+    mock_timeseries_for_site_level_non_FU_visit_site_testing_small_leak_fix,
+    mock_results_for_site_level_non_FU_visit_site_testing_small_leak_fix
+    )
+
+
+@pytest.mark.parametrize("test_input, expected", [
+    # Test site level follow-up where leak is found
+    (
+        (
+            "mock_site_for_site_level_FU_visit_site_testing",
+            "mock_config_for_site_level_FU_visit_site_testing",
+            "mock_state_for_site_level_FU_visit_site_testing",
+            "mock_timeseries_for_site_level_FU_visit_site_testing"
+        ),
+        ("mock_results_for_site_level_FU_visit_site_testing")
+    ),
+    # Test site level follow-up where leak is missed
+    (
+        (
+            "mock_site_for_site_level_FU_visit_site_testing_small_leak",
+            "mock_config_for_site_level_FU_visit_site_testing_small_leak",
+            "mock_state_for_site_level_FU_visit_site_testing_small_leak",
+            "mock_timeseries_for_site_level_FU_visit_site_testing_small_leak"
+        ),
+        ("mock_results_for_site_level_FU_visit_site_testing_small_leak")
+    ),
+    # Test component level follow-up where leak is found
+    (
+        (
+            "mock_site_for_component_level_FU_visit_site_testing",
+            "mock_config_for_component_level_FU_visit_site_testing",
+            "mock_state_for_component_level_FU_visit_site_testing",
+            "mock_timeseries_for_component_level_FU_visit_site_testing"
+        ),
+        ("mock_results_for_component_level_FU_visit_site_testing")
+    ),
+    # Test component level follow-up where leak is missed
+    (
+        (
+            "mock_site_for_component_level_FU_visit_site_testing_small_leak",
+            "mock_config_for_component_level_FU_visit_site_testing_small_leak",
+            "mock_state_for_component_level_FU_visit_site_testing_small_leak",
+            "mock_timeseries_for_component_level_FU_visit_site_testing_small_leak"
+        ),
+        ("mock_results_for_component_level_FU_visit_site_testing_small_leak")
+    ),
+    # Test site level screening (non follow-up) where leak is found
+    (
+        (
+            "mock_site_for_site_level_non_FU_visit_site_testing",
+            "mock_config_for_site_level_non_FU_visit_site_testing",
+            "mock_state_for_site_level_non_FU_visit_site_testing",
+            "mock_timeseries_for_site_level_non_FU_visit_site_testing"
+        ),
+        ("mock_results_for_site_level_non_FU_visit_site_testing")
+    ),
+    # Test site level screening (non follow-up) where leak is missed
+    (
+        (
+            "mock_site_for_site_level_non_FU_visit_site_testing_small_leak",
+            "mock_config_for_site_level_non_FU_visit_site_testing_small_leak",
+            "mock_state_for_site_level_non_FU_visit_site_testing_small_leak",
+            "mock_timeseries_for_site_level_non_FU_visit_site_testing_small_leak"
+
+        ),
+        ("mock_results_for_site_level_non_FU_visit_site_testing_small_leak")
+    ),
+]
+)
+def test_053_visit_site_gives_expected_behavior(
+    mocker, test_input, expected, request
+) -> None:
+    # Add src directory to the path
+    sys.path.insert(1, str(Path(os.path.dirname(os.path.realpath(__file__))
+                                ).parent.parent.parent.parent / "src"))
+    crew = BaseCrew(
+        request.getfixturevalue(test_input[2]),
+        None,
+        request.getfixturevalue(test_input[1]),
+        request.getfixturevalue(test_input[3]),
+        None,
+        None
+    )
+    mocker.patch.object(BaseCrew, 'detect_emissions',
+                        return_value=request.getfixturevalue(expected)[0])
+    mocker.patch.object(BaseCrew, 'gen_site_vis_rec',
+                        return_value={})
+    crew.candidate_flags = []
+    site = request.getfixturevalue(test_input[0])
+    crew.visit_site(site)
+    result: Any = crew.candidate_flags
+    assert result == request.getfixturevalue(expected)[1]
+    assert site == request.getfixturevalue(expected)[2]
+    assert crew.timeseries == request.getfixturevalue(expected)[3]

--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -1290,11 +1290,11 @@ Method costs. Currency is not important but must be consistent across all inputs
 
 **Default input:** N/A
 
-**Description:** Allows for surveying methods to determine which follow-up method to run if multiples are present. If not set, LDAR-Sim will expect only 1 followup method to be present for a single program.
+**Description:** Allows for surveying methods to determine which follow-up method to run if multiples are present. If not set, LDAR-Sim will expect only 1 followup method to be present for a single program. Site level follow-up methods can be used by leveraging this parameter, allowing for subsequent rounds of screenings based on initial screening results. This feature can be used to model work-practices with multiple screening done in order to increase confidence in fugitive emissions, measurement accuracy, etc. Each method in the follow-up chain must have the preferred_method set to the corresponding method it triggers.
 
 **Notes on acquisition:** N/A
 
-**Notes of caution:** If method within a program is set to have a preferred follow up method, all methods used by the program should also be set with a preferred method to avoid ambiguity of which followup method is being used.
+**Notes of caution:** If method within a program is set to have a preferred follow up method, all methods used by the program should also be set with a preferred method to avoid ambiguity of which followup method is being used. The last follow-up method in a work practice must be at a component level for leaks to be tagged and then repaired.
 
 #### delay
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 2023-06 - Version 2.1.4
+
+1. **Added functionality for site level follow-ups** Users can now have measurement_scale "site" level follow ups by leveraging the follow-up: preferred_method parameter. This allows for modelling of multiple screenings based on the results of each prior screening (Which could increase confidence in fugitives, improve measurement accuracy, etc).
+
 ## 2023-06 - Version 2.1.3
 
 1. **Added documentation for subtype_file functionality** Added documentation to the user manual to describe subtype file functionality.


### PR DESCRIPTION
Visit site logic was altered to support unflagging/reflagging of sites when the measurement scale of the sensor used by the crew visiting the site is "site-level" and the crew belongs to a follow-up method. Unit testing was added to verify functionality of the modified visit_site functionality.

This change was made to resolve the need for some site-level measurement scale methods method to be follow-up methods, as described by #56.

The purpose of this changes is to enable the use of site-level measurement scale follow-up method in LDAR-Sim.

This pull request is anticipated to result in a patch level version bump from 2.1.3 to 2.1.4

Closes #56 

E2E testing passed: 
[E2E testing Results.zip](https://github.com/LDAR-Sim/LDAR_Sim/files/11793885/E2E.testing.Results.zip)
