### PR TITLE
126 incorrect survey times when using 2 mobile methods deployed simultaneously

### DIFF
--- a/LDAR_Sim/src/methods/company.py
+++ b/LDAR_Sim/src/methods/company.py
@@ -119,6 +119,7 @@ class BaseCompany:
             site.update({'{}_surveys_done_this_year'.format(self.name): 0})
             site.update({'{}_missed_leaks'.format(self.name): 0})
 
+        rollover = []
         make_crew_loc = import_module('methods.deployment.{}_company'.format(
             self.config['deployment_type'].lower()))
         make_crews = getattr(make_crew_loc, 'make_crews')
@@ -130,7 +131,8 @@ class BaseCompany:
             virtual_world,
             simulation_settings,
             timeseries,
-            self.deployment_days
+            self.deployment_days,
+            rollover
         )
         for idx, cnt in enumerate(self.crews):
             self.timeseries['{}_cost'.format(self.name)][self.state['t'].current_timestep] += \

--- a/LDAR_Sim/src/methods/crew.py
+++ b/LDAR_Sim/src/methods/crew.py
@@ -45,6 +45,7 @@ class BaseCrew:
             timeseries,
             deployment_days,
             id,
+            rollover,
             site=None
     ):
         """
@@ -80,7 +81,8 @@ class BaseCrew:
             config,
             virtual_world,
             simulation_settings,
-            deployment_days
+            deployment_days,
+            rollover
         )
 
         if self.config['deployment_type'] == 'mobile':

--- a/LDAR_Sim/src/methods/deployment/mobile_company.py
+++ b/LDAR_Sim/src/methods/deployment/mobile_company.py
@@ -35,7 +35,8 @@ def make_crews(
         virtual_world,
         simulation_settings,
         timeseries,
-        deployment_days
+        deployment_days,
+        rollover
 ):
     """ Generate crews using BaseCrew class.
 
@@ -61,7 +62,8 @@ def make_crews(
                 config,
                 timeseries,
                 deployment_days,
-                id=i + 1
+                id=i + 1,
+                rollover=rollover
             )
         )
 

--- a/LDAR_Sim/src/methods/deployment/mobile_crew.py
+++ b/LDAR_Sim/src/methods/deployment/mobile_crew.py
@@ -29,7 +29,6 @@ from methods.deployment.generic_funcs import get_work_hours
 
 
 class Schedule():
-    rollover = []
 
     def __init__(
             self,
@@ -41,6 +40,7 @@ class Schedule():
             virtual_world,
             simulation_settings,
             deployment_days,
+            rollover,
             home_bases=None
     ):
         self.config = config
@@ -55,7 +55,7 @@ class Schedule():
         self.end_hour = None
         self.allowed_end_time = None
         self.last_site_travel_home_min = None
-        # self.rollover = None  # (rollover_site_plan)
+        self.rollover = rollover  # (rollover_site_plan)
         self.travel_all_day = False
         self.scheduling = self.config['scheduling']
         # define a list of home bases for crew and redefine the initial location of crew
@@ -163,7 +163,7 @@ class Schedule():
         # add a site to the rollover list if there are still remaining mins in survey
         if len(site_plans_today) > 0:
             if site_plans_today[-1]['remaining_mins'] > 0:
-                Schedule.rollover.append(site_plans_today[-1])
+                self.rollover.append(site_plans_today[-1])
         else:
             self.travel_all_day = True
         # The crew does not actually travel this is only done for planning purposes
@@ -213,12 +213,12 @@ class Schedule():
                                          self.state['t'].current_timestep]:
             return None
 
-        if len(Schedule.rollover) > 0:
-            for s in Schedule.rollover:
+        if len(self.rollover) > 0:
+            for s in self.rollover:
                 if site['facility_ID'] == s['site']['facility_ID']:
                     # Remove facility from rollover list, and retrieve remaining survey minutes
                     LDAR_mins = s['remaining_mins']
-                    Schedule.rollover.remove(s)
+                    self.rollover.remove(s)
                     break
                 else:
                     LDAR_mins = int(site['{}_time'.format(name)])
@@ -338,8 +338,8 @@ class Schedule():
         Returns:
             A dictionary (travel plan) of the selected site
         """
-        if len(Schedule.rollover) > 0:
-            site_plan = Schedule.rollover
+        if len(self.rollover) > 0:
+            site_plan = self.rollover
 
         # route planning -> find the nearest site
         if self.config['scheduling']['route_planning']:

--- a/LDAR_Sim/src/methods/deployment/orbit_company.py
+++ b/LDAR_Sim/src/methods/deployment/orbit_company.py
@@ -29,7 +29,8 @@ def make_crews(
         virtual_world,
         simulation_settings,
         timeseries,
-        deployment_days
+        deployment_days,
+        rollover
 ):
     """ Generate crews using BaseCrew class.
 
@@ -55,7 +56,8 @@ def make_crews(
                 config,
                 timeseries,
                 deployment_days,
-                id=i + 1
+                id=i + 1,
+                rollover=rollover
             )
         )
 

--- a/LDAR_Sim/src/methods/deployment/orbit_crew.py
+++ b/LDAR_Sim/src/methods/deployment/orbit_crew.py
@@ -43,6 +43,7 @@ class Schedule():
             virtual_world,
             simulation_settings,
             deployment_days,
+            rollover,
             home_bases=None
     ):
         self.config = config

--- a/LDAR_Sim/src/methods/deployment/stationary_company.py
+++ b/LDAR_Sim/src/methods/deployment/stationary_company.py
@@ -31,7 +31,8 @@ def make_crews(
     virtual_world,
     simulation_settings,
     timeseries,
-    deployment_days
+    deployment_days,
+    rollover
 ):
     """ Generate crews using BaseCrew class.
 
@@ -72,7 +73,8 @@ def make_crews(
                     timeseries,
                     deployment_days,
                     id=crew_ID,
-                    site=site
+                    site=site,
+                    rollover=rollover
                 ))
 
 

--- a/LDAR_Sim/src/methods/deployment/stationary_crew.py
+++ b/LDAR_Sim/src/methods/deployment/stationary_crew.py
@@ -31,6 +31,7 @@ class Schedule():
         virtual_world,
         simulation_settings,
         deployment_days,
+        rollover,
         home_bases=None
     ):
         self.config = config

--- a/LDAR_Sim/src/methods/deployment/template_company.py
+++ b/LDAR_Sim/src/methods/deployment/template_company.py
@@ -30,7 +30,8 @@ def make_crews(
         virtual_world,
         simulation_settings,
         timeseries,
-        deployment_days
+        deployment_days,
+        rollover
 ):
     """ Generate crews using BaseCrew class.
 
@@ -56,7 +57,8 @@ def make_crews(
                 config,
                 timeseries,
                 deployment_days,
-                id=i + 1
+                id=i + 1,
+                rollover=rollover
             )
         )
 

--- a/LDAR_Sim/src/methods/deployment/template_crew.py
+++ b/LDAR_Sim/src/methods/deployment/template_crew.py
@@ -31,6 +31,7 @@ class Schedule():
             virtual_world,
             simulation_settings,
             deployment_days,
+            rollover,
             home_bases=None
     ):
         self.config = config

--- a/LDAR_Sim/testing/unit_testing/test_methods/test_crew/test_detect_emissions.py
+++ b/LDAR_Sim/testing/unit_testing/test_methods/test_crew/test_detect_emissions.py
@@ -42,6 +42,7 @@ def test_051_detect_emissions_simple(
         mock_config_for_crew_testing_1,
         None,
         None,
+        None,
         None
     )
     result: Any = crew.detect_emissions(mock_site_for_crew_testing_1)
@@ -73,6 +74,7 @@ def test_051_detect_emissions_simple_w_static_vents(
         mock_vw_for_crew_testing_2,
         mock_settings_for_crew_testing_1,
         mock_config_for_crew_testing_2,
+        None,
         None,
         None,
         None

--- a/LDAR_Sim/testing/unit_testing/test_methods/test_crew/test_visit_site.py
+++ b/LDAR_Sim/testing/unit_testing/test_methods/test_crew/test_visit_site.py
@@ -126,6 +126,7 @@ def test_053_visit_site_gives_expected_behavior(
         request.getfixturevalue(test_input[1]),
         request.getfixturevalue(test_input[3]),
         None,
+        None,
         None
     )
     mocker.patch.object(BaseCrew, 'detect_emissions',

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 2023-10-19 - Version 3.3.2
+
+1. **Bugfix for concurrent mobile method survey times** Resolved a bug where previously survey time for concurrent mobile methods would be incorrect.
+
 ## 2023-09-21 - Version 3.3.1
 
 1. **Follow-up Watchlist sorting toggle** Sorting on the follow-up watch list can be turned off.


### PR DESCRIPTION
# Pull Request Key Information

## Reason for change

This is done to fix an issue where 2 simultaneously deployed mobile
crews from different companies would unintentionally share a rollover,
which would result in erroneous survey/screening times for those
companies and crews.

## What was changed

Added logic to pass a rollover down to crews upon creation by a company.
The rollover is shared by all crews belonging to a company. This means
crews belonging to the same company can coordinate, but crews belonging
to different companies are unable to do so.

## Intended Purpose

Resolve Issue #126 

## Level of version change required

Patch to v3.3.2

## Testing Completed

All unit testing and E2E testing passed. 
[Test_Results_97b2f0e5c2a377f13614d922fa416dc98f982e6d.zip](https://github.com/LDAR-Sim/LDAR_Sim/files/13048113/Test_Results_97b2f0e5c2a377f13614d922fa416dc98f982e6d.zip)


Manual testing was completed to confirm the bug was resolved. A new E2E was not made given large refactors are planned for LDAR-Sim in the near future that will require the E2E testing suite to be recreated. See attached ZIP files for manual testing parameters and results.
[Manual_Testing.zip](https://github.com/LDAR-Sim/LDAR_Sim/files/13048116/Manual_Testing.zip)


## Target Issue

Closes #126 

## Additional Information

N/A
