### PR TITLE
<Feat> Optional sorting of flagged sites

### DIFF
--- a/LDAR_Sim/src/default_parameters/m_default.yml
+++ b/LDAR_Sim/src/default_parameters/m_default.yml
@@ -49,6 +49,6 @@ follow_up:
   min_followup_days_to_end: 0 # days
   proportion: 1.0 # 0 to 1.0
   redundancy_filter: "recent" # recent/max/average
-  sort: True # True/False
+  sort_by_rate: True # True/False
   threshold: 0.0 # g/s
   threshold_type: "absolute" # absolute/relative

--- a/LDAR_Sim/src/default_parameters/m_default.yml
+++ b/LDAR_Sim/src/default_parameters/m_default.yml
@@ -49,5 +49,6 @@ follow_up:
   min_followup_days_to_end: 0 # days
   proportion: 1.0 # 0 to 1.0
   redundancy_filter: "recent" # recent/max/average
+  sort: True # True/False
   threshold: 0.0 # g/s
   threshold_type: "absolute" # absolute/relative

--- a/LDAR_Sim/src/methods/company.py
+++ b/LDAR_Sim/src/methods/company.py
@@ -259,11 +259,12 @@ class BaseCompany:
         # This ensures that the leakiest sites are at the top of the dictionary
         # so proportional site followup can be performed without resorting everyday
         # within the flag_sites function.
-        site_wl = {k: v for k, v in sorted(
-            site_wl.items(),
-            key=lambda x: x[1]['site_measured_rate'],
-            reverse=True)
-        }
+        if self.config['follow_up']['sort']:
+            site_wl = {k: v for k, v in sorted(
+                site_wl.items(),
+                key=lambda x: x[1]['site_measured_rate'],
+                reverse=True)
+            }
         self.site_watchlist = site_wl
 
     def flag_site(self, site):

--- a/LDAR_Sim/src/methods/company.py
+++ b/LDAR_Sim/src/methods/company.py
@@ -259,7 +259,7 @@ class BaseCompany:
         # This ensures that the leakiest sites are at the top of the dictionary
         # so proportional site followup can be performed without resorting everyday
         # within the flag_sites function.
-        if self.config['follow_up']['sort']:
+        if self.config['follow_up']['sort_by_rate']:
             site_wl = {k: v for k, v in sorted(
                 site_wl.items(),
                 key=lambda x: x[1]['site_measured_rate'],

--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -1680,7 +1680,7 @@ Method weather envelopes
 
 **Notes on acquisition:** Based on operator work practices.
 
-**Notes of caution:** For the intended follow-up `interaction_priority:proportion` use case, it's advisable to enable sorting by setting `sort: True`. This ensures that the original purpose of using `interaction_priority:proportion` is maintained.
+**Notes of caution:** For the intended follow-up `interaction_priority:proportion` use case, it's advisable to enable sorting by setting `sort_by_rate: True`. This ensures that the original purpose of using `interaction_priority:proportion` is maintained.
 
 #### &lt;threshold&gt;
 

--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -1670,6 +1670,18 @@ Method weather envelopes
 
 **Notes of caution:** N/A
 
+#### &lt;sort&gt;
+
+**Data type:** Boolean
+
+**Default input:** True
+
+**Description:** Indicates whether the sites flagged for follow-up will be sorted by their emission rates for subsequent follow-up survey methods.
+
+**Notes on acquisition:** Based on operator work practices.
+
+**Notes of caution:** N/A
+
 #### &lt;threshold&gt;
 
 **Data type:** Float

--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -1680,7 +1680,7 @@ Method weather envelopes
 
 **Notes on acquisition:** Based on operator work practices.
 
-**Notes of caution:** N/A
+**Notes of caution:** For the intended follow-up `interaction_priority:proportion` use case, it's advisable to enable sorting by setting `sort: True`. This ensures that the original purpose of using `interaction_priority:proportion` is maintained.
 
 #### &lt;threshold&gt;
 

--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -1670,13 +1670,13 @@ Method weather envelopes
 
 **Notes of caution:** N/A
 
-#### &lt;sort&gt;
+#### &lt;sort_by_rate&gt;
 
 **Data type:** Boolean
 
 **Default input:** True
 
-**Description:** Indicates whether the sites flagged for follow-up will be sorted by their emission rates for subsequent follow-up survey methods.
+**Description:** Indicates whether the sites flagged for follow-up will be sorted by their emission rates for subsequent follow-up survey methods. If set to True, follow-ups will sorted based on the observed site emission rates, prioritizing the largest emitting sites first.
 
 **Notes on acquisition:** Based on operator work practices.
 

--- a/changelog.md
+++ b/changelog.md
@@ -2,7 +2,7 @@
 
 ## 2023-09-21 - Version 3.3.1
 
-1. **Follow-up Watchlist sorting** Sorting on the follow-up watch list can be turned off.
+1. **Follow-up Watchlist sorting toggle** Sorting on the follow-up watch list can be turned off.
 
 ## 2023-09-14 - Version 3.3.0
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 2023-09-21 - Version 3.3.1
+
+1. **Follow-up Watchlist sorting** Sorting on the follow-up watch list can be turned off.
+
 ## 2023-09-14 - Version 3.3.0
 
 1. **Bugfix to Proportion** LDAR-Sim proportion has been fixed to properly proportion by top proportion % of emitting sites where previously proportioning was done by dropping sites with the longest time since last being surveyed.


### PR DESCRIPTION
# Pull Request Key Information

## Reason for change

Not all work practices prioritize flagged sites for follow-up based on emission sizes.

## What was changed

An additional method parameter has been added, which serves as a flag to determine sorting behavior.

## Intended Purpose

The purpose is to provide the ability to turn off sorting for flagged follow-up sites based on measured emission rates.

## Level of version change required

Patch

## Testing Completed

All existing unit tests and E2E tests have passed. 
Additionally, a manual check of the follow-up ordering/sorting was performed using the site_visits outputs.

[Test-FEA_opt_follow-up-sort.zip](https://github.com/LDAR-Sim/LDAR_Sim/files/12553288/Test-FEA_opt_follow-up-sort.zip)


## Additional Information

N/A
