### PR TITLE
<Bug>: Fix unit conversion (Issue #140)

### DIFF
--- a/LDAR_Sim/external_sensors/METEC_WIND.py
+++ b/LDAR_Sim/external_sensors/METEC_WIND.py
@@ -92,7 +92,7 @@ def detect_emissions(
     hourly_windspeed = self.state["weather"].get_hourly_weather(
         ["winds"], self.state["t"].current_date, number_of_hours=1, site=site
     )
-    average_wind = np.average(hourly_windspeed["winds"]) * MsTOKMh  # m/s to km/hr
+    average_wind = np.average(hourly_windspeed["winds"])
 
     if self.config["measurement_scale"] == "site":
         # Calculate the rate per wind based on the overall site rate

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 2023-11-30 - Version 3.3.5
+
+1. **Bug fix for METEC wind sensor** Fixed the wind factor units. Previously used km/hr, changed to m/s to properly reflect the METEC wind dependent curve.
+
 ## 2023-11-23 - Version 3.3.4
 
 1. **New External Sensor** Added new external sensor - METEC Wind normalized curve


### PR DESCRIPTION
Reason for change:
Wrong units were used for PoD

Resolution:
Fixed the units being used

Effect(s) of change:
Fix the METEC wind sensor to properly reflect the METEC wind dependent curve

# Pull Request Key Information

## Reason for change

The wind factor was using the wrong units. 

## What was changed

External sensor - METEC Wind was updated

## Intended Purpose

Fix a bug related to the external sensor - METEC Wind

## Level of version change required

Minor version change

## Testing Completed

All unit tests pass
[unit_test_results.txt](https://github.com/LDAR-Sim/LDAR_Sim/files/13518183/unit_test_results.txt)

E2E tests pass
[E2E test results.zip](https://github.com/LDAR-Sim/LDAR_Sim/files/13518359/E2E.test.results.zip)


## Target Issue

closes #140 

## Additional Information

Include any other important information here.
