### PR TITLE
feat: Add site summary stats for batch sim running

### DIFF
--- a/LDAR_Sim/src/batch/batch_summary_funcs.py
+++ b/LDAR_Sim/src/batch/batch_summary_funcs.py
@@ -1,0 +1,35 @@
+import numpy as np
+import csv
+SITE_EMISSIONS = "total_emissions_kg"
+SITE_LEAKS = "cum_leaks"
+
+BATCH_SIMULATIONS = "batch_sims"
+SITES_SUMMARY_FP = "sites_summary.csv"
+
+
+def write_sites_summary(site_df, summary_path, prog_name):
+    site_summary = get_sites_summary(site_df, prog_name)
+
+    with open(summary_path / SITES_SUMMARY_FP, mode='a', newline='') as sites_sum_file:
+        fieldnames = site_summary.keys()
+        writer = csv.DictWriter(sites_sum_file, fieldnames=fieldnames)
+
+        if sites_sum_file.tell() == 0:
+            writer.writeheader()
+
+        writer.writerow(site_summary)
+
+
+def get_sites_summary(site_df, prog_name):
+    site_summary = {}
+    site_summary.update([("Program", prog_name)])
+    site_summary.update([("Mean_Emissions_per_site", site_df[SITE_EMISSIONS].mean())])
+    site_summary.update([("5th_percentile_Emissions_per_site",
+                        np.percentile(site_df[SITE_EMISSIONS], 5))])
+    site_summary.update([("95th_percentile_Emissions_per_site",
+                        np.percentile(site_df[SITE_EMISSIONS], 95))])
+    site_summary.update([("Mean_leaks_per_site", site_df[SITE_LEAKS].mean())])
+    site_summary.update([("5th_percentile_leaks_per_site", np.percentile(site_df[SITE_LEAKS], 5))])
+    site_summary.update(
+        [("95th_percentile_leaks_per_site", np.percentile(site_df[SITE_LEAKS], 95))])
+    return site_summary


### PR DESCRIPTION
# Pull Request Key Information

## Reason for change

When running simulations in batches, there is a need to summarize and combine results across multiple simulations.

## What was changed

Some key site statistics are now output to a new site statistics file when a batch running flag is true/exists. If the flag is true/exists, columns that wont be useful for combining results are dropped from the sites csv as well.

## Intended Purpose

Added batch summary functionality when the batch running flag is true.

## Level of version change required

N/A - Merge into prototype branch doesn't need patch

## Testing Completed

Manual testing

## Target Issue

N/A

## Additional Information

N/A
