### PR TITLE
Batchrun ts summary stats

### DIFF
--- a/LDAR_Sim/src/batch/batch_summary_funcs.py
+++ b/LDAR_Sim/src/batch/batch_summary_funcs.py
@@ -5,6 +5,14 @@ SITE_LEAKS = "cum_leaks"
 
 BATCH_SIMULATIONS = "batch_sims"
 SITES_SUMMARY_FP = "sites_summary.csv"
+TS_SUMMARY_FP = "timeseries_summary.csv"
+
+TS_EMISSIONS = 'daily_emissions_kg'
+TS_COST = 'total_daily_cost'
+TS_REPAIR_COST = 'repair_cost'
+TS_ACTIVE_LEAKS = 'active_leaks'
+TS_NEW_LEAKS = 'new_leaks'
+TS_N_TAGS = 'n_tags'
 
 
 def write_sites_summary(site_df, summary_path, prog_name):
@@ -33,3 +41,28 @@ def get_sites_summary(site_df, prog_name):
     site_summary.update(
         [("95th_percentile_leaks_per_site", np.percentile(site_df[SITE_LEAKS], 95))])
     return site_summary
+
+
+def get_ts_summary(ts_df, prog_name):
+    ts_summary = {}
+    ts_summary_cols = [TS_EMISSIONS, TS_COST, TS_REPAIR_COST,
+                       TS_ACTIVE_LEAKS, TS_NEW_LEAKS, TS_N_TAGS]
+    ts_summary.update([("Program", prog_name)])
+    for col in ts_summary_cols:
+        ts_summary.update([(f"Mean_{col}_per_day", ts_df[col].mean())])
+        ts_summary.update([(f"5th_percentile_{col}_per_day", np.percentile(ts_df[col], 5))])
+        ts_summary.update([(f"95th_percentile_{col}_per_day", np.percentile(ts_df[col], 95))])
+    return ts_summary
+
+
+def write_ts_summary(ts_df, summary_path, prog_name):
+    site_summary = get_ts_summary(ts_df, prog_name)
+
+    with open(summary_path / TS_SUMMARY_FP, mode='a', newline='') as ts_sum_file:
+        fieldnames = site_summary.keys()
+        writer = csv.DictWriter(ts_sum_file, fieldnames=fieldnames)
+
+        if ts_sum_file.tell() == 0:
+            writer.writeheader()
+
+        writer.writerow(site_summary)

--- a/LDAR_Sim/src/ldar_sim.py
+++ b/LDAR_Sim/src/ldar_sim.py
@@ -38,7 +38,7 @@ from methods.company import BaseCompany
 from numpy.random import binomial, choice
 from out_processing.plotter import make_plots
 from utils.attribution import update_tag
-from batch.batch_summary_funcs import write_sites_summary, BATCH_SIMULATIONS
+from batch.batch_summary_funcs import write_sites_summary, BATCH_SIMULATIONS, write_ts_summary
 
 warnings.filterwarnings("ignore", category=np.VisibleDeprecationWarning)
 
@@ -535,7 +535,9 @@ class LdarSim:
             )
             # TODO add a batch folder to outputs in the batch script and then alter the path below
             summary_path = self.output_dir.parent
-            write_sites_summary(site_df, summary_path, program_parameters['program_name'])
+            prog_name = program_parameters['program_name']
+            write_sites_summary(site_df, summary_path, prog_name)
+            write_ts_summary(time_df, summary_path, prog_name)
 
         # Write csv files
         if simulation_settings[OUTPUTS][LEAKS]:


### PR DESCRIPTION
# Pull Request Key Information

## Reason for change

With running batch simulations, summary statistics are needed so LDAR-Sim still produces useful outputs

## What was changed

Added timeseries summary statistics

## Intended Purpose

Introduce timeseries summary statistics

## Level of version change required

N/A- merge into a features branch

## Testing Completed

Manual testing

## Target Issue

N/A

## Additional Information

N/A
