### PR TITLE
106 feat separate natural repair cost for cost of normal repairs

### DIFF
--- a/LDAR_Sim/testing/end_to_end_testing/test_suite/test_various_program_parameters/expected_outputs/prog_table.json
+++ b/LDAR_Sim/testing/end_to_end_testing/test_suite/test_various_program_parameters/expected_outputs/prog_table.json
@@ -1,1 +1,70 @@
-[{"program_name": "P_OGI", "emis_kg_day_site_med": 933322.1760000002, "act_leaks_day_site_med": 0.44, "mit_vol_tco2e": 4174687256.947201, "mit_vol_perc": 1.4856243907368754, "cost": 786500.0, "cost_mit_vol_tco2e": 0.000188397346098481, "nat_leak_repair_count": 11.0, "emis_nat_perc": 0.05641657697316022, "methods": {"OGI": {"sites_visited": 951.0, "n_flags": "N/A", "missed_leaks": 0.0, "n_tags": 616.0, "flag_rate": "N/A", "tag_rate": 0.4794952681388013, "method_name": "OGI", "prescribed_surveys": 951.0}}}, {"program_name": "P_air", "emis_kg_day_site_med": 933446.5920000003, "act_leaks_day_site_med": 0.48, "mit_vol_tco2e": 4003060787.712001, "mit_vol_perc": 1.3425511465974023, "cost": 641500.0, "cost_mit_vol_tco2e": 0.00016025237537465857, "nat_leak_repair_count": 3.0, "emis_nat_perc": 0.013292637954263747, "methods": {"airH": {"sites_visited": 1000.0, "n_flags": 460.0, "missed_leaks": 0.0, "n_tags": "N/A", "flag_rate": 0.46, "tag_rate": "N/A", "method_name": "airH", "prescribed_surveys": 1000.0}, "OGI_FU": {"sites_visited": 460.0, "n_flags": "N/A", "missed_leaks": 0.0, "n_tags": 635.0, "flag_rate": "N/A", "tag_rate": 0.991304347826087, "method_name": "OGI_FU", "prescribed_surveys": "N/A"}}}, {"program_name": "P_none", "emis_kg_day_site_med": 2489050.9439999987, "act_leaks_day_site_med": 1.2, "mit_vol_tco2e": 0.0, "mit_vol_perc": 0.0, "cost": 298500.0, "cost_mit_vol_tco2e": NaN, "nat_leak_repair_count": 597.0, "emis_nat_perc": 0.9590294014939178, "methods": {}}]
+[
+    {
+        "program_name": "P_OGI",
+        "emis_kg_day_site_med": 933322.1760000002,
+        "act_leaks_day_site_med": 0.44,
+        "mit_vol_tco2e": 4174687256.947201,
+        "mit_vol_perc": 1.4856243907368754,
+        "cost": 784900.0,
+        "cost_mit_vol_tco2e": 0.00018801408385594117,
+        "nat_leak_repair_count": 11.0,
+        "emis_nat_perc": 0.05641657697316022,
+        "methods": {
+            "OGI": {
+                "sites_visited": 951.0,
+                "n_flags": "N/A",
+                "missed_leaks": 0.0,
+                "n_tags": 616.0,
+                "flag_rate": "N/A",
+                "tag_rate": 0.4794952681388013,
+                "method_name": "OGI",
+                "prescribed_surveys": 951.0
+            }
+        }
+    },
+    {
+        "program_name": "P_air",
+        "emis_kg_day_site_med": 933446.5920000003,
+        "act_leaks_day_site_med": 0.48,
+        "mit_vol_tco2e": 4003060787.712001,
+        "mit_vol_perc": 1.3425511465974023,
+        "cost": 639900.0,
+        "cost_mit_vol_tco2e": 0.00015985268121939831,
+        "nat_leak_repair_count": 3.0,
+        "emis_nat_perc": 0.013292637954263747,
+        "methods": {
+            "airH": {
+                "sites_visited": 1000.0,
+                "n_flags": 460.0,
+                "missed_leaks": 0.0,
+                "n_tags": "N/A",
+                "flag_rate": 0.46,
+                "tag_rate": "N/A",
+                "method_name": "airH",
+                "prescribed_surveys": 1000.0
+            },
+            "OGI_FU": {
+                "sites_visited": 460.0,
+                "n_flags": "N/A",
+                "missed_leaks": 0.0,
+                "n_tags": 635.0,
+                "flag_rate": "N/A",
+                "tag_rate": 0.991304347826087,
+                "method_name": "OGI_FU",
+                "prescribed_surveys": "N/A"
+            }
+        }
+    },
+    {
+        "program_name": "P_none",
+        "emis_kg_day_site_med": 2489050.9439999987,
+        "act_leaks_day_site_med": 1.2,
+        "mit_vol_tco2e": 0.0,
+        "mit_vol_perc": 0.0,
+        "cost": 238800.0,
+        "cost_mit_vol_tco2e": NaN,
+        "nat_leak_repair_count": 597.0,
+        "emis_nat_perc": 0.9590294014939178,
+        "methods": {}
+    }
+]

--- a/LDAR_Sim/testing/unit_testing/test_ldar_sim/ldar_sim_testing_fixtures.py
+++ b/LDAR_Sim/testing/unit_testing/test_ldar_sim/ldar_sim_testing_fixtures.py
@@ -1,0 +1,187 @@
+""" Fixures for testing ldar_sim.py functionality"""
+
+import pytest
+from src.time_counter import TimeCounter
+from src.weather.weather_lookup_hourly import WeatherLookup
+
+import datetime
+
+
+@pytest.fixture(name="mock_state_for_ldar_sim_testing_1")
+def mock_state_for_ldar_sim_testing_1_fix(mocker):
+    mock_tc = mocker.Mock(TimeCounter)
+    mock_tc.current_date = datetime.datetime(2017, 1, 1, 8, 0)
+    mock_tc.current_timestep = 1
+    mock_weather = mocker.Mock(WeatherLookup)
+    mock_weather.latitude = [55.05]
+    mock_weather.longitude = [-119.99]
+    return {
+        'campaigns': None,
+        'sites': [
+            {
+                "active_leaks": {
+                    'tagged': True,
+                },
+                'subtype_code': None,
+                'facility_ID': 0,
+                'lat': 55.05,
+                'lon': -119.99
+            }
+        ],
+        't': mock_tc,
+        'weather': mock_weather,
+        'site_visits': {
+            "OGI": []
+        }
+    }
+
+
+@pytest.fixture(name="mock_vw_for_ldar_sim_testing_1")
+def mock_vw_for_ldar_sim_testing_1_fix():
+    return {
+        'emissions': {
+            'leak_file': None,
+            'max_leak_rate': 100000
+        },
+        'subtype_file': None,
+        'pregenerate_leaks': True,
+        'initial_leaks': [
+            [
+                {
+                    'tagged': True,
+                    'tagged_by_company': "natural",
+                    'day_ts_began': -1,
+                    "rate": 1
+                }
+            ]
+        ],
+        'timesteps': 2
+    }
+
+
+@pytest.fixture(name="mock_program_params_for_ldar_sim_testing_1")
+def mock_program_params_for_ldar_sim_testing_1_fix():
+    return {
+        'economics': {
+            'repair_costs': {
+                'file': None,
+                'vals': [200.0]
+            }
+        },
+        'methods': {}
+
+    }
+
+
+@pytest.fixture(name="mock_timeseries_for_ldar_sim_testing_1")
+def mock_timeseries_for_ldar_sim_testing_1_fix():
+    return {
+        'total_daily_cost': []
+    }
+
+
+@pytest.fixture(name="mock_vw_for_ldar_sim_testing_2")
+def mock_vw_for_ldar_sim_testing_2_fix():
+    return {
+        'emissions': {
+            'leak_file': None,
+            'max_leak_rate': 100000,
+            'consider_venting': False
+        },
+        'subtype_file': None,
+        'pregenerate_leaks': True,
+        'initial_leaks': [
+            [
+                {
+                    'tagged': True,
+                    'tagged_by_company': "OGI",
+                    'day_ts_began': -1,
+                    "rate": 1,
+                    "estimated_date_began": 0
+                }
+            ]
+        ],
+        'timesteps': 2,
+        'consider_weather': False
+    }
+
+
+@pytest.fixture(name="mock_state_for_ldar_sim_testing_2")
+def mock_state_for_ldar_sim_testing_2_fix(mocker):
+    mock_tc = mocker.Mock(TimeCounter)
+    mock_tc.current_date = datetime.datetime(2017, 1, 1, 8, 0)
+    mock_tc.current_timestep = 1
+    mock_tc.start_date = datetime.datetime(2017, 1, 1, 8, 0)
+    mock_weather = mocker.Mock(WeatherLookup)
+    mock_weather.latitude = [55.05]
+    mock_weather.longitude = [-119.99]
+    return {
+        'campaigns': None,
+        'sites': [
+            {
+                "active_leaks": {
+                    'tagged': True,
+                    "estimated_date_began": 0
+                },
+                'subtype_code': None,
+                'facility_ID': 0,
+                'lat': 55.05,
+                'lon': -119.99,
+                'repair_delay': 0
+            }
+        ],
+        't': mock_tc,
+        'weather': mock_weather,
+        'site_visits': {
+            "OGI": []
+        },
+        'methods': []
+    }
+
+
+@pytest.fixture(name="mock_sim_settings_for_ldar_sim_testing_2")
+def mock_sim_settings_for_ldar_sim_testing_2_fix():
+    return {
+        "input_directory": None
+    }
+
+
+@pytest.fixture(name="mock_program_params_for_ldar_sim_testing_2")
+def mock_program_params_for_ldar_sim_testing_2_fix():
+    return {
+        'economics': {
+            'repair_costs': {
+                'file': None,
+                'vals': [200.0]
+            },
+            'verification_cost': 100
+        },
+        'methods': {
+            "OGI": {
+                "reporting_delay": 0,
+                'RS': 1,
+                'scheduling': {
+                    'min_time_bt_surveys': None,
+                    'deployment_months': [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12],
+                    'route_planning': False,
+                    'deployment_years': [2017],
+                    'LDAR_crew_init_location': []
+                },
+                'is_follow_up': False,
+                'deployment_type': 'mobile',
+                'measurement_scale': 'component',
+                'time': 60,
+                'n_crews': 1,
+                'label': "OGI",
+                'max_workday': 8,
+                't_bw_sites': {
+                    'file': None
+                },
+                'consider_daylight': True,
+                'cost': {
+                    'upfront': 0
+                }
+            }
+        }
+
+    }

--- a/LDAR_Sim/testing/unit_testing/test_ldar_sim/test_repair_leaks.py
+++ b/LDAR_Sim/testing/unit_testing/test_ldar_sim/test_repair_leaks.py
@@ -1,0 +1,63 @@
+""" Module for testing the ldar_sim.py function repair_leaks"""
+from src.ldar_sim import LdarSim
+
+import datetime
+
+from testing.unit_testing.test_ldar_sim.ldar_sim_testing_fixtures \
+    import (  # Noqa: 401
+        mock_state_for_ldar_sim_testing_1_fix,
+        mock_program_params_for_ldar_sim_testing_1_fix,
+        mock_vw_for_ldar_sim_testing_1_fix,
+        mock_timeseries_for_ldar_sim_testing_1_fix,
+        mock_vw_for_ldar_sim_testing_2_fix,
+        mock_state_for_ldar_sim_testing_2_fix,
+        mock_program_params_for_ldar_sim_testing_2_fix,
+        mock_sim_settings_for_ldar_sim_testing_2_fix
+    )
+
+
+def test_001_natural_repair_adds_to_natural_repair_cost(
+        mock_state_for_ldar_sim_testing_1,
+        mock_program_params_for_ldar_sim_testing_1,
+        mock_vw_for_ldar_sim_testing_1,
+        mock_timeseries_for_ldar_sim_testing_1
+):
+    ldarsim = LdarSim(
+        None,
+        mock_state_for_ldar_sim_testing_1,
+        mock_program_params_for_ldar_sim_testing_1,
+        mock_vw_for_ldar_sim_testing_1,
+        mock_timeseries_for_ldar_sim_testing_1,
+        None,
+        None
+    )
+    ldarsim.state['sites'][0]['active_leaks'][0]['date_tagged'] = datetime.datetime(
+        2017, 1, 1, 8, 0)
+    ldarsim.repair_leaks()
+    assert ldarsim.timeseries['repair_cost'][1] == 0
+    assert ldarsim.timeseries['nat_repair_cost'][1] == 200
+    assert ldarsim.timeseries['verification_cost'][1] == 0
+
+
+def test_001_non_natural_repair_adds_to_repair_cost(
+        mock_sim_settings_for_ldar_sim_testing_2,
+        mock_state_for_ldar_sim_testing_2,
+        mock_program_params_for_ldar_sim_testing_2,
+        mock_vw_for_ldar_sim_testing_2,
+        mock_timeseries_for_ldar_sim_testing_1
+):
+    ldarsim = LdarSim(
+        mock_sim_settings_for_ldar_sim_testing_2,
+        mock_state_for_ldar_sim_testing_2,
+        mock_program_params_for_ldar_sim_testing_2,
+        mock_vw_for_ldar_sim_testing_2,
+        mock_timeseries_for_ldar_sim_testing_1,
+        None,
+        None
+    )
+    ldarsim.state['sites'][0]['active_leaks'][0]['date_tagged'] = datetime.datetime(
+        2017, 1, 1, 8, 0)
+    ldarsim.repair_leaks()
+    assert ldarsim.timeseries['repair_cost'][1] == 200
+    assert ldarsim.timeseries['nat_repair_cost'][1] == 0
+    assert ldarsim.timeseries['verification_cost'][1] == 100


### PR DESCRIPTION
# Pull Request Key Information

## Reason for change

Often, natural repair cost overshadows repair costs in simulation due to the simulation starting from a state of no LDAR.

## What was changed

While this change will still include natural repair costs in the total program costs, they are now separate from typical repair costs. Additionally, there is now no verification cost for natural repairs.

## Intended Purpose

To separate repair costs from natural repair costs

## Level of version change required

Patch

## Testing Completed

All unit testing and end to end testing passing: 
[testing_results_314b42a0cb7a36a98969b0ef38b33080b18f0408.zip](https://github.com/LDAR-Sim/LDAR_Sim/files/12480706/testing_results_314b42a0cb7a36a98969b0ef38b33080b18f0408.zip)


## Target Issue

Closes #106 

## Additional Information

N/A
