### PR TITLE
107 bug natural n tags fails to increment

### DIFF
--- a/LDAR_Sim/src/utils/attribution.py
+++ b/LDAR_Sim/src/utils/attribution.py
@@ -40,6 +40,7 @@ def update_tag(
             # natural can still repair a tagged leak
             leak['date_tagged'] = time_obj.current_date
             leak['tagged_by_company'] = company
+            timeseries['natural_n_tags'][time_obj.current_timestep] += 1
         elif leak['tagged_by_company'] == company:
             timeseries['{}_redund_tags'.format(company)][
                 time_obj.current_timestep] += 1

--- a/LDAR_Sim/testing/unit_testing/test_utils/test_attribution/attribution_testing_fixtures.py
+++ b/LDAR_Sim/testing/unit_testing/test_utils/test_attribution/attribution_testing_fixtures.py
@@ -1,0 +1,49 @@
+"""Fixtures for testing utils.attribution methods"""
+
+import pytest
+import datetime
+
+from src.time_counter import TimeCounter
+
+
+@pytest.fixture(name="mock_leak_for_update_tag_testing_1")
+def mock_leak_for_update_tag_testing_1_fix():
+    return {
+        'tagged': True,
+        'date_tagged': datetime.datetime(2017, 1, 1, 8, 0)
+    }
+
+
+@pytest.fixture(name="mock_leak_for_update_tag_testing_2")
+def mock_leak_for_update_tag_testing_2_fix():
+    return {
+        'tagged': False
+    }
+
+
+@pytest.fixture(name="mock_company_for_update_tag_testing_1")
+def mock_company_for_update_tag_testing_1_fix():
+    return "natural"
+
+
+@pytest.fixture(name="mock_TimeCounter_for_update_tag_testing_1")
+def mock_TimeCounter_for_update_tag_testing_1_fix(mocker):
+    mock_tc = mocker.Mock(TimeCounter)
+    mock_tc.current_date = datetime.datetime(2017, 1, 1, 8, 0)
+    mock_tc.current_timestep = 1
+    return mock_tc
+
+
+@pytest.fixture(name="mock_timeseries_for_update_tag_testing_1")
+def mock_timeseries_for_update_tag_testing_1_fix():
+    return {
+        'natural_n_tags': [0, 0]
+    }
+
+
+@pytest.fixture(name="mock_site_for_update_tag_testing_1")
+def mock_site_for_update_tag_testing_1_fix():
+    return {
+        'currently_flagged': False,
+        'flagged_by': None
+    }

--- a/LDAR_Sim/testing/unit_testing/test_utils/test_attribution/test_update_tag.py
+++ b/LDAR_Sim/testing/unit_testing/test_utils/test_attribution/test_update_tag.py
@@ -1,0 +1,48 @@
+"""Test file to unit test attribution.py update_tag functionality"""
+from src.utils.attribution import update_tag
+from testing.unit_testing.test_utils.test_attribution.attribution_testing_fixtures \
+    import (  # Noqa: 401
+        mock_leak_for_update_tag_testing_1_fix,
+        mock_leak_for_update_tag_testing_2_fix,
+        mock_company_for_update_tag_testing_1_fix,
+        mock_TimeCounter_for_update_tag_testing_1_fix,
+        mock_timeseries_for_update_tag_testing_1_fix,
+        mock_site_for_update_tag_testing_1_fix
+    )
+
+
+def test_072_update_tag_nat_repair_prev_tagged_by_other_company(
+        mock_leak_for_update_tag_testing_1,
+        mock_timeseries_for_update_tag_testing_1,
+        mock_TimeCounter_for_update_tag_testing_1,
+        mock_company_for_update_tag_testing_1
+):
+    update_tag(
+        mock_leak_for_update_tag_testing_1,
+        None,
+        None,
+        mock_timeseries_for_update_tag_testing_1,
+        mock_TimeCounter_for_update_tag_testing_1,
+        mock_company_for_update_tag_testing_1
+    )
+    assert mock_timeseries_for_update_tag_testing_1['natural_n_tags'][
+        mock_TimeCounter_for_update_tag_testing_1.current_timestep] == 1
+
+
+def test_072_update_tag_nat_repair_no_prev_tag(
+        mock_leak_for_update_tag_testing_2,
+        mock_site_for_update_tag_testing_1,
+        mock_timeseries_for_update_tag_testing_1,
+        mock_TimeCounter_for_update_tag_testing_1,
+        mock_company_for_update_tag_testing_1
+):
+    update_tag(
+        mock_leak_for_update_tag_testing_2,
+        None,
+        mock_site_for_update_tag_testing_1,
+        mock_timeseries_for_update_tag_testing_1,
+        mock_TimeCounter_for_update_tag_testing_1,
+        mock_company_for_update_tag_testing_1
+    )
+    assert mock_timeseries_for_update_tag_testing_1['natural_n_tags'][
+        mock_TimeCounter_for_update_tag_testing_1.current_timestep] == 1

--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,10 @@
 
 1. **Fix to update_tag** Fix applied to update tag to increment natural_n_tags when the natural company overwrites an existing tag and repairs the book.
 
+## 2023-08 - Version 3.2.1
+
+1. **Performance Improvements** Runtime performance improvements have been made for LDAR-Sim initialization.
+
 ## 2023-08 - Version 3.2.0
 
 1. **Added outputs parameters to control files output from LDAR-Sim** New output parameters introduced to the LDAR-Sim simulation settings allow for users to select specific outputs to enable/disable. This can help reduce the memory load of simulations for users running large simulations if they do not care about every result.

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 2023-08 - Version 3.2.2
+
+1. **Fix to update_tag** Fix applied to update tag to increment natural_n_tags when the natural company overwrites an existing tag and repairs the book.
+
 ## 2023-08 - Version 3.2.0
 
 1. **Added outputs parameters to control files output from LDAR-Sim** New output parameters introduced to the LDAR-Sim simulation settings allow for users to select specific outputs to enable/disable. This can help reduce the memory load of simulations for users running large simulations if they do not care about every result.


### PR DESCRIPTION
# Pull Request Key Information

## Reason for change

natural_n_tags was only tracking leaks initially tagged by the natural company, but the natural company does have the ability to overwrite tags made by other companies when the leak hits the NRd. This should also be tracked by natural_n_tags

## What was changed

Fixed natural_n_tags tracking to track leaks tagged and repaired by natural when previously tagged by another company.

## Intended Purpose

Have natural_n_tags track all leaks tagged and immediately repaired by the natural company, not just leak it was the first to tag.

## Level of version change required

Patch

## Testing Completed

E2E testing and unit all pass. 
[test_results_3551badf02a16d904e804cef670b94a542164607.zip](https://github.com/LDAR-Sim/LDAR_Sim/files/12469025/test_results_3551badf02a16d904e804cef670b94a542164607.zip)


## Target Issue

Closes #107 

## Additional Information

N/A
