### PR TITLE
style: Update issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,26 @@
+---
+name: Bug report
+about: Report a bug or defect in LDAR-Sim
+title: "[BUG] Brief Description"
+labels: ''
+assignees: ''
+
+---
+
+### Description of the Bug/Defect
+Describe the bug/defect in as much detail as possible. Be clear and concise.
+
+### Steps to reproduce 
+Describe steps to reproduce the bug/defect. Be as accurate as possible in describing the steps to reproduce.
+
+### Evidence
+Include screenshots, error messages, output files and any other material that may be useful here to explain what happened
+
+### Expected behavior
+Describe what you expected to happen. How is it different from what happened? Be clear and concise.
+
+### Inputs and Parameters
+As part of the submissions for a bug report, include a zipped folder containing the LDAR-Sim input files and parameters if relevant and they do not contain confidential information. If they do contain confidential information, if it is possible to remove or redact that information and submit the files, it is recommended to do so.
+
+### Additional Context
+Include any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,23 @@
+---
+name: Feature request
+about: Request new functionality for LDAR-Sim
+title: "[FEAT] Brief Description"
+labels: ''
+assignees: ''
+
+---
+
+### Requested Feature
+Describe the feature being requested in detail. Be clear and concise. 
+
+### Need for feature
+Describe why the feature is important.
+
+### Problem to solve
+Describe what problem the feature will solve, if any.
+
+### Implementation Ideas
+Describe the ideas, if any that you have for how to solve the problem outlined as part of this feature request.
+
+### Additional context
+Include any other context about the feature request here.


### PR DESCRIPTION
Reason for change: Currently, there is no template or standardized procedure for GitHub issues, making it difficult for developers to track and compare bugs and requested features.

Resolution: Adding GitHub issue templates will help to standardize the development process and make it easer for developers to review issues.

Effect(s) of change: Users will be advised to use Issue templates when creating new Issues for LDAR-Sim