### PR TITLE
fix: Improve mem efficiency of loading emissions

### DIFF
--- a/LDAR_Sim/src/virtual_world/sources.py
+++ b/LDAR_Sim/src/virtual_world/sources.py
@@ -17,6 +17,7 @@ along with this program.  If not, see <https://opensource.org/licenses/MIT>.
 
 ------------------------------------------------------------------------------
 """
+
 from datetime import date, timedelta
 import re
 import sys
@@ -244,6 +245,7 @@ class Source:
         return newly_activated_emissions
 
     def set_pregen_emissions(self, src_emissions, sim_number) -> None:
+        self._generated_emissions.clear()
         self._generated_emissions[sim_number] = src_emissions
 
     def get_id(self) -> str:


### PR DESCRIPTION
# Pull Request Key Information

## Reason for change

Emissions from simulations before the current simulation would remain in memory even after their simulation had finished. This is a problematic behavior for simulations sets with many simulations as memory use grows until all simulation sets are completed.

## What was changed

Now clears other emissions when loading in emissions for a given simulation.

## Intended Purpose

Improve Memory Efficiency

## Level of version change required

N/A

## Testing Completed

Manual testing

## Target Issue

N/A

## Additional Information

N/A
