### PR TITLE
Bug fix - Simulation Set number

### DIFF
--- a/LDAR_Sim/src/ldar_sim_run.py
+++ b/LDAR_Sim/src/ldar_sim_run.py
@@ -279,7 +279,7 @@ if __name__ == "__main__":
                         (
                             daylight,
                             weather,
-                            simulation,
+                            simulation_number,
                             program,
                             meth_params,
                             sim_params,
@@ -297,7 +297,7 @@ if __name__ == "__main__":
                         prog_data,
                     )
                 gc.collect()
-                print(f"Finished simulating set {simulation}")
+                print(f"Finished simulating set {simulation_number}")
 
             # -- Batch Report --
             print("...Cleaning up output data")


### PR DESCRIPTION
# Pull Request Key Information

## Reason for change

Simulations errored out with a key error when attempting to simulate more than 5 simulation sets. 

## Intended Purpose

Fix bug that prevents users from running more than 5 simulation sets.

## Level of version change required

N/A

## Testing Completed

Manual testing to see if the key error happens after doing n_simulation > 5

## Additional Information

Include any other important information here.
