### PR TITLE
Fix typos in ParameterMigrationGuide.md

### DIFF
--- a/ParameterMigrationGuide.md
+++ b/ParameterMigrationGuide.md
@@ -58,7 +58,7 @@ Contains parameters used to inform the LDAR-Sim virtual world. These parameters 
 
 ### 2. Creating the Virtual World parameter file
 
-1. Locate the program parameter file associated with the baseline program for your simulation. The program name name will match the value set for the baseline_program parameter in the Simulation_settings (Your transformed global parameters file). This will often be set to P_none.
+1. Locate the program parameter file associated with the baseline program for your simulation. The program name parameter will match the value set for the baseline_program parameter in the Simulation_settings (Your transformed global parameters file). This will often be set to P_none.
 
     For Example:
 

--- a/ParameterMigrationGuide.md
+++ b/ParameterMigrationGuide.md
@@ -58,7 +58,7 @@ Contains parameters used to inform the LDAR-Sim virtual world. These parameters 
 
 ### 2. Creating the Virtual World parameter file
 
-1. Locate the program parameter file associate with the baseline program for your simulation. It's name will match the value set for the baseline_program parameter in the Simulation_settings (Your transformed global parameters file). This will often be set to P_none.
+1. Locate the program parameter file associated with the baseline program for your simulation. It's name will match the value set for the baseline_program parameter in the Simulation_settings (Your transformed global parameters file). This will often be set to P_none.
 
     For Example:
 
@@ -72,7 +72,7 @@ Contains parameters used to inform the LDAR-Sim virtual world. These parameters 
     program_name: P_none
     ```
 
-    Ideally the name of the should also be P_none.yaml, but this is not required.
+    Ideally the name of the file should also be P_none.yaml, but this is not required.
 
 2. Copy the key value pairs of the following parameters from the baseline program if they exist:
 

--- a/ParameterMigrationGuide.md
+++ b/ParameterMigrationGuide.md
@@ -58,7 +58,7 @@ Contains parameters used to inform the LDAR-Sim virtual world. These parameters 
 
 ### 2. Creating the Virtual World parameter file
 
-1. Locate the program parameter file associated with the baseline program for your simulation. The paogram name name will match the value set for the baseline_program parameter in the Simulation_settings (Your transformed global parameters file). This will often be set to P_none.
+1. Locate the program parameter file associated with the baseline program for your simulation. The program name name will match the value set for the baseline_program parameter in the Simulation_settings (Your transformed global parameters file). This will often be set to P_none.
 
     For Example:
 

--- a/ParameterMigrationGuide.md
+++ b/ParameterMigrationGuide.md
@@ -58,7 +58,7 @@ Contains parameters used to inform the LDAR-Sim virtual world. These parameters 
 
 ### 2. Creating the Virtual World parameter file
 
-1. Locate the program parameter file associated with the baseline program for your simulation. It's name will match the value set for the baseline_program parameter in the Simulation_settings (Your transformed global parameters file). This will often be set to P_none.
+1. Locate the program parameter file associated with the baseline program for your simulation. The paogram name name will match the value set for the baseline_program parameter in the Simulation_settings (Your transformed global parameters file). This will often be set to P_none.
 
     For Example:
 


### PR DESCRIPTION
# Pull Request Key Information

## Reason for change

Typos were discover in the parameter migration guide

## What was changed

The typos were resolved

## Intended Purpose

Removed the typos found in our documentation

## Level of version change required

N/A

## Testing Completed

Not required.

## Target Issue

N/A

## Additional Information

N/A
