### PR TITLE
feat: Add more timeseries summary outputs

### DIFF
--- a/LDAR_Sim/src/batch/batch_summary_funcs.py
+++ b/LDAR_Sim/src/batch/batch_summary_funcs.py
@@ -19,6 +19,9 @@ TS_ACTIVE_LEAKS = 'active_leaks'
 TS_NEW_LEAKS = 'new_leaks'
 TS_N_TAGS = 'n_tags'
 
+TS_SITE_VISITS = "sites_visited"
+TS_EFFECTIVE_FLAGS = "eff_flags"
+
 
 def write_sites_summary(site_df, summary_path, prog_name):
     site_summary = get_sites_summary(site_df, prog_name)
@@ -87,11 +90,20 @@ def get_ts_summary(ts_df, prog_name):
     ts_summary = {}
     ts_summary_cols = [TS_EMISSIONS, TS_COST, TS_REPAIR_COST,
                        TS_ACTIVE_LEAKS, TS_NEW_LEAKS, TS_N_TAGS]
+    ts_partial_cols_to_sum = [TS_SITE_VISITS, TS_EFFECTIVE_FLAGS, TS_N_TAGS]
     ts_summary.update([("Program", prog_name)])
+    ts_summary.update([("Total Emissions", ts_df[TS_EMISSIONS].sum())])
     for col in ts_summary_cols:
         ts_summary.update([(f"Mean_{col}_per_day", ts_df[col].mean())])
         ts_summary.update([(f"5th_percentile_{col}_per_day", np.percentile(ts_df[col], 5))])
         ts_summary.update([(f"95th_percentile_{col}_per_day", np.percentile(ts_df[col], 95))])
+
+    extra_stats = {}
+    for df_col in ts_df.columns:
+        for col in ts_partial_cols_to_sum:
+            if col in df_col:
+                extra_stats.update([(f"Sum_{df_col}_overall", ts_df[df_col].sum())])
+    ts_summary.update([("Additional Statistics", extra_stats)])
     return ts_summary
 
 

--- a/LDAR_Sim/testing/unit_testing/test_batch/test_batch_summary_funcs/test_get_ts_summary.py
+++ b/LDAR_Sim/testing/unit_testing/test_batch/test_batch_summary_funcs/test_get_ts_summary.py
@@ -3,7 +3,7 @@ from hypothesis import given, strategies as st
 
 
 from src.batch.batch_summary_funcs import (
-    get_ts_summary, TS_EMISSIONS, TS_COST, TS_REPAIR_COST, TS_ACTIVE_LEAKS, TS_NEW_LEAKS, TS_N_TAGS
+    get_ts_summary, TS_EMISSIONS, TS_COST, TS_REPAIR_COST, TS_ACTIVE_LEAKS, TS_NEW_LEAKS, TS_N_TAGS, TS_EFFECTIVE_FLAGS, TS_SITE_VISITS
 )
 
 ts_summary_cols = [TS_EMISSIONS, TS_COST, TS_REPAIR_COST,
@@ -12,6 +12,12 @@ ts_summary_cols = [TS_EMISSIONS, TS_COST, TS_REPAIR_COST,
 ts_float_cols = [TS_EMISSIONS, TS_COST, TS_REPAIR_COST]
 
 ts_int_cols = [TS_ACTIVE_LEAKS, TS_NEW_LEAKS, TS_N_TAGS]
+
+placeholder_method_cols = [
+    f"Test_{TS_N_TAGS}",
+    f"Test_{TS_EFFECTIVE_FLAGS}",
+    f"Test_{TS_SITE_VISITS}"
+]
 
 positive_floats = st.floats(min_value=0, max_value=float('inf'),
                             allow_nan=False, allow_infinity=False)
@@ -28,6 +34,8 @@ def generate_test_leaks_data(draw):
             st.lists(positive_floats, min_size=rows, max_size=rows))
     for col in ts_int_cols:
         data[col] = draw(st.lists(positive_ints, min_size=rows, max_size=rows))
+    for col in placeholder_method_cols:
+        data[col] = draw(st.lists(positive_ints, min_size=rows, max_size=rows))
     ts_df = pd.DataFrame(data)
     return ts_df
 
@@ -39,8 +47,14 @@ def test_150_get_sites_valid_date(ts_df):
     mean_vals = ts_df.mean()
     p_95_vals = ts_df.quantile(0.95)
     p_05_vals = ts_df.quantile(0.05)
+    sum_vals = ts_df.sum()
 
     for col in ts_summary_cols:
         assert summary_dict[f"Mean_{col}_per_day"] == mean_vals[col]
         assert summary_dict[f"5th_percentile_{col}_per_day"] == p_05_vals[col]
         assert summary_dict[f"95th_percentile_{col}_per_day"] == p_95_vals[col]
+
+    for col in placeholder_method_cols:
+        assert summary_dict["Additional Statistics"][f"Sum_{col}_overall"] == sum_vals[col]
+
+    assert summary_dict["Total Emissions"] == sum_vals[TS_EMISSIONS]


### PR DESCRIPTION
# Pull Request Key Information

## Reason for change

Review of initial timeseries summary statistic outputs has indicated that the inclusion of total emissions, total effective flags, total tags and total site visits would be of use to potential users.

## What was changed

New summary outputs added to timeseries summary csv.

## Intended Purpose

Intended to improve usefulness and useability of tracked batch summary statistics.

## Level of version change required

N/A - Merge into feature branch

## Testing Completed

Manual testing - Timeseries summary unit testing needs to be updated once this is merged.

## Target Issue

N/A

## Additional Information
N/A
