### PR TITLE
<FEAT>: Update output file names

### DIFF
--- a/LDAR_Sim/src/ldar_sim.py
+++ b/LDAR_Sim/src/ldar_sim.py
@@ -520,17 +520,20 @@ class LdarSim:
             # Write csv files
             leak_df.to_csv(
                 self.output_dir /
-                'leaks_output_{}.csv'.format(virtual_world['simulation']),
+                'leaks_output_{}_{}.csv'.format(
+                    virtual_world['simulation'], program_parameters['program_name']),
                 index=False)
 
             time_df.to_csv(
                 self.output_dir /
-                'timeseries_output_{}.csv'.format(virtual_world['simulation']),
+                'timeseries_output_{}_{}.csv'.format(
+                    virtual_world['simulation'], program_parameters['program_name']),
                 index=False)
 
             site_df.to_csv(
                 self.output_dir /
-                'sites_output_{}.csv'.format(virtual_world['simulation']),
+                'sites_output_{}_{}.csv'.format(
+                    virtual_world['simulation'], program_parameters['program_name']),
                 index=False)
 
             for meth, meth_vis_df in site_visits.items():

--- a/LDAR_Sim/src/out_processing/batch_reporting.py
+++ b/LDAR_Sim/src/out_processing/batch_reporting.py
@@ -489,7 +489,8 @@ class BatchReporting:
         method_lists = []
         for i in range(len(self.directories)):
             df = pd.read_csv(
-                self.output_directory / self.directories[i] / "timeseries_output_0.csv")
+                self.output_directory / self.directories[i] /
+                "timeseries_output_0_{}.csv".format(self.directories[i]))
             df = df.filter(regex='cost$', axis=1)
             df = df.drop(columns=["total_daily_cost"])
             method_lists.append(list(df))

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 2023-07 - Version 3.0.1
+
+1. **Updated Output CSV file names** The output file names will now also contain program name.
+
 ## 2023-07 - Version 3.0.0
 
 1. **Refactored Parameter Structure** The LDAR-Sim parameter structure has been refactored. Many of the parameters previously in the program level can now be located in the new virtual_world parameters file. This will help make LDAR-Sim parameterization more intuitive.


### PR DESCRIPTION
Reason for change:
Ease of use for users who open multiple output files simultaneously

Resolution:
Add program name to output file names

Effect(s) of change:
Only affects CSV file names

# Pull Request Key Information

## What was changed

Output file names will now contain the program name

## Intended Purpose

Improve the user experience navigating through different output files

## Level of version change required

Minor patch update

## Testing Completed

Ran all existing E2E and unit tests, Passed 100%. 
[E2E Test Results.zip](https://github.com/LDAR-Sim/LDAR_Sim/files/12232136/E2E.Test.Results.zip)

## Target Issue

Closes #81 

## Additional Information

Include any other important information here.
