### PR TITLE
Clarify recommended linting tool

### DIFF
--- a/LDAR_Sim/external_sensors/README.md
+++ b/LDAR_Sim/external_sensors/README.md
@@ -18,8 +18,7 @@ This document provides coding guidelines and best practices for developing exter
 ## General Guidelines
 
 - Keep the code modular, well-organized, and maintainable.
-- Follow the [Python PEP 8 Style Guide](https://www.python.org/dev/peps/pep-0008/) for code style and formatting.
-  - If possible use the autopep8 auto formatting
+- Use consistent and readable code formatting.
 - Write code that is concise, readable, and self-explanatory.
 - Avoid unnecessary code duplication; favor code reuse.
 
@@ -37,11 +36,11 @@ This document provides coding guidelines and best practices for developing exter
 
 ## Code Formatting
 
-- Use consistent and readable code formatting.
-- Keep lines within a reasonable length (80-120 characters).
+- Follow the [Python PEP 8 Style Guide](https://www.python.org/dev/peps/pep-0008/) for code style and formatting.
+  - If possible use the autopep8 auto formatting
+- Keep lines within a reasonable length (80-100 characters).
 - Use blank lines and proper spacing to enhance readability.
 - Follow appropriate naming conventions for constants and global variables.
-- If possible use Black as a formatter.
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ Several LDAR-Sim advances are not publicly available at this time, including mor
 
 ## Contributions and collaboration
 
-The Included python code follows strict PEP8 Standards for formatting with a modification to the Line Length rule, where lines cannot exceed 100 characters. Contributed code will be rejected if it does not meet this standard. We suggest using PEP8 autoformatters and Linting (Flake8 , Black) when making contributions.
+The included python code follows strict PEP8 Standards for formatting with a modification to the Line Length rule, where lines cannot exceed 100 characters. Contributed code will be rejected if it does not meet this standard. We suggest using autopep8 for style formatting and flake8 for additional linting when making contributions.
 
 When submitting Issues, Commits and Pull Requests, please use the provided templates to ensure consistent format. For instructions on how to setup the LDAR-Sim commit message template please see the [Setup Instructions](LDAR_Sim/install/SetupInstructions.md)
 


### PR DESCRIPTION
# Pull Request Key Information

## Reason for change

Three different style formatter recommendations are currently given, and two different maximum line length values.

## What was changed

This PR suggests combining the two different places where this is mentioned in the external_sensors\Readme into one and making the line length and linter tool recommendation consistent between there and the main Readme. I have written autopep8 since that is the one in requirements.txt, but that is obviously up to the developers.

## Intended Purpose

Reduce confusion over what style to follow when contributing.

## Level of version change required

Minor

## Testing Completed

None

## Target Issue

None

## Additional Information

None
