### PR TITLE
V4 summary outputs

### DIFF
--- a/LDAR_Sim/src/file_processing/output_processing/multi_simulation_outputs.py
+++ b/LDAR_Sim/src/file_processing/output_processing/multi_simulation_outputs.py
@@ -1,3 +1,23 @@
+"""
+------------------------------------------------------------------------------
+Program:     The LDAR Simulator (LDAR-Sim)
+File:        multi_simulation_outputs
+Purpose: Functionality for outputs across multiple simulations.
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the MIT License as published
+by the Free Software Foundation, version 3.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+MIT License for more details.
+You should have received a copy of the MIT License
+along with this program.  If not, see <https://opensource.org/licenses/MIT>.
+
+------------------------------------------------------------------------------
+"""
+
 import os
 from pathlib import Path
 import numpy as np
@@ -64,6 +84,7 @@ def get_sum(df: pd.DataFrame, column: str) -> float:
     return df[column].sum()
 
 
+# TODO add this comment to the relevant User Manual Section
 # Currently defined to compute percentiles using a median-unbiased method as described in:
 # https://numpy.org/doc/stable/reference/generated/numpy.percentile.html and
 # Rob J. Hyndman & Yanan Fan (1996) Sample Quantiles in Statistical

--- a/LDAR_Sim/src/file_processing/output_processing/multi_simulation_outputs.py
+++ b/LDAR_Sim/src/file_processing/output_processing/multi_simulation_outputs.py
@@ -1,0 +1,213 @@
+import os
+from pathlib import Path
+import numpy as np
+import pandas as pd
+import re
+from file_processing.output_processing.output_utils import (
+    TIMESERIES_COL_ACCESSORS as tca,
+    EMIS_DATA_COL_ACCESSORS as eca,
+)
+
+
+class TS_SUMMARY_COLUMNS_ACCESSORS:
+    PROG_NAME = "Program Name"
+    SIM = "Simulation"
+    AVG_T_DAILY_EMIS = 'Average "True" Daily Emissions (Kg Methane)'
+    T_DAILY_EMIS_95 = '95th Percentile "True" Daily Emissions (Kg Methane)'
+    T_DAILY_EMIS_5 = '5th Percentile "True" Daily Emissions (Kg Methane)'
+    AVG_DAILY_COST = "Average Daily Cost ($)"
+    DAILY_COST_95 = "95th Percentile Daily Cost ($)"
+    DAILY_COST_5 = "5th Percentile Daily Cost ($)"
+
+
+class EMIS_SUMMARY_COLUMNS_ACCESSORS:
+    PROG_NAME = "Program Name"
+    SIM = "Simulation"
+    T_TOTAL_EMIS = 'Total "True" Emissions (Kg Methane)'
+    AVG_T_EMIS_RATE = 'Average "True" Emissions Rate (g/s)'
+    T_EMIS_RATE_95 = '95th Percentile "True" Emissions Rate (g/s)'
+    T_EMIS_RATE_5 = '5th Percentile "True" Emissions Rate (g/s)'
+    T_AVG_EMIS_AMOUNT = '"True" Average Emissions Amount (Kg Methane)'
+    T_EMIS_AMOUNT_95 = '95th Percentile "True" Emissions Amount (Kg Methane)'
+    T_EMIS_AMOUNT_5 = '5th Percentile "True" Emissions Amount (Kg Methane)'
+
+
+TS_SUMMARY_COLUMNS = [
+    TS_SUMMARY_COLUMNS_ACCESSORS.PROG_NAME,
+    TS_SUMMARY_COLUMNS_ACCESSORS.SIM,
+    TS_SUMMARY_COLUMNS_ACCESSORS.AVG_T_DAILY_EMIS,
+    TS_SUMMARY_COLUMNS_ACCESSORS.T_DAILY_EMIS_95,
+    TS_SUMMARY_COLUMNS_ACCESSORS.T_DAILY_EMIS_5,
+    TS_SUMMARY_COLUMNS_ACCESSORS.AVG_DAILY_COST,
+    TS_SUMMARY_COLUMNS_ACCESSORS.DAILY_COST_95,
+    TS_SUMMARY_COLUMNS_ACCESSORS.DAILY_COST_5,
+]
+
+EMIS_SUMMARY_COLUMNS = [
+    EMIS_SUMMARY_COLUMNS_ACCESSORS.PROG_NAME,
+    EMIS_SUMMARY_COLUMNS_ACCESSORS.SIM,
+    EMIS_SUMMARY_COLUMNS_ACCESSORS.T_TOTAL_EMIS,
+    EMIS_SUMMARY_COLUMNS_ACCESSORS.AVG_T_EMIS_RATE,
+    EMIS_SUMMARY_COLUMNS_ACCESSORS.T_EMIS_RATE_95,
+    EMIS_SUMMARY_COLUMNS_ACCESSORS.T_EMIS_RATE_5,
+    EMIS_SUMMARY_COLUMNS_ACCESSORS.T_AVG_EMIS_AMOUNT,
+    EMIS_SUMMARY_COLUMNS_ACCESSORS.T_EMIS_AMOUNT_95,
+    EMIS_SUMMARY_COLUMNS_ACCESSORS.T_EMIS_AMOUNT_5,
+]
+
+
+def get_mean_val(df: pd.DataFrame, column: str) -> float:
+    return df[column].mean()
+
+
+def get_sum(df: pd.DataFrame, column: str) -> float:
+    return df[column].sum()
+
+
+# Currently defined to compute percentiles using a median-unbiased method as described in:
+# https://numpy.org/doc/stable/reference/generated/numpy.percentile.html and
+# Rob J. Hyndman & Yanan Fan (1996) Sample Quantiles in Statistical
+# Packages, The American Statistician, 50:4, 361-365
+# As this is described as the suggested method for unknown distributions
+def get_nth_percentile(df: pd.DataFrame, column: str, percentile: float) -> float:
+    return np.percentile(df[column], percentile, method="median_unbiased")
+
+
+TS_MAPPING_TO_SUMMARY_COLS = {
+    TS_SUMMARY_COLUMNS_ACCESSORS.AVG_T_DAILY_EMIS: lambda df: get_mean_val(df, tca.EMIS),
+    TS_SUMMARY_COLUMNS_ACCESSORS.T_DAILY_EMIS_95: lambda df: get_nth_percentile(df, tca.EMIS, 95),
+    TS_SUMMARY_COLUMNS_ACCESSORS.T_DAILY_EMIS_5: lambda df: get_nth_percentile(df, tca.EMIS, 5),
+    TS_SUMMARY_COLUMNS_ACCESSORS.AVG_DAILY_COST: lambda df: get_mean_val(df, tca.COST),
+    TS_SUMMARY_COLUMNS_ACCESSORS.DAILY_COST_95: lambda df: get_nth_percentile(df, tca.COST, 95),
+    TS_SUMMARY_COLUMNS_ACCESSORS.DAILY_COST_5: lambda df: get_nth_percentile(df, tca.COST, 5),
+}
+
+EMIS_MAPPING_TO_SUMMARY_COLS = {
+    EMIS_SUMMARY_COLUMNS_ACCESSORS.T_TOTAL_EMIS: lambda df: get_sum(df, eca.T_VOL_EMIT),
+    EMIS_SUMMARY_COLUMNS_ACCESSORS.AVG_T_EMIS_RATE: lambda df: get_mean_val(df, eca.T_RATE),
+    EMIS_SUMMARY_COLUMNS_ACCESSORS.T_EMIS_RATE_95: lambda df: get_nth_percentile(
+        df, eca.T_RATE, 95
+    ),
+    EMIS_SUMMARY_COLUMNS_ACCESSORS.T_EMIS_RATE_5: lambda df: get_nth_percentile(df, eca.T_RATE, 5),
+    EMIS_SUMMARY_COLUMNS_ACCESSORS.T_AVG_EMIS_AMOUNT: lambda df: get_mean_val(df, eca.T_VOL_EMIT),
+    EMIS_SUMMARY_COLUMNS_ACCESSORS.T_EMIS_AMOUNT_95: lambda df: get_nth_percentile(
+        df, eca.T_VOL_EMIT, 95
+    ),
+    EMIS_SUMMARY_COLUMNS_ACCESSORS.T_EMIS_AMOUNT_5: lambda df: get_nth_percentile(
+        df, eca.T_VOL_EMIT, 5
+    ),
+}
+
+TS_SUMMARY_FILENAME = "daily_summary_stats.csv"
+EMIS_SUMMARY_FILENAME = "emissions_summary_stats.csv"
+
+TS_PATTERN = re.compile(r".*timeseries\.csv$")
+EMIS_PATTERN = re.compile(r".*emissions_summary\.csv$")
+
+OUTPUTS_NAME_SIM_EXTRACTION_REGEX = re.compile(r"^(.*?)_(\d+)_.+.csv$")
+
+OUTPUT_KEEP_STR = "kept"
+OUTPUT_KEEP_REGEX = re.compile(re.escape(OUTPUT_KEEP_STR))
+
+
+def gen_ts_summary(dir: Path):
+    ts_summary_df = pd.DataFrame(columns=TS_SUMMARY_COLUMNS)
+    with os.scandir(dir) as entries:
+        for entry in entries:
+            if (
+                entry.is_file()
+                and TS_PATTERN.match(entry.name)
+                and not re.search(OUTPUT_KEEP_REGEX, entry.name)
+            ):
+                new_summary_row = {}
+                ts_data: pd.DataFrame = pd.read_csv(entry.path)
+                new_summary_row[TS_SUMMARY_COLUMNS_ACCESSORS.PROG_NAME] = (
+                    OUTPUTS_NAME_SIM_EXTRACTION_REGEX.match(entry.name).group(1)
+                )
+                new_summary_row[TS_SUMMARY_COLUMNS_ACCESSORS.SIM] = (
+                    OUTPUTS_NAME_SIM_EXTRACTION_REGEX.match(entry.name).group(2)
+                )
+                for sum_stat, calc in TS_MAPPING_TO_SUMMARY_COLS.items():
+                    new_summary_row[sum_stat] = calc(ts_data)
+                ts_summary_df.loc[len(ts_summary_df)] = new_summary_row
+    return ts_summary_df
+
+
+def gen_emissions_summary(dir: Path):
+    emis_summary_df = pd.DataFrame(columns=EMIS_SUMMARY_COLUMNS)
+    with os.scandir(dir) as entries:
+        for entry in entries:
+            if (
+                entry.is_file()
+                and EMIS_PATTERN.match(entry.name)
+                and not re.search(OUTPUT_KEEP_REGEX, entry.name)
+            ):
+                new_summary_row = {}
+                emis_data: pd.DataFrame = pd.read_csv(entry.path)
+                new_summary_row[EMIS_SUMMARY_COLUMNS_ACCESSORS.PROG_NAME] = (
+                    OUTPUTS_NAME_SIM_EXTRACTION_REGEX.match(entry.name).group(1)
+                )
+                new_summary_row[EMIS_SUMMARY_COLUMNS_ACCESSORS.SIM] = (
+                    OUTPUTS_NAME_SIM_EXTRACTION_REGEX.match(entry.name).group(2)
+                )
+                for sum_stat, calc in EMIS_MAPPING_TO_SUMMARY_COLS.items():
+                    new_summary_row[sum_stat] = calc(emis_data)
+                emis_summary_df.loc[len(emis_summary_df)] = new_summary_row
+    return emis_summary_df
+
+
+def get_summary_file(out_dir: Path, filename: str):
+    filepath: Path = out_dir / filename
+    if os.path.exists(filepath):
+        return pd.read_csv(filepath)
+    else:
+        return pd.DataFrame()
+
+
+def save_summary_file(summary_file: pd.DataFrame, out_dir: Path, filename: str):
+    filepath: Path = out_dir / filename
+    summary_file.to_csv(filepath, index=False, mode="w")
+
+
+def clear_directory(dir: Path):
+    with os.scandir(dir) as entries:
+        for entry in entries:
+            if not re.search(OUTPUT_KEEP_REGEX, entry.name):
+                os.remove(entry.path)
+
+
+def mark_outputs_to_keep(dir: Path):
+    with os.scandir(dir) as entries:
+        for entry in entries:
+            if entry.is_file():
+                old_file_path = entry.path
+                new_name = OUTPUT_KEEP_STR + entry.name
+                new_file_path = os.path.join(dir, new_name)
+                os.rename(old_file_path, new_file_path)
+
+
+def concat_output_data(out_dir: Path, clear_outputs: bool):
+    leg_ts_sum: pd.DataFrame = get_summary_file(out_dir, TS_SUMMARY_FILENAME)
+    leg_emis_sum: pd.DataFrame = get_summary_file(out_dir, EMIS_SUMMARY_FILENAME)
+    program_dirs = [f.path for f in os.scandir(out_dir) if f.is_dir()]
+    prog_ts_sum_dfs: list[pd.DataFrame] = []
+    prog_emis_sum_dfs: list[pd.DataFrame] = []
+    for program_dir in program_dirs:
+        prog_ts_sum_dfs.append(gen_ts_summary(program_dir))
+        prog_emis_sum_dfs.append(gen_emissions_summary(program_dir))
+        if clear_outputs:
+            clear_directory(program_dir)
+        else:
+            mark_outputs_to_keep(program_dir)
+    if not leg_ts_sum.empty and not leg_emis_sum.empty:
+        prog_ts_sum_dfs.insert(0, leg_ts_sum)
+        new_ts_sum: pd.DataFrame = pd.concat(prog_ts_sum_dfs, ignore_index=True)
+        prog_emis_sum_dfs.insert(0, leg_emis_sum)
+        new_emis_sum: pd.DataFrame = pd.concat(prog_emis_sum_dfs, ignore_index=True)
+        save_summary_file(new_ts_sum, out_dir, TS_SUMMARY_FILENAME)
+        save_summary_file(new_emis_sum, out_dir, EMIS_SUMMARY_FILENAME)
+    else:
+        new_ts_sum: pd.DataFrame = pd.concat(prog_ts_sum_dfs, ignore_index=True)
+        new_emis_sum: pd.DataFrame = pd.concat(prog_emis_sum_dfs, ignore_index=True)
+        save_summary_file(new_ts_sum, out_dir, TS_SUMMARY_FILENAME)
+        save_summary_file(new_emis_sum, out_dir, EMIS_SUMMARY_FILENAME)

--- a/LDAR_Sim/src/file_processing/output_processing/output_utils.py
+++ b/LDAR_Sim/src/file_processing/output_processing/output_utils.py
@@ -2,36 +2,55 @@ from dataclasses import dataclass
 from numpy import NaN
 
 
-EMIS_SUMMARY_DATA_COLS = [
-    "Emissions ID",
-    "Status",
-    "Days Active",
-    "Volume Emitted",
-    "True Rate",
-    "Measured Rate" "Date Began",
-    "Initially Detected By",
-    "Initially Detected Date",
-    "Tagged",
-    "Tagged By",
-    "equipment",
+class EMIS_DATA_COL_ACCESSORS:
+    EMIS_ID = "Emissions ID"
+    SITE_ID = "Site ID"
+    EQG = "Equipment Group"
+    STATUS = "Status"
+    DAYS_ACT = "Days Active"
+    T_VOL_EMIT = '"True" Volume Emitted (Kg Methane)'
+    T_RATE = '"True" Rate (g/s)'
+    M_RATE = '"Measured" Rate (g/s)'
+    DATE_BEG = "Date Began"
+    DATE_REP = "Date Repaired"
+    INIT_DETECT_BY = "Initially Detected By"
+    INIT_DETECT_DATE = "Initially Detected Date"
+    TAGGED = "Tagged"
+    TAGGED_BY = "Tagged By"
+    EQUIP = "Equipment"
+
+
+EMIS_DATA_COLS = [
+    EMIS_DATA_COL_ACCESSORS.EMIS_ID,
+    EMIS_DATA_COL_ACCESSORS.STATUS,
+    EMIS_DATA_COL_ACCESSORS.DAYS_ACT,
+    EMIS_DATA_COL_ACCESSORS.T_VOL_EMIT,
+    EMIS_DATA_COL_ACCESSORS.T_RATE,
+    EMIS_DATA_COL_ACCESSORS.M_RATE,
+    EMIS_DATA_COL_ACCESSORS.DATE_BEG,
+    EMIS_DATA_COL_ACCESSORS.INIT_DETECT_BY,
+    EMIS_DATA_COL_ACCESSORS.INIT_DETECT_DATE,
+    EMIS_DATA_COL_ACCESSORS.TAGGED,
+    EMIS_DATA_COL_ACCESSORS.TAGGED_BY,
+    EMIS_DATA_COL_ACCESSORS.EQUIP,
 ]
 
-EMIS_SUMMARY_FINAL_COL_ORDER = [
-    "Emissions ID",
-    "Site ID",
-    "Equipment Group",
-    "Equipment",
-    "Status",
-    "Days Active",
-    "Date Began",
-    "Date Repaired",
-    "Volume Emitted",
-    "True Rate",
-    "Measured Rate",
-    "Initially Detected By",
-    "Initially Detected Date",
-    "Tagged",
-    "Tagged By",
+EMIS_DATA_FINAL_COL_ORDER = [
+    EMIS_DATA_COL_ACCESSORS.EMIS_ID,
+    EMIS_DATA_COL_ACCESSORS.SITE_ID,
+    EMIS_DATA_COL_ACCESSORS.EQG,
+    EMIS_DATA_COL_ACCESSORS.EQUIP,
+    EMIS_DATA_COL_ACCESSORS.STATUS,
+    EMIS_DATA_COL_ACCESSORS.DAYS_ACT,
+    EMIS_DATA_COL_ACCESSORS.DATE_BEG,
+    EMIS_DATA_COL_ACCESSORS.DATE_REP,
+    EMIS_DATA_COL_ACCESSORS.T_VOL_EMIT,
+    EMIS_DATA_COL_ACCESSORS.T_RATE,
+    EMIS_DATA_COL_ACCESSORS.M_RATE,
+    EMIS_DATA_COL_ACCESSORS.INIT_DETECT_BY,
+    EMIS_DATA_COL_ACCESSORS.INIT_DETECT_DATE,
+    EMIS_DATA_COL_ACCESSORS.TAGGED,
+    EMIS_DATA_COL_ACCESSORS.TAGGED_BY,
 ]
 
 TIMESERIES_COLUMNS = [

--- a/LDAR_Sim/src/initialization/initialize_emissions.py
+++ b/LDAR_Sim/src/initialization/initialize_emissions.py
@@ -21,6 +21,7 @@ along with this program.  If not, see <https://opensource.org/licenses/MIT>.
 # TODO create logic to read in the generated emission file
 # TODO move over and cleanup all logic to read in previously
 # generated infrastructure and emissions
+from pathlib import Path
 import pickle
 from datetime import date
 
@@ -80,7 +81,7 @@ def initialize_emissions(
     return None
 
 
-def read_in_emissions(infrastructure: Infrastructure, generator_dir, sim_numb):
+def read_in_emissions(infrastructure: Infrastructure, generator_dir: Path, sim_numb: int):
     # Load emissions into the pregenerated infrastructure
     emissions: dict = {}
     emis_file_loc = generator_dir / f"gen_infrastructure_emissions_{sim_numb}.p"

--- a/LDAR_Sim/src/initialization/initialize_emissions.py
+++ b/LDAR_Sim/src/initialization/initialize_emissions.py
@@ -24,6 +24,8 @@ along with this program.  If not, see <https://opensource.org/licenses/MIT>.
 import pickle
 from datetime import date
 
+from virtual_world.infrastructure import Infrastructure
+
 
 def initialize_emissions(
     n_sims,
@@ -78,7 +80,7 @@ def initialize_emissions(
     return None
 
 
-def read_in_emissions(infrastructure, generator_dir, sim_numb):
+def read_in_emissions(infrastructure: Infrastructure, generator_dir, sim_numb):
     # Load emissions into the pregenerated infrastructure
     emissions: dict = {}
     emis_file_loc = generator_dir / f"gen_infrastructure_emissions_{sim_numb}.p"

--- a/LDAR_Sim/src/ldar_sim.py
+++ b/LDAR_Sim/src/ldar_sim.py
@@ -28,7 +28,7 @@ from virtual_world.infrastructure import Infrastructure
 from time_counter import TimeCounter
 from programs.program import Program
 from file_processing.output_processing.output_utils import (
-    EMIS_SUMMARY_FINAL_COL_ORDER,
+    EMIS_DATA_FINAL_COL_ORDER,
     TIMESERIES_COLUMNS,
     TIMESERIES_COL_ACCESSORS as tca,
     EmisRepairInfo,
@@ -97,11 +97,11 @@ class LdarSim:
         overall_emission_data: pd.DataFrame = self._infrastructure.gen_summary_emis_data()
 
         overall_emission_data = overall_emission_data[
-            EMIS_SUMMARY_FINAL_COL_ORDER
+            EMIS_DATA_FINAL_COL_ORDER
             + [
                 col
                 for col in overall_emission_data.columns
-                if col not in EMIS_SUMMARY_FINAL_COL_ORDER
+                if col not in EMIS_DATA_FINAL_COL_ORDER
             ]
         ]
 

--- a/LDAR_Sim/src/virtual_world/emissions.py
+++ b/LDAR_Sim/src/virtual_world/emissions.py
@@ -17,11 +17,15 @@ along with this program.  If not, see <https://opensource.org/licenses/MIT>.
 
 ------------------------------------------------------------------------------
 """
+
 from datetime import date
 from typing import Any
 
 from numpy.random import binomial
-from file_processing.output_processing.output_utils import EmisRepairInfo
+from file_processing.output_processing.output_utils import (
+    EmisRepairInfo,
+    EMIS_DATA_COL_ACCESSORS as eca,
+)
 
 from utils.conversion_constants import GRAMS_PER_SECOND_TO_KG_PER_DAY
 
@@ -100,17 +104,17 @@ class Emission:
 
     def get_summary_dict(self) -> dict[str, Any]:
         summary_dict = {}
-        summary_dict.update({("Emissions ID", self._emissions_id)})
-        summary_dict.update({("Status", self._status)})
-        summary_dict.update({("Days Active", self._active_days)})
-        summary_dict.update({("Volume Emitted", self.get_emis_vol())})
-        summary_dict.update({("True Rate", self._rate)})
-        summary_dict.update({("Measured Rate", self._measured_rate)})
-        summary_dict.update({("Date Began", self._start_date)})
-        summary_dict.update({("Initially Detected By", self._init_detect_by)})
-        summary_dict.update({("Initially Detected Date", self._init_detect_date)})
-        summary_dict.update({("Tagged", "N/A")})
-        summary_dict.update({("Tagged By", "N/A")})
+        summary_dict.update({(eca.EMIS_ID, self._emissions_id)})
+        summary_dict.update({(eca.STATUS, self._status)})
+        summary_dict.update({(eca.DAYS_ACT, self._active_days)})
+        summary_dict.update({(eca.T_VOL_EMIT, self.get_emis_vol())})
+        summary_dict.update({(eca.T_RATE, self._rate)})
+        summary_dict.update({(eca.M_RATE, self._measured_rate)})
+        summary_dict.update({(eca.DATE_BEG, self._start_date)})
+        summary_dict.update({(eca.INIT_DETECT_BY, self._init_detect_by)})
+        summary_dict.update({(eca.INIT_DETECT_DATE, self._init_detect_date)})
+        summary_dict.update({(eca.TAGGED, "N/A")})
+        summary_dict.update({(eca.TAGGED_BY, "N/A")})
         summary_dict.update(self._tech_spat_covs)
         return summary_dict
 

--- a/LDAR_Sim/src/virtual_world/equipment.py
+++ b/LDAR_Sim/src/virtual_world/equipment.py
@@ -24,7 +24,7 @@ import re
 
 import pandas as pd
 from file_processing.output_processing.output_utils import (
-    EMIS_SUMMARY_DATA_COLS,
+    EMIS_DATA_COLS,
     EmisRepairInfo,
     TsEmisData,
 )
@@ -171,7 +171,7 @@ class Equipment:
 
         # Handle empty dataframe cases
         if emis_data_active.empty and emis_data_inactive.empty:
-            columns = EMIS_SUMMARY_DATA_COLS
+            columns = EMIS_DATA_COLS
             return pd.DataFrame(columns=columns)
         elif emis_data_inactive.empty:
             emis_data = emis_data_active

--- a/LDAR_Sim/src/virtual_world/equipment_groups.py
+++ b/LDAR_Sim/src/virtual_world/equipment_groups.py
@@ -22,7 +22,7 @@ from datetime import date
 
 import pandas as pd
 from file_processing.output_processing.output_utils import (
-    EMIS_SUMMARY_DATA_COLS,
+    EMIS_DATA_COLS,
     EmisRepairInfo,
     TsEmisData,
 )
@@ -159,7 +159,7 @@ class Equipment_Group:
         if equip_emis_dataframes:
             emis_data: pd.DataFrame = pd.concat(equip_emis_dataframes)
         else:
-            emis_data: pd.DataFrame = pd.DataFrame(columns=EMIS_SUMMARY_DATA_COLS)
+            emis_data: pd.DataFrame = pd.DataFrame(columns=EMIS_DATA_COLS)
         emis_data["Equipment Group"] = self._id
         return emis_data
 

--- a/LDAR_Sim/testing/unit_testing/test_file_processing/test_output_processing/test_multi_simulation_outputs/test_concat_output_data.py
+++ b/LDAR_Sim/testing/unit_testing/test_file_processing/test_output_processing/test_multi_simulation_outputs/test_concat_output_data.py
@@ -1,0 +1,253 @@
+import os
+from pathlib import Path
+
+import pandas as pd
+
+from src.file_processing.output_processing.multi_simulation_outputs import (  # noqa
+    TS_SUMMARY_FILENAME,
+    EMIS_SUMMARY_FILENAME,
+    gen_ts_summary,
+    TS_SUMMARY_COLUMNS_ACCESSORS as tsca,
+    gen_emissions_summary,
+    EMIS_SUMMARY_COLUMNS_ACCESSORS as esca,
+    get_summary_file,
+    clear_directory,
+    mark_outputs_to_keep,
+    concat_output_data,
+    save_summary_file,
+)
+
+
+class MockDirEntry:
+    def __init__(self, name):
+        self.name = name
+        self.path = name
+
+    def is_dir(self) -> bool:
+        return True
+
+
+mock_legacy_ts_summary_csv = pd.DataFrame(
+    {
+        tsca.PROG_NAME: ["test", "test", "test"],
+        tsca.SIM: ["0", "1", "2"],
+        tsca.AVG_T_DAILY_EMIS: [2.5, 6.5, 10.5],
+        tsca.T_DAILY_EMIS_95: [4.0, 8.0, 12.0],
+        tsca.T_DAILY_EMIS_5: [1.0, 5.0, 9.0],
+        tsca.AVG_DAILY_COST: [8.5, 4.5, 1.5],
+        tsca.DAILY_COST_95: [10.0, 6.0, 3.0],
+        tsca.DAILY_COST_5: [7.0, 3.0, 0.0],
+    }
+)
+
+mock_legacy_emis_summary_csv = pd.DataFrame(
+    {
+        esca.PROG_NAME: ["test", "test", "test"],
+        esca.SIM: ["0", "1", "2"],
+        esca.T_TOTAL_EMIS: [10, 26, 42],
+        esca.AVG_T_EMIS_RATE: [8.5, 4.5, 1.5],
+        esca.T_EMIS_RATE_95: [10.0, 6.0, 3.0],
+        esca.T_EMIS_RATE_5: [7.0, 3.0, 0.0],
+        esca.T_AVG_EMIS_AMOUNT: [2.5, 6.5, 10.5],
+        esca.T_EMIS_AMOUNT_95: [4.0, 8.0, 12.0],
+        esca.T_EMIS_AMOUNT_5: [1.0, 5.0, 9.0],
+    }
+)
+
+mock_current_ts_summary_csv = pd.DataFrame(
+    {
+        tsca.PROG_NAME: ["test", "test", "test"],
+        tsca.SIM: ["3", "4", "5"],
+        tsca.AVG_T_DAILY_EMIS: [2.5, 6.5, 10.5],
+        tsca.T_DAILY_EMIS_95: [4.0, 8.0, 12.0],
+        tsca.T_DAILY_EMIS_5: [1.0, 5.0, 9.0],
+        tsca.AVG_DAILY_COST: [8.5, 4.5, 1.5],
+        tsca.DAILY_COST_95: [10.0, 6.0, 3.0],
+        tsca.DAILY_COST_5: [7.0, 3.0, 0.0],
+    }
+)
+
+mock_current_emis_summary_csv = pd.DataFrame(
+    {
+        esca.PROG_NAME: ["test", "test", "test"],
+        esca.SIM: ["3", "4", "5"],
+        esca.T_TOTAL_EMIS: [10, 26, 42],
+        esca.AVG_T_EMIS_RATE: [8.5, 4.5, 1.5],
+        esca.T_EMIS_RATE_95: [10.0, 6.0, 3.0],
+        esca.T_EMIS_RATE_5: [7.0, 3.0, 0.0],
+        esca.T_AVG_EMIS_AMOUNT: [2.5, 6.5, 10.5],
+        esca.T_EMIS_AMOUNT_95: [4.0, 8.0, 12.0],
+        esca.T_EMIS_AMOUNT_5: [1.0, 5.0, 9.0],
+    }
+)
+
+
+class results_holder:
+    def __init__(self):
+        self.results = {TS_SUMMARY_FILENAME: None, EMIS_SUMMARY_FILENAME: None}
+
+
+expected_results_for_concat = {
+    TS_SUMMARY_FILENAME: pd.DataFrame(
+        {
+            tsca.PROG_NAME: ["test", "test", "test", "test", "test", "test"],
+            tsca.SIM: ["0", "1", "2", "3", "4", "5"],
+            tsca.AVG_T_DAILY_EMIS: [2.5, 6.5, 10.5, 2.5, 6.5, 10.5],
+            tsca.T_DAILY_EMIS_95: [4.0, 8.0, 12.0, 4.0, 8.0, 12.0],
+            tsca.T_DAILY_EMIS_5: [1.0, 5.0, 9.0, 1.0, 5.0, 9.0],
+            tsca.AVG_DAILY_COST: [8.5, 4.5, 1.5, 8.5, 4.5, 1.5],
+            tsca.DAILY_COST_95: [10.0, 6.0, 3.0, 10.0, 6.0, 3.0],
+            tsca.DAILY_COST_5: [7.0, 3.0, 0.0, 7.0, 3.0, 0.0],
+        }
+    ),
+    EMIS_SUMMARY_FILENAME: pd.DataFrame(
+        {
+            esca.PROG_NAME: ["test", "test", "test", "test", "test", "test"],
+            esca.SIM: ["0", "1", "2", "3", "4", "5"],
+            esca.T_TOTAL_EMIS: [10, 26, 42, 10, 26, 42],
+            esca.AVG_T_EMIS_RATE: [8.5, 4.5, 1.5, 8.5, 4.5, 1.5],
+            esca.T_EMIS_RATE_95: [10.0, 6.0, 3.0, 10.0, 6.0, 3.0],
+            esca.T_EMIS_RATE_5: [7.0, 3.0, 0.0, 7.0, 3.0, 0.0],
+            esca.T_AVG_EMIS_AMOUNT: [2.5, 6.5, 10.5, 2.5, 6.5, 10.5],
+            esca.T_EMIS_AMOUNT_95: [4.0, 8.0, 12.0, 4.0, 8.0, 12.0],
+            esca.T_EMIS_AMOUNT_5: [1.0, 5.0, 9.0, 1.0, 5.0, 9.0],
+        }
+    ),
+}
+
+expected_results_no_concat = {
+    TS_SUMMARY_FILENAME: pd.DataFrame(
+        {
+            tsca.PROG_NAME: ["test", "test", "test"],
+            tsca.SIM: ["3", "4", "5"],
+            tsca.AVG_T_DAILY_EMIS: [2.5, 6.5, 10.5],
+            tsca.T_DAILY_EMIS_95: [4.0, 8.0, 12.0],
+            tsca.T_DAILY_EMIS_5: [1.0, 5.0, 9.0],
+            tsca.AVG_DAILY_COST: [8.5, 4.5, 1.5],
+            tsca.DAILY_COST_95: [10.0, 6.0, 3.0],
+            tsca.DAILY_COST_5: [7.0, 3.0, 0.0],
+        }
+    ),
+    EMIS_SUMMARY_FILENAME: pd.DataFrame(
+        {
+            esca.PROG_NAME: ["test", "test", "test"],
+            esca.SIM: ["3", "4", "5"],
+            esca.T_TOTAL_EMIS: [10, 26, 42],
+            esca.AVG_T_EMIS_RATE: [8.5, 4.5, 1.5],
+            esca.T_EMIS_RATE_95: [10.0, 6.0, 3.0],
+            esca.T_EMIS_RATE_5: [7.0, 3.0, 0.0],
+            esca.T_AVG_EMIS_AMOUNT: [2.5, 6.5, 10.5],
+            esca.T_EMIS_AMOUNT_95: [4.0, 8.0, 12.0],
+            esca.T_EMIS_AMOUNT_5: [1.0, 5.0, 9.0],
+        }
+    ),
+}
+
+
+def mock_scandir(dir: Path):
+    yield MockDirEntry(name="test")
+
+
+def mock_gen_ts_summary(dir: Path):
+    return mock_current_ts_summary_csv
+
+
+def mock_gen_emis_summary(dir: Path):
+    return mock_current_emis_summary_csv
+
+
+def mock_get_summary_file_prev_files(dir: Path, filename: str):
+    if filename == TS_SUMMARY_FILENAME:
+        return mock_legacy_ts_summary_csv
+    else:
+        return mock_legacy_emis_summary_csv
+
+
+def mock_get_summary_file_no_prev_files(dir: Path, filename: str):
+    return pd.DataFrame()
+
+
+def test_000_concat_output_data_concats_if_prev_data_exists(monkeypatch):
+    monkeypatch.setattr(os, "scandir", mock_scandir)
+    monkeypatch.setattr(
+        "src.file_processing.output_processing.multi_simulation_outputs.gen_ts_summary",
+        mock_gen_ts_summary,
+    )
+    monkeypatch.setattr(
+        "src.file_processing.output_processing.multi_simulation_outputs.gen_emissions_summary",
+        mock_gen_emis_summary,
+    )
+    monkeypatch.setattr(
+        "src.file_processing.output_processing.multi_simulation_outputs.get_summary_file",
+        mock_get_summary_file_prev_files,
+    )
+    clear_dir_called: bool = False
+
+    def mock_clear_directory(dir: Path):
+        nonlocal clear_dir_called
+        clear_dir_called = True
+
+    monkeypatch.setattr(
+        "src.file_processing.output_processing.multi_simulation_outputs.clear_directory",
+        mock_clear_directory,
+    )
+
+    results = results_holder()
+
+    def mock_save_summary_file(dataframe: pd.DataFrame, path: Path, filename: str):
+        nonlocal results
+        results.results[filename] = dataframe
+
+    monkeypatch.setattr(
+        "src.file_processing.output_processing.multi_simulation_outputs.save_summary_file",
+        mock_save_summary_file,
+    )
+
+    concat_output_data("test", True)
+
+    assert clear_dir_called
+    for file, result in results.results.items():
+        assert result.equals(expected_results_for_concat[file])
+
+
+def test_000_concat_output_data_uses_current_if_no_prev_data(monkeypatch):
+    monkeypatch.setattr(os, "scandir", mock_scandir)
+    monkeypatch.setattr(
+        "src.file_processing.output_processing.multi_simulation_outputs.gen_ts_summary",
+        mock_gen_ts_summary,
+    )
+    monkeypatch.setattr(
+        "src.file_processing.output_processing.multi_simulation_outputs.gen_emissions_summary",
+        mock_gen_emis_summary,
+    )
+    monkeypatch.setattr(
+        "src.file_processing.output_processing.multi_simulation_outputs.get_summary_file",
+        mock_get_summary_file_no_prev_files,
+    )
+    mark_outputs_to_keep_called: bool = False
+
+    def mock_mark_outputs_to_keep(dir: Path):
+        nonlocal mark_outputs_to_keep_called
+        mark_outputs_to_keep_called = True
+
+    monkeypatch.setattr(
+        "src.file_processing.output_processing.multi_simulation_outputs.mark_outputs_to_keep",
+        mock_mark_outputs_to_keep,
+    )
+
+    results = results_holder()
+
+    def mock_save_summary_file(dataframe: pd.DataFrame, path: Path, filename: str):
+        nonlocal results
+        results.results[filename] = dataframe
+
+    monkeypatch.setattr(
+        "src.file_processing.output_processing.multi_simulation_outputs.save_summary_file",
+        mock_save_summary_file,
+    )
+
+    concat_output_data("test", False)
+
+    assert mark_outputs_to_keep_called
+    for file, result in results.results.items():
+        assert result.equals(expected_results_no_concat[file])

--- a/LDAR_Sim/testing/unit_testing/test_file_processing/test_output_processing/test_multi_simulation_outputs/test_concat_output_data.py
+++ b/LDAR_Sim/testing/unit_testing/test_file_processing/test_output_processing/test_multi_simulation_outputs/test_concat_output_data.py
@@ -1,3 +1,23 @@
+"""
+------------------------------------------------------------------------------
+Program:     The LDAR Simulator (LDAR-Sim)
+File:        test_concat_output_data
+Purpose: Testing the concat output data method.
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the MIT License as published
+by the Free Software Foundation, version 3.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+MIT License for more details.
+You should have received a copy of the MIT License
+along with this program.  If not, see <https://opensource.org/licenses/MIT>.
+
+------------------------------------------------------------------------------
+"""
+
 import os
 from pathlib import Path
 

--- a/LDAR_Sim/testing/unit_testing/test_file_processing/test_output_processing/test_multi_simulation_outputs/test_gen_emissions_summary.py
+++ b/LDAR_Sim/testing/unit_testing/test_file_processing/test_output_processing/test_multi_simulation_outputs/test_gen_emissions_summary.py
@@ -1,0 +1,67 @@
+from contextlib import contextmanager
+from pathlib import Path
+
+import pandas as pd
+from src.file_processing.output_processing.multi_simulation_outputs import (
+    gen_emissions_summary,
+    EMIS_SUMMARY_COLUMNS_ACCESSORS as esca,
+)
+import os
+from src.file_processing.output_processing.output_utils import EMIS_DATA_COL_ACCESSORS as eca
+
+
+class MockDirEntry:
+    def __init__(self, name):
+        self.name = name
+        self.path = name
+
+    def is_file(self) -> bool:
+        return True
+
+
+@contextmanager
+def mock_scandir(dir: Path):
+    yield [
+        MockDirEntry(name="test_0_emissions_summary.csv"),
+        MockDirEntry(name="test_1_emissions_summary.csv"),
+        MockDirEntry(name="test_2_emissions_summary.csv"),
+    ]
+
+
+def mock_read_csv(file_path: str):
+    return mock_csv_data[file_path]
+
+
+mock_csv_data = {
+    "test_0_emissions_summary.csv": pd.DataFrame(
+        {eca.T_VOL_EMIT: [1, 2, 3, 4], eca.T_RATE: [10, 9, 8, 7]}
+    ),
+    "test_1_emissions_summary.csv": pd.DataFrame(
+        {eca.T_VOL_EMIT: [5, 6, 7, 8], eca.T_RATE: [6, 5, 4, 3]}
+    ),
+    "test_2_emissions_summary.csv": pd.DataFrame(
+        {eca.T_VOL_EMIT: [9, 10, 11, 12], eca.T_RATE: [3, 2, 1, 0]}
+    ),
+}
+
+expected_summary_csv = pd.DataFrame(
+    {
+        esca.PROG_NAME: ["test", "test", "test"],
+        esca.SIM: ["0", "1", "2"],
+        esca.T_TOTAL_EMIS: [10, 26, 42],
+        esca.AVG_T_EMIS_RATE: [8.5, 4.5, 1.5],
+        esca.T_EMIS_RATE_95: [10.0, 6.0, 3.0],
+        esca.T_EMIS_RATE_5: [7.0, 3.0, 0.0],
+        esca.T_AVG_EMIS_AMOUNT: [2.5, 6.5, 10.5],
+        esca.T_EMIS_AMOUNT_95: [4.0, 8.0, 12.0],
+        esca.T_EMIS_AMOUNT_5: [1.0, 5.0, 9.0],
+    }
+)
+
+
+def test_000_correct_summary_generated_from_3_es(monkeypatch):
+    monkeypatch.setattr(os, "scandir", mock_scandir)
+    monkeypatch.setattr(pd, "read_csv", mock_read_csv)
+    test_es_summary: pd.DataFrame = gen_emissions_summary("test")
+    assert isinstance(test_es_summary, pd.DataFrame)
+    assert test_es_summary.equals(expected_summary_csv)

--- a/LDAR_Sim/testing/unit_testing/test_file_processing/test_output_processing/test_multi_simulation_outputs/test_gen_emissions_summary.py
+++ b/LDAR_Sim/testing/unit_testing/test_file_processing/test_output_processing/test_multi_simulation_outputs/test_gen_emissions_summary.py
@@ -1,3 +1,23 @@
+"""
+------------------------------------------------------------------------------
+Program:     The LDAR Simulator (LDAR-Sim)
+File:        test gen emissions summary
+Purpose: Unit testing the gen emissions summary method.
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the MIT License as published
+by the Free Software Foundation, version 3.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+MIT License for more details.
+You should have received a copy of the MIT License
+along with this program.  If not, see <https://opensource.org/licenses/MIT>.
+
+------------------------------------------------------------------------------
+"""
+
 from contextlib import contextmanager
 from pathlib import Path
 

--- a/LDAR_Sim/testing/unit_testing/test_file_processing/test_output_processing/test_multi_simulation_outputs/test_gen_ts_summary.py
+++ b/LDAR_Sim/testing/unit_testing/test_file_processing/test_output_processing/test_multi_simulation_outputs/test_gen_ts_summary.py
@@ -1,3 +1,23 @@
+"""
+------------------------------------------------------------------------------
+Program:     The LDAR Simulator (LDAR-Sim)
+File:        test gen ts summary
+Purpose: Unit testing the gen ts summary method.
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the MIT License as published
+by the Free Software Foundation, version 3.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+MIT License for more details.
+You should have received a copy of the MIT License
+along with this program.  If not, see <https://opensource.org/licenses/MIT>.
+
+------------------------------------------------------------------------------
+"""
+
 from contextlib import contextmanager
 from pathlib import Path
 

--- a/LDAR_Sim/testing/unit_testing/test_file_processing/test_output_processing/test_multi_simulation_outputs/test_gen_ts_summary.py
+++ b/LDAR_Sim/testing/unit_testing/test_file_processing/test_output_processing/test_multi_simulation_outputs/test_gen_ts_summary.py
@@ -1,0 +1,60 @@
+from contextlib import contextmanager
+from pathlib import Path
+
+import pandas as pd
+from src.file_processing.output_processing.multi_simulation_outputs import (
+    gen_ts_summary,
+    TS_SUMMARY_COLUMNS_ACCESSORS as tsca,
+)
+import os
+from src.file_processing.output_processing.output_utils import TIMESERIES_COL_ACCESSORS as tca
+
+
+class MockDirEntry:
+    def __init__(self, name):
+        self.name = name
+        self.path = name
+
+    def is_file(self) -> bool:
+        return True
+
+
+@contextmanager
+def mock_scandir(dir: Path):
+    yield [
+        MockDirEntry(name="test_0_timeseries.csv"),
+        MockDirEntry(name="test_1_timeseries.csv"),
+        MockDirEntry(name="test_2_timeseries.csv"),
+    ]
+
+
+def mock_read_csv(file_path: str):
+    return mock_csv_data[file_path]
+
+
+mock_csv_data = {
+    "test_0_timeseries.csv": pd.DataFrame({tca.EMIS: [1, 2, 3, 4], tca.COST: [10, 9, 8, 7]}),
+    "test_1_timeseries.csv": pd.DataFrame({tca.EMIS: [5, 6, 7, 8], tca.COST: [6, 5, 4, 3]}),
+    "test_2_timeseries.csv": pd.DataFrame({tca.EMIS: [9, 10, 11, 12], tca.COST: [3, 2, 1, 0]}),
+}
+
+expected_summary_csv = pd.DataFrame(
+    {
+        tsca.PROG_NAME: ["test", "test", "test"],
+        tsca.SIM: ["0", "1", "2"],
+        tsca.AVG_T_DAILY_EMIS: [2.5, 6.5, 10.5],
+        tsca.T_DAILY_EMIS_95: [4.0, 8.0, 12.0],
+        tsca.T_DAILY_EMIS_5: [1.0, 5.0, 9.0],
+        tsca.AVG_DAILY_COST: [8.5, 4.5, 1.5],
+        tsca.DAILY_COST_95: [10.0, 6.0, 3.0],
+        tsca.DAILY_COST_5: [7.0, 3.0, 0.0],
+    }
+)
+
+
+def test_000_correct_summary_generated_from_3_ts(monkeypatch):
+    monkeypatch.setattr(os, "scandir", mock_scandir)
+    monkeypatch.setattr(pd, "read_csv", mock_read_csv)
+    test_ts_summary: pd.DataFrame = gen_ts_summary("test")
+    assert isinstance(test_ts_summary, pd.DataFrame)
+    assert test_ts_summary.equals(expected_summary_csv)


### PR DESCRIPTION
# Pull Request Key Information

## Reason for change

LDAR-Sim v4 currently produces timeseries and emissions data outputs
per program per each simulation. With multiple programs and multiple
simulations there currently exists no convenient way to review overall
results. The power of LDAR-SIm lies in running multiple simulations
to approach an "typical" result by considering results
across multiple simulations. This creates a need for results
the individual results of simulations such that the "average"
simulation result can be considered.

## What was changed

Added new outputs reporting:

Program name
Simulation Number
The average Daily Emissions for the simulation
The 95th percentile daily emissions for the simulation
The 5th percentile daily emissions for the simulation
The average Daily Cost for the simulation
The 95th percentile daily Cost for the simulation
The 5th percentile daily Cost for the simulation

for the timeseries output

and

Program name
Simulation Number
Total "True" Emissions for the simulation
The average "True" Emissions for the simulation
The 95th percentile "True" Emissions for the simulation
The 5th percentile "True" Emissions for the simulation
The average emissions rate for the simulation
The 95th percentile emissions rate for the simulation
The 5th percentile emissions rate for the simulation

for the emissions output

## Intended Purpose

Add new summary outputs for LDAR-Sim v4

## Level of version change required

Minor

## Testing Completed

Unit test adding and Passing

## Target Issue

N/A

## Additional Information

