### PR TITLE
V4 preseed random fix

### DIFF
--- a/LDAR_Sim/src/initialization/initialize_emissions.py
+++ b/LDAR_Sim/src/initialization/initialize_emissions.py
@@ -27,6 +27,7 @@ from datetime import date
 import numpy as np
 from virtual_world.infrastructure import Infrastructure
 from initialization.preseed import gen_seed_timeseries
+from utils.file_name_constants import N_SIM_SAVE_FILE
 
 
 def initialize_emissions(
@@ -39,16 +40,10 @@ def initialize_emissions(
     end_date: date,
     generator_dir: Path,
 ):
-    n_sim_loc = generator_dir / "n_sim_saved.p"
+    n_sim_loc = generator_dir / N_SIM_SAVE_FILE
     n_simulation_saved: int = 0
     # Store params used to generate the pickle files for change detection
     if not hash_file_exist:
-        if preseed:
-            seed_timeseries = gen_seed_timeseries(
-                sim_end_date=end_date, sim_start_date=start_date, gen_dir=generator_dir
-            )
-        else:
-            seed_timeseries = None
         # Generate emissions for all simulation sets
         for i in range(n_sims):
             if preseed:
@@ -66,12 +61,10 @@ def initialize_emissions(
             pickle.dump(emissions, open(emis_file_loc, "wb"))
         pickle.dump(n_sims, open(n_sim_loc, "wb"))
     else:
-
         n_simulation_saved = pickle.load(open(n_sim_loc, "rb"))
 
         if n_simulation_saved < n_sims:
-            n_sim = n_simulation_saved
-            pickle.dump(n_sim, open(n_sim_loc, "wb"))
+            pickle.dump(n_sims, open(n_sim_loc, "wb"))
 
             # More simulations are required. Generated emissions can still be re-used,
             # but it is necessary to generate more emissions scenarios for the extra simulations
@@ -92,12 +85,12 @@ def initialize_emissions(
 
                 pickle.dump(emissions, open(emis_file_loc, "wb"))
 
-        if preseed:
-            seed_timeseries = gen_seed_timeseries(
-                sim_end_date=end_date, sim_start_date=start_date, gen_dir=generator_dir
-            )
-        else:
-            seed_timeseries = None
+    if preseed:
+        seed_timeseries = gen_seed_timeseries(
+            sim_end_date=end_date, sim_start_date=start_date, gen_dir=generator_dir
+        )
+    else:
+        seed_timeseries = None
     return seed_timeseries
 
 

--- a/LDAR_Sim/src/initialization/initialize_infrastructure.py
+++ b/LDAR_Sim/src/initialization/initialize_infrastructure.py
@@ -4,6 +4,7 @@ from virtual_world.infrastructure import Infrastructure
 import hashlib
 import json
 import numpy as np
+from utils.file_name_constants import HASH_FILE, INFRA_FILE
 
 
 def hash_file(file_path) -> str:
@@ -40,9 +41,8 @@ def initialize_infrastructure(
 
     # Generate Infrastructure for all simulations.
     # If previously generated infrastructure exists, use it instead.
-    hash_file_loc = generator_dir / "gen_infrastructure_hashes.p"
-    infra_file_loc = generator_dir / "gen_infrastructure.p"
-    preseed_loc = generator_dir / "emis_preseed.p"
+    hash_file_loc = generator_dir / HASH_FILE
+    infra_file_loc = generator_dir / INFRA_FILE
     # emis_file_loc = generator_dir / "gen_infrastructure_emissions.p"
     # TODO Also add logic to hash the emissions rate sources file. Add logic elsewhere to make
     # that a standard input.
@@ -134,7 +134,6 @@ def initialize_infrastructure(
             infrastructure: Infrastructure = Infrastructure(
                 virtual_world=virtual_world, methods=methods, in_dir=in_dir
             )
-            pickle.dump(preseed_val, open(preseed_loc, "wb"))
             # Save the generated Infrastructure,
             # the input file hashes and the virtual world hash.
             pickle.dump(

--- a/LDAR_Sim/src/initialization/initialize_infrastructure.py
+++ b/LDAR_Sim/src/initialization/initialize_infrastructure.py
@@ -3,6 +3,7 @@ import pickle
 from virtual_world.infrastructure import Infrastructure
 import hashlib
 import json
+import numpy as np
 
 
 def hash_file(file_path) -> str:
@@ -31,10 +32,7 @@ def hash_dict(in_dict) -> str:
 
 
 def initialize_infrastructure(
-    methods,
-    virtual_world,
-    generator_dir,
-    in_dir,
+    methods, virtual_world, generator_dir, in_dir, preseed, preseed_val
 ) -> Infrastructure:
 
     if not os.path.exists(generator_dir):
@@ -44,6 +42,7 @@ def initialize_infrastructure(
     # If previously generated infrastructure exists, use it instead.
     hash_file_loc = generator_dir / "gen_infrastructure_hashes.p"
     infra_file_loc = generator_dir / "gen_infrastructure.p"
+    preseed_loc = generator_dir / "emis_preseed.p"
     # emis_file_loc = generator_dir / "gen_infrastructure_emissions.p"
     # TODO Also add logic to hash the emissions rate sources file. Add logic elsewhere to make
     # that a standard input.
@@ -78,6 +77,9 @@ def initialize_infrastructure(
     if not os.path.isfile(hash_file_loc) or not os.path.isfile(infra_file_loc):
         # No previously generated Infrastructure found, generate new Infrastructure
         print("Generating Infrastructure")
+        if preseed:
+            np.random.seed(preseed_val[0])
+
         infrastructure: Infrastructure = Infrastructure(
             virtual_world=virtual_world, methods=methods, in_dir=in_dir
         )
@@ -125,10 +127,14 @@ def initialize_infrastructure(
             # meaning something has changed with the infrastructure or virtual world.
             # Either way, the sites need to be generated anew.
             print("Generating Infrastructure")
+
+            if preseed:
+                np.random.seed(preseed_val[0])
+
             infrastructure: Infrastructure = Infrastructure(
                 virtual_world=virtual_world, methods=methods, in_dir=in_dir
             )
-
+            pickle.dump(preseed_val, open(preseed_loc, "wb"))
             # Save the generated Infrastructure,
             # the input file hashes and the virtual world hash.
             pickle.dump(

--- a/LDAR_Sim/src/initialization/initialize_infrastructure.py
+++ b/LDAR_Sim/src/initialization/initialize_infrastructure.py
@@ -31,14 +31,11 @@ def hash_dict(in_dict) -> str:
 
 
 def initialize_infrastructure(
-    n_sims,
     methods,
     virtual_world,
     generator_dir,
     in_dir,
 ) -> Infrastructure:
-    # Store params used to generate the pickle files for change detection
-    n_simulations: int = n_sims
 
     if not os.path.exists(generator_dir):
         os.mkdir(generator_dir)
@@ -93,13 +90,11 @@ def initialize_infrastructure(
                 "equipment_group_file": equip_group_file_hash,
                 "sources_file": sources_file_hash,
                 "virtual_world": virtual_world_hash,
-                "n_simulations": n_simulations,
             },
             open(hash_file_loc, "wb"),
         )
         pickle.dump({"infrastructure": infrastructure}, open(infra_file_loc, "wb"))
         hash_file_exist = False
-        n_sims_match = False
     else:
         # Read in all the saved hashes from the infrastructure used to generate
         # the previously generated sites.
@@ -110,9 +105,6 @@ def initialize_infrastructure(
         gen_sources_file_hash: str = gen_infra_hash_dict["sources_file"]
         gen_virtual_world_hash: str = gen_infra_hash_dict["virtual_world"]
 
-        # Read the previous number of simulations
-        gen_n_simulations = gen_infra_hash_dict["n_simulations"]
-
         # Check if all previous hashes match current hashes
         hashes_match: bool = (
             gen_sites_file_hash == sites_file_hash
@@ -121,9 +113,6 @@ def initialize_infrastructure(
             and gen_sources_file_hash == sources_file_hash
             and gen_virtual_world_hash == virtual_world_hash
         )
-
-        # Check if the same number of simulations or less simulations are required.
-        n_sims_match: bool = gen_n_simulations >= n_simulations
 
         # Determine what to do next based on if all current hashes match previous hashes
         if hashes_match:
@@ -149,11 +138,10 @@ def initialize_infrastructure(
                     "equipment_group_file": equip_group_file_hash,
                     "sources_file": sources_file_hash,
                     "virtual_world": virtual_world_hash,
-                    "n_simulations": n_simulations,
                 },
                 open(hash_file_loc, "wb"),
             )
             pickle.dump({"infrastructure": infrastructure}, open(infra_file_loc, "wb"))
 
             hash_file_exist = False
-    return infrastructure, hash_file_exist, n_sims_match
+    return infrastructure, hash_file_exist

--- a/LDAR_Sim/src/initialization/preseed.py
+++ b/LDAR_Sim/src/initialization/preseed.py
@@ -18,26 +18,24 @@
 #
 # ------------------------------------------------------------------------------
 
-import random
+import numpy as np
 from datetime import date, timedelta
 import pickle
 
 
-def gen_seed_timeseries(
-    sim_start_date: date, sim_end_date: date, gen_dir, preseed_file_exist
-) -> list[int]:
+def gen_seed_timeseries(sim_start_date: date, sim_end_date: date, gen_dir) -> list[int]:
     seed_ts_dict: dict[date, int] = {}
 
     preseed_loc = gen_dir / "preseed.p"
-    # check for existing file
-    if preseed_file_exist:
-        seed_ts_dict = pickle.load(open(preseed_loc, "rb"))
-        return seed_ts_dict
-
     current_date = sim_start_date
     while current_date <= sim_end_date:
-        seed_ts_dict[current_date] = random.randint(1, 50)
+        seed_ts_dict[current_date] = np.random.randint(0, 255)
         current_date += timedelta(days=1)
     pickle.dump(seed_ts_dict, open(preseed_loc, "wb"))
 
     return seed_ts_dict
+
+
+def get_seed_timeseries(gen_dir) -> list[int]:
+    preseed_loc = gen_dir / "preseed.p"
+    return pickle.load(open(preseed_loc, "rb"))

--- a/LDAR_Sim/src/initialization/preseed.py
+++ b/LDAR_Sim/src/initialization/preseed.py
@@ -21,13 +21,20 @@
 import numpy as np
 from datetime import date, timedelta
 import pickle
+import os
 
 
 def gen_seed_timeseries(sim_start_date: date, sim_end_date: date, gen_dir) -> list[int]:
     seed_ts_dict: dict[date, int] = {}
-
     preseed_loc = gen_dir / "preseed.p"
     current_date = sim_start_date
+
+    if os.path.isfile(preseed_loc):
+        seed_ts_dict = get_seed_timeseries(gen_dir)
+        # check that the sim length matches
+        if (sim_end_date - sim_start_date).days + 1 == len(seed_ts_dict):
+            return seed_ts_dict
+    print("Generating Random seed values for simulation...")
     while current_date <= sim_end_date:
         seed_ts_dict[current_date] = np.random.randint(0, 255)
         current_date += timedelta(days=1)
@@ -38,4 +45,32 @@ def gen_seed_timeseries(sim_start_date: date, sim_end_date: date, gen_dir) -> li
 
 def get_seed_timeseries(gen_dir) -> list[int]:
     preseed_loc = gen_dir / "preseed.p"
+    return pickle.load(open(preseed_loc, "rb"))
+
+
+def gen_seed_emis(n_sim: int, gen_dir):
+    preseed_val: list[int] = []
+    preseed_loc = gen_dir / "emis_preseed.p"
+    if not os.path.exists(gen_dir):
+        os.mkdir(gen_dir)
+
+    if os.path.isfile(preseed_loc):
+        preseed_val = get_emis_seed(gen_dir)
+        if len(preseed_val) < n_sim:
+            print("Generating additional Random Seed values for emissions...")
+            for i in range(len(preseed_val), n_sim):
+                emis_preseed: int = np.random.randint(0, 255)
+                preseed_val.append(emis_preseed)
+            pickle.dump(preseed_val, open(preseed_loc, "wb"))
+    else:
+        print("Generating Random Seed values for emissions...")
+        for i in range(n_sim):
+            emis_preseed: int = np.random.randint(0, 255)
+            preseed_val.append(emis_preseed)
+        pickle.dump(preseed_val, open(preseed_loc, "wb"))
+    return preseed_val
+
+
+def get_emis_seed(gen_dir) -> list[int]:
+    preseed_loc = gen_dir / "emis_preseed.p"
     return pickle.load(open(preseed_loc, "rb"))

--- a/LDAR_Sim/src/initialization/preseed.py
+++ b/LDAR_Sim/src/initialization/preseed.py
@@ -22,11 +22,12 @@ import numpy as np
 from datetime import date, timedelta
 import pickle
 import os
+from utils.file_name_constants import PRESEED_FILE, EMISSION_PRESEED_FILE
 
 
 def gen_seed_timeseries(sim_start_date: date, sim_end_date: date, gen_dir) -> list[int]:
     seed_ts_dict: dict[date, int] = {}
-    preseed_loc = gen_dir / "preseed.p"
+    preseed_loc = gen_dir / PRESEED_FILE
     current_date = sim_start_date
 
     if os.path.isfile(preseed_loc):
@@ -44,13 +45,13 @@ def gen_seed_timeseries(sim_start_date: date, sim_end_date: date, gen_dir) -> li
 
 
 def get_seed_timeseries(gen_dir) -> list[int]:
-    preseed_loc = gen_dir / "preseed.p"
+    preseed_loc = gen_dir / PRESEED_FILE
     return pickle.load(open(preseed_loc, "rb"))
 
 
 def gen_seed_emis(n_sim: int, gen_dir):
     preseed_val: list[int] = []
-    preseed_loc = gen_dir / "emis_preseed.p"
+    preseed_loc = gen_dir / EMISSION_PRESEED_FILE
     if not os.path.exists(gen_dir):
         os.mkdir(gen_dir)
 
@@ -72,5 +73,5 @@ def gen_seed_emis(n_sim: int, gen_dir):
 
 
 def get_emis_seed(gen_dir) -> list[int]:
-    preseed_loc = gen_dir / "emis_preseed.p"
+    preseed_loc = gen_dir / EMISSION_PRESEED_FILE
     return pickle.load(open(preseed_loc, "rb"))

--- a/LDAR_Sim/src/ldar_sim_run.py
+++ b/LDAR_Sim/src/ldar_sim_run.py
@@ -33,7 +33,6 @@ from file_processing.output_processing.multi_simulation_outputs import (
 
 
 from initialization.initialize_infrastructure import initialize_infrastructure
-from initialization.preseed import gen_seed_timeseries
 from virtual_world.infrastructure import Infrastructure
 from stdout_redirect import stdout_redirect
 from virtual_world.sites import Site
@@ -219,8 +218,7 @@ if __name__ == "__main__":
     print("...Initializing infrastructure")
 
     simulation_count: int = sim_params["n_simulations"]
-    infrastructure, hash_file_exist, n_sim_match = initialize_infrastructure(
-        simulation_count,
+    infrastructure, hash_file_exist = initialize_infrastructure(
         methods,
         virtual_world,
         generator_dir,
@@ -228,22 +226,17 @@ if __name__ == "__main__":
     )
     infrastructure: Infrastructure
     hash_file_exist: bool
-    n_sim_match: bool
     print("...Initializing emissions")
     # Pregenerate emissions
-    initialize_emissions(
-        simulation_count, hash_file_exist, n_sim_match, infrastructure, virtual_world, generator_dir
+    seed_timeseries = initialize_emissions(
+        simulation_count,
+        preseed_random,
+        hash_file_exist,
+        infrastructure,
+        date(*virtual_world["start_date"]),
+        date(*virtual_world["end_date"]),
+        generator_dir,
     )
-    # Check and set up preseed random if relevant
-    if preseed_random:
-        seed_timeseries = gen_seed_timeseries(
-            sim_end_date=date(*virtual_world["end_date"]),
-            sim_start_date=date(*virtual_world["start_date"]),
-            gen_dir=generator_dir,
-            preseed_file_exist=hash_file_exist,  # assumes if hash files exist, so will the preseed.
-        )
-    else:
-        seed_timeseries = None
     # Initialize objects
     print("...Initializing weather")
     weather = WL(virtual_world, in_dir)

--- a/LDAR_Sim/src/ldar_sim_run.py
+++ b/LDAR_Sim/src/ldar_sim_run.py
@@ -39,7 +39,7 @@ from stdout_redirect import stdout_redirect
 from virtual_world.sites import Site
 from weather.daylight_calculator import DaylightCalculatorAve
 from weather.weather_lookup import WeatherLookup as WL
-
+from utils.file_name_constants import PARAMETER_FILE, GENERATOR_FOLDER
 from utils.generic_functions import check_ERA5_file
 from file_processing.input_processing.input_manager import InputManager
 from initialization.args import (
@@ -204,9 +204,9 @@ if __name__ == "__main__":
     if os.path.exists(out_dir):
         shutil.rmtree(out_dir)
     os.makedirs(out_dir)
-    input_manager.write_parameters(out_dir / "parameters.yaml")
+    input_manager.write_parameters(out_dir / PARAMETER_FILE)
 
-    generator_dir = in_dir / "generator"
+    generator_dir = in_dir / GENERATOR_FOLDER
     if os.path.exists(generator_dir):
         print(
             "\n".join(

--- a/LDAR_Sim/src/ldar_sim_run.py
+++ b/LDAR_Sim/src/ldar_sim_run.py
@@ -33,6 +33,7 @@ from file_processing.output_processing.multi_simulation_outputs import (
 
 
 from initialization.initialize_infrastructure import initialize_infrastructure
+from initialization.preseed import gen_seed_emis
 from virtual_world.infrastructure import Infrastructure
 from stdout_redirect import stdout_redirect
 from virtual_world.sites import Site
@@ -216,13 +217,12 @@ if __name__ == "__main__":
             )
         )
     print("...Initializing infrastructure")
-
     simulation_count: int = sim_params["n_simulations"]
+    emis_preseed_val: list[int] = None
+    if preseed_random:
+        emis_preseed_val = gen_seed_emis(simulation_count, generator_dir)
     infrastructure, hash_file_exist = initialize_infrastructure(
-        methods,
-        virtual_world,
-        generator_dir,
-        in_dir,
+        methods, virtual_world, generator_dir, in_dir, preseed_random, emis_preseed_val
     )
     infrastructure: Infrastructure
     hash_file_exist: bool
@@ -231,6 +231,7 @@ if __name__ == "__main__":
     seed_timeseries = initialize_emissions(
         simulation_count,
         preseed_random,
+        emis_preseed_val,
         hash_file_exist,
         infrastructure,
         date(*virtual_world["start_date"]),

--- a/LDAR_Sim/src/methods/init_func/repair_delay.py
+++ b/LDAR_Sim/src/methods/init_func/repair_delay.py
@@ -19,7 +19,6 @@
 # ------------------------------------------------------------------------------
 
 import numpy as np
-import random
 
 
 def determine_delay(virtual_world):
@@ -39,7 +38,7 @@ def determine_delay(virtual_world):
         delay = virtual_world["repair_delay"]["val"][0]
     elif virtual_world["repair_delay"]["type"] == "list":
         list_len = len(virtual_world["repair_delay"]["val"])
-        delay_ind = random.randint(0, list_len - 1)
+        delay_ind = np.random.randint(0, list_len - 1)
         delay = virtual_world["repair_delay"]["val"][delay_ind]
     elif virtual_world["repair_delay"]["type"] == "distribution":
         delay = np.random.lognormal(

--- a/LDAR_Sim/src/utils/file_name_constants.py
+++ b/LDAR_Sim/src/utils/file_name_constants.py
@@ -1,0 +1,29 @@
+# ------------------------------------------------------------------------------
+# Program:     The LDAR Simulator (LDAR-Sim)
+# File:        utils.file_name_constats
+# Purpose:     Contains constants used to define file names
+#
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the MIT License as published
+# by the Free Software Foundation, version 3.
+
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# MIT License for more details.
+# You should have received a copy of the MIT License
+# along with this program.  If not, see <https://opensource.org/licenses/MIT>.
+#
+# ------------------------------------------------------------------------------
+
+PRESEED_FILE = "preseed.p"
+EMISSION_PRESEED_FILE = "emis_preseed.p"
+N_SIM_SAVE_FILE = "n_sim_saved.p"
+
+HASH_FILE = "gen_infrastructure_hashes.p"
+INFRA_FILE = "gen_infrastructure.p"
+
+PARAMETER_FILE = "parameters.yaml"
+
+GENERATOR_FOLDER = "generator"

--- a/LDAR_Sim/src/virtual_world/sources.py
+++ b/LDAR_Sim/src/virtual_world/sources.py
@@ -22,7 +22,6 @@ from datetime import date, timedelta
 import re
 import sys
 from typing import Literal
-import random
 
 import numpy as np
 import pandas as pd
@@ -170,10 +169,10 @@ class Source:
         if isinstance(self._emis_rep_delay, int):
             return self._emis_rep_delay
         elif isinstance(self._emis_rep_delay, list):
-            return random.choice(self._emis_rep_delay)
+            return np.random.choice(self._emis_rep_delay)
         elif isinstance(self._emis_rep_delay, str):
             if self._emis_rep_delay in repair_delay_dataframe:
-                return random.choice(repair_delay_dataframe[self._emis_rep_delay])
+                return np.random.choice(repair_delay_dataframe[self._emis_rep_delay])
             else:
                 print(self.INVALID_REPAIR_DELAY_COL_MSG.format(key=self._emis_rep_delay))
                 sys.exit()


### PR DESCRIPTION
# Pull Request Key Information

## Reason for change

Setting the random seed function was not working as intended. 

## What was changed

The random seeds are now utilized, and simulations can be replicated if users provide the pre-seed files. 

## Intended Purpose

To allow for users to replicate simulations as long as they have the pre-seed generator files. 

## Testing Completed

Output files were manually compared using https://www.diffchecker.com/
First set of outputs were made by sims ran normally with no generator files
Second set of outputs were made by sims ran with existing generator files
Third set of outputs were generated by sims that had only the pre-generated seed files (preseed.p and emis_preseed.p)
Fourth set of outputs were generated by changing the version number in the parameters. 

The following zip contains the files necessary to replicate the test mentioned above. 
[simple_test_case.zip](https://github.com/LDAR-Sim/LDAR_Sim/files/14365442/simple_test_case.zip)

Shows the expected identical emissions summary file from the first vs fourth set of outputs
![image](https://github.com/LDAR-Sim/LDAR_Sim/assets/43421303/6fb6fd09-15f3-4ff3-b356-374909e74a04)

Shows the expected 8 lines of differences from the change in versions from the first vs fourth parameter file
![image](https://github.com/LDAR-Sim/LDAR_Sim/assets/43421303/369fe154-410e-4b4a-82ba-9fd6387785a0)
