### PR TITLE
Rework n_init_leaks

### DIFF
--- a/LDAR_Sim/src/default_parameters/virtual_world_default.yml
+++ b/LDAR_Sim/src/default_parameters/virtual_world_default.yml
@@ -19,5 +19,5 @@ emissions:
   max_leak_rate: 100000.0
   units: ["kilogram", "hour"]
 NRd: 365
-n_init_leaks: "_placeholder_int_"
+n_init_leaks_prob: "_placeholder_float_"
 n_init_days: "_placeholder_int_"

--- a/LDAR_Sim/src/initialization/leaks.py
+++ b/LDAR_Sim/src/initialization/leaks.py
@@ -123,15 +123,15 @@ def generate_initial_leaks(virtual_world, site, start_date):
         NRd = virtual_world['NRd']
         LPR = virtual_world['emissions']['LPR']
 
-    if virtual_world['n_init_leaks'] is not None:
-        n_leaks = virtual_world['n_init_leaks']
-    else:
-        n_leaks = random.binomial(NRd, LPR)
-
     if virtual_world['n_init_days'] is not None:
         init_max_days_active = virtual_world['n_init_days']
     else:
         init_max_days_active = NRd
+
+    if virtual_world['n_init_leaks_prob'] is not None:
+        n_leaks = random.binomial(init_max_days_active, virtual_world['n_init_leaks_prob'])
+    else:
+        n_leaks = random.binomial(init_max_days_active, LPR)
 
     prog_start_date = datetime(*start_date)
 

--- a/LDAR_Sim/testing/end_to_end_testing/test_suite/Site_level_venting/expected_outputs/parameters.yaml
+++ b/LDAR_Sim/testing/end_to_end_testing/test_suite/Site_level_venting/expected_outputs/parameters.yaml
@@ -319,7 +319,7 @@ virtual_world:
       - hour
   infrastructure_file: facilities_Perm.csv
   n_init_days: null
-  n_init_leaks: null
+  n_init_leaks_prob: null
   parameter_level: virtual_world
   repair_delay:
     type: default

--- a/LDAR_Sim/testing/end_to_end_testing/test_suite/Test_follow_up_parameters/expected_outputs/parameters.yaml
+++ b/LDAR_Sim/testing/end_to_end_testing/test_suite/Test_follow_up_parameters/expected_outputs/parameters.yaml
@@ -738,7 +738,7 @@ virtual_world:
       - hour
   infrastructure_file: facilities_alberta.csv
   n_init_days: null
-  n_init_leaks: null
+  n_init_leaks_prob: null
   parameter_level: virtual_world
   repair_delay:
     type: default

--- a/LDAR_Sim/testing/end_to_end_testing/test_suite/basic_test_LPRx2/expected_outputs/parameters.yaml
+++ b/LDAR_Sim/testing/end_to_end_testing/test_suite/basic_test_LPRx2/expected_outputs/parameters.yaml
@@ -319,7 +319,7 @@ virtual_world:
       - hour
   infrastructure_file: facilities_Perm.csv
   n_init_days: null
-  n_init_leaks: null
+  n_init_leaks_prob: null
   parameter_level: virtual_world
   repair_delay:
     type: default

--- a/LDAR_Sim/testing/end_to_end_testing/test_suite/simple_test_case_1/expected_outputs/parameters.yaml
+++ b/LDAR_Sim/testing/end_to_end_testing/test_suite/simple_test_case_1/expected_outputs/parameters.yaml
@@ -319,7 +319,7 @@ virtual_world:
       - hour
   infrastructure_file: facilities_Perm.csv
   n_init_days: null
-  n_init_leaks: null
+  n_init_leaks_prob: null
   parameter_level: virtual_world
   repair_delay:
     type: default

--- a/LDAR_Sim/testing/end_to_end_testing/test_suite/simple_test_case_2/expected_outputs/parameters.yaml
+++ b/LDAR_Sim/testing/end_to_end_testing/test_suite/simple_test_case_2/expected_outputs/parameters.yaml
@@ -656,7 +656,7 @@ virtual_world:
       - hour
   infrastructure_file: facilities_alberta.csv
   n_init_days: null
-  n_init_leaks: null
+  n_init_leaks_prob: null
   parameter_level: virtual_world
   repair_delay:
     type: default

--- a/LDAR_Sim/testing/end_to_end_testing/test_suite/subtype_leak_and_vent_files_test/expected_outputs/parameters.yaml
+++ b/LDAR_Sim/testing/end_to_end_testing/test_suite/subtype_leak_and_vent_files_test/expected_outputs/parameters.yaml
@@ -319,7 +319,7 @@ virtual_world:
       - hour
   infrastructure_file: facilities_Perm.csv
   n_init_days: null
-  n_init_leaks: null
+  n_init_leaks_prob: null
   parameter_level: virtual_world
   repair_delay:
     type: default

--- a/LDAR_Sim/testing/end_to_end_testing/test_suite/test_various_program_parameters/expected_outputs/parameters.yaml
+++ b/LDAR_Sim/testing/end_to_end_testing/test_suite/test_various_program_parameters/expected_outputs/parameters.yaml
@@ -319,7 +319,7 @@ virtual_world:
       - hour
   infrastructure_file: facilities_Perm.csv
   n_init_days: null
-  n_init_leaks: null
+  n_init_leaks_prob: null
   parameter_level: virtual_world
   repair_delay:
     type: default

--- a/LDAR_Sim/testing/unit_testing/test_initialization/test_leaks/leak_testing_fixtures.py
+++ b/LDAR_Sim/testing/unit_testing/test_initialization/test_leaks/leak_testing_fixtures.py
@@ -10,7 +10,7 @@ def mock_vw_fix():
     return {
         'subtype_file': None,
         'NRd': 10,
-        'n_init_leaks': None,
+        'n_init_leaks_prob': None,
         'n_init_days': None,
         'emissions': {
             'LPR': 0.5,
@@ -27,7 +27,7 @@ def mock_vw_2_fix():
     return {
         'subtype_file': None,
         'NRd': 10,
-        'n_init_leaks': 1,
+        'n_init_leaks_prob': 0.1,
         'n_init_days': 10,
         'emissions': {
             'LPR': 0.5,

--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -802,13 +802,15 @@ The NRd value should be the same for **all** programs
 
 Additionally, NRd is recommended to be always be equal or greater than n_init_days.
 
-### &lt;n_init_leaks&gt;
+### &lt;n_init_leaks_prob&gt;
 
-**Data type:** Integer
+**Data type:** Float
 
 **Default input:** N/A
 
-**Description:** The number of leaks present per site in the system at the time of the simulation start date
+**Description:** The probability of a given site to have a leak arise at a given day. This parameter behaves similarly to LPR, however this probability is only used for initialization of the simulation, LPR will determine the probability of leaks arising at a given site for the rest of the duration of the simulation.
+
+By default LPR will be used if value is not provided
 
 **Notes on acquisition:** Estimate from empirical data or use previously published value. This value can be calculated by multiplying the n_init_days by LPR.
 

--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -810,6 +810,8 @@ Additionally, NRd is recommended to be always be equal or greater than n_init_da
 
 **Description:** The probability of a given site to have a leak arise at a given day. This parameter behaves similarly to LPR, however this probability is only used for initialization of the simulation, LPR will determine the probability of leaks arising at a given site for the rest of the duration of the simulation.
 
+Example: if n_init_leaks_prob = 0.1 and n_init_days = 10 on a given day there is 10% chance that a leak will arise at a given site. There would be around 1 (10*0.1) leaks at a given site at the beginning of the simulation. There is a potential to have more or less leaks.
+
 By default LPR will be used if value is not provided
 
 **Notes on acquisition:** Estimate from empirical data or use previously published value. This value can be calculated by multiplying the n_init_days by LPR.

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 2023-08 - Version 3.1.0
+
+1. **Reworked n_init_leaks** The parameter n_init_leaks was reworked to n_init_leaks_prob. See the User Manual for details on how to use the parameter.
+
 ## 2023-07 - Version 3.0.1
 
 1. **Updated Output CSV file names** The output file names will now also contain program name.


### PR DESCRIPTION
# Pull Request Key Information

## Reason for change

n_init_leaks was limited in use case. 

## What was changed

Changed n_init_leaks to n_init_leaks_prob, and updated functionality to mimic LPR. 

## Intended Purpose

Improved n_init_leaks

## Level of version change required

Minor version bump to v3.1.0 required

## Testing Completed

Updated parameter values in unit test and existing E2E tests. 
All unit tests and E2E passed. 
[E2E Test results.zip](https://github.com/LDAR-Sim/LDAR_Sim/files/12264148/E2E.Test.results.zip)

## Target Issue

n/a

## Additional Information

Include any other important information here.
