### PR TITLE
<FEAT>: Limit processes

### DIFF
--- a/LDAR_Sim/src/ldar_sim_run.py
+++ b/LDAR_Sim/src/ldar_sim_run.py
@@ -260,7 +260,9 @@ if __name__ == "__main__":
         sim_counts.append(simulation_count % 5)
     else:
         sim_counts = [simulation_count]
-
+    n_process = sim_params["n_processes"]
+    if len(programs) < sim_params["n_processes"]:
+        n_process = len(programs)
     with mp.Manager() as manager:
         lock = manager.Lock()
         for batch_count, sim_count in enumerate(sim_counts):
@@ -291,7 +293,8 @@ if __name__ == "__main__":
                             lock,
                         )
                     )
-                with mp.Pool(processes=sim_params["n_processes"]) as p:
+
+                with mp.Pool(processes=n_process) as p:
                     sim_outputs = p.starmap(
                         simulate,
                         prog_data,


### PR DESCRIPTION
# Pull Request Key Information

## Reason for change

There is a potential for extra processes to be spawned with  multiprocessing This resource could be used by the actual processes that are working instead of being left idle.

## What was changed

If the number of programs is less than the number of available processes, limit the number of processes that are generated to the number of programs.

## Intended Purpose

Help with the simulation's resource allocations. 

## Level of version change required
N/A

## Testing Completed

Manual testing

