### PR TITLE
Add ability to define Equipment in Site Type File

### DIFF
--- a/LDAR_Sim/src/file_processing/input_processing/infrastructure_processing.py
+++ b/LDAR_Sim/src/file_processing/input_processing/infrastructure_processing.py
@@ -27,9 +27,14 @@ from virtual_world.infrastructure_const import Infrastructure_Constants as ic
 
 MISSING_SITES_FILE_HEADER_ERROR = "The sites file is missing the column: {}"
 
+NO_PERSISTENT_FIELD_FOR_SOURCES_WARNING = (
+    "WARNING: The persistent field has not been provided for sources."
+    "Assuming all sources are persistent."
+)
+
 
 def read_in_infrastructure_files(virtual_world, in_dir: Path) -> dict[str, DataFrame]:
-    input_dict = {}
+    input_dict: dict[str, DataFrame] = {}
     input_dict["sites"] = file_reader(in_dir / virtual_world["infrastructure"]["sites_file"])
 
     if virtual_world["infrastructure"]["site_type_file"]:
@@ -43,9 +48,13 @@ def read_in_infrastructure_files(virtual_world, in_dir: Path) -> dict[str, DataF
         )
 
     if virtual_world["infrastructure"]["sources_file"]:
-        input_dict["sources"] = file_reader(
-            in_dir / virtual_world["infrastructure"]["sources_file"]
-        )
+        source_df: DataFrame = file_reader(in_dir / virtual_world["infrastructure"]["sources_file"])
+        if ic.Sources_File_Constants.PERSISTENT not in source_df.columns:
+            source_df[ic.Sources_File_Constants.PERSISTENT] = True
+            source_df[ic.Sources_File_Constants.ACTIVE_DUR] = 1
+            source_df[ic.Sources_File_Constants.INACTIVE_DUR] = 0
+            print(NO_PERSISTENT_FIELD_FOR_SOURCES_WARNING)
+        input_dict["sources"] = source_df
 
     return input_dict
 

--- a/LDAR_Sim/src/file_processing/output_processing/output_utils.py
+++ b/LDAR_Sim/src/file_processing/output_processing/output_utils.py
@@ -5,7 +5,7 @@ from numpy import NaN
 class EMIS_DATA_COL_ACCESSORS:
     EMIS_ID = "Emissions ID"
     SITE_ID = "Site ID"
-    EQG = "Equipment Group"
+    EQG = "Equipment"
     STATUS = "Status"
     DAYS_ACT = "Days Active"
     T_VOL_EMIT = '"True" Volume Emitted (Kg Methane)'

--- a/LDAR_Sim/src/virtual_world/equipment.py
+++ b/LDAR_Sim/src/virtual_world/equipment.py
@@ -104,17 +104,17 @@ class Equipment:
 
     def _create_sources(self, infrastructure_inputs, prop_params) -> None:
         if self._equip_type != "Placeholder" and "sources" in infrastructure_inputs:
-            sources_info = infrastructure_inputs["sources"]
-            sources = sources_info.loc[
-                sources_info[Infrastructure_Constants.Sources_File_Constants.EQUIPMENT]
+            sources_info: pd.DataFrame = infrastructure_inputs["sources"]
+            sources: pd.DataFrame = sources_info.loc[
+                sources_info[Infrastructure_Constants.Sources_File_Constants.COMPONENT]
                 == self._equip_type
             ]
-            for source in sources:
+            for idx, source in sources.iterrows():
                 src_prop_params = deepcopy(prop_params)
                 src_id = source[Infrastructure_Constants.Sources_File_Constants.SOURCE]
                 self._sources.append(Source(src_id, source, src_prop_params))
         elif self._equip_type == "Placeholder":
-            src_id = "Placeholder_Non_Rep"
+            src_id = "Placeholder_Rep"
             placeholder_source_info = {
                 Infrastructure_Constants.Sources_File_Constants.REPAIRABLE: True,
                 Infrastructure_Constants.Sources_File_Constants.PERSISTENT: True,

--- a/LDAR_Sim/src/virtual_world/equipment_groups.py
+++ b/LDAR_Sim/src/virtual_world/equipment_groups.py
@@ -84,11 +84,8 @@ class Equipment_Group:
 
     def _create_equipment(self, infrastructure_inputs, prop_params, info) -> None:
         for col, val in info.items():
-            if "equipment" in col.lower():
-                for count in range(0, val):
-                    self._equipment.append(
-                        Equipment(col, count, infrastructure_inputs, prop_params)
-                    )
+            for count in range(0, val):
+                self._equipment.append(Equipment(col, count, infrastructure_inputs, prop_params))
 
     def _set_method_specific_params(self, prop_params):
         self._meth_survey_times = prop_params["Method_Specific_Params"].pop(

--- a/LDAR_Sim/src/virtual_world/infrastructure_const.py
+++ b/LDAR_Sim/src/virtual_world/infrastructure_const.py
@@ -25,7 +25,7 @@ class Infrastructure_Constants:
         LON = "lon"  # Longitude
         ID = "site_ID"  # Site ID
         TYPE = "site_type"  # Site Type
-        EQG = "equipment_groups"  # Equipment Group
+        EQG = "equipment"  # Equipment Group
         REP_EMIS_ERS = "repairable_ERS"  # Repairable Emissions: Emissions Rate Source
         REP_EMIS_EPR = "repairable_EPR"  # Repairable Emissions : Emission Production Rate
         REP_EMIS_RD = "repairable_RD"  # Repairable Emissions : Repair Delay
@@ -58,8 +58,12 @@ class Infrastructure_Constants:
             SURVEY_TIME_PLACEHOLDER,
         ]
 
+        REQUIRED_HEADERS: list[str] = [ID, LAT, LON, TYPE]
+
+        OPTIONAL_SHARED_HEADERS: list[str] = [EQG]
+
     class Equipment_Group_File_Constants:
-        EQUIPMENT_GROUP = "equipment_group"  # Equipment Group
+        EQUIPMENT_GROUP = "equipment"  # Equipment Group
         REP_EMIS_ERS = "repairable_ERS"  # Repairable Emissions Rate Source
         REP_EMIS_EPR = "repairable_EPR"  # Repairable Emissions Production Rate
         REP_EMIS_RD = "repairable_RD"  # Repairable Emissions Repair Delay
@@ -88,7 +92,7 @@ class Infrastructure_Constants:
 
     class Site_Type_File_Constants:
         TYPE = "site_type"  # Site Type
-        EQG = "equipment_group"  # Equipment Group
+        EQG = "equipment"  # Equipment Group
         REP_EMIS_ERS = "repairable_ERS"  # Repairable Emissions: Emissions Rate Source
         REP_EMIS_EPR = "repairable_EPR"  # Repairable Emissions : Emission Production Rate
         REP_EMIS_RD = "repairable_RD"  # Repairable Emissions : Repair Delay

--- a/LDAR_Sim/src/virtual_world/infrastructure_const.py
+++ b/LDAR_Sim/src/virtual_world/infrastructure_const.py
@@ -75,7 +75,7 @@ class Infrastructure_Constants:
         SPATIAL_PLACEHOLDER = "_spatial"  # Spatial coverage - Method specific
 
     class Sources_File_Constants:
-        EQUIPMENT = "equipment"
+        COMPONENT = "component"
         SOURCE = "source"
         EMIS_EPR = "EPR"
         EMIS_ERS = "ERS"  # Emission rate source

--- a/LDAR_Sim/src/virtual_world/sites.py
+++ b/LDAR_Sim/src/virtual_world/sites.py
@@ -126,7 +126,7 @@ class Site:
     ) -> None:
         if isinstance(equipment_groups, str):
             split_eqgs: list[str] = [
-                split2.replace("'", "").strip()
+                split2
                 for split1 in equipment_groups.split(";")
                 for split2 in split1.split(",")
                 if split2 not in [""]

--- a/LDAR_Sim/src/virtual_world/sites.py
+++ b/LDAR_Sim/src/virtual_world/sites.py
@@ -21,6 +21,7 @@
 import copy
 from datetime import date
 import math
+from typing import Union
 
 
 import pandas as pd
@@ -118,10 +119,21 @@ class Site:
         return instance
 
     def _create_equipment_groups(
-        self, equipment_groups: list, infrastructure_inputs, propagating_params
+        self,
+        equipment_groups: Union[list, str, int, float, None],
+        infrastructure_inputs,
+        propagating_params,
     ) -> None:
+        if isinstance(equipment_groups, str):
+            split_eqgs: list[str] = [
+                split2.replace("'", "").strip()
+                for split1 in equipment_groups.split(";")
+                for split2 in split1.split(",")
+                if split2 not in [""]
+            ]
+            equipment_groups = split_eqgs
         if isinstance(equipment_groups, list) and len(equipment_groups) > 0:
-            equip_groups_in: pd.DataFrame = infrastructure_inputs["equipment_groups"]
+            equip_groups_in: pd.DataFrame = infrastructure_inputs["equipment"]
             for equipment_group in equipment_groups:
                 site_equipment_group = equip_groups_in.loc[
                     equip_groups_in[
@@ -137,7 +149,7 @@ class Site:
                         ],
                         infrastructure_inputs,
                         prop_params,
-                        site_equipment_group,
+                        site_equipment_group[1:],
                     )
                 )
         elif isinstance(equipment_groups, (int, float)):
@@ -160,7 +172,7 @@ class Site:
             )
             prop_params = copy.deepcopy(propagating_params)
             self._equipment_groups.append(
-                Equipment_Group(i, infrastructure_inputs, prop_params, equip_group_info)
+                Equipment_Group(0, infrastructure_inputs, prop_params, equip_group_info)
             )
 
     def _set_survey_costs(self, methods: list[str]) -> float:

--- a/LDAR_Sim/src/virtual_world/sources.py
+++ b/LDAR_Sim/src/virtual_world/sources.py
@@ -45,17 +45,21 @@ class Source:
 
     def __init__(self, id: str, info, prop_params) -> None:
         self._source_ID: str = id
-        self._repairable = info[Infrastructure_Constants.Sources_File_Constants.REPAIRABLE]
-        self._persistent = info[Infrastructure_Constants.Sources_File_Constants.PERSISTENT]
-        self._active_duration = info[Infrastructure_Constants.Sources_File_Constants.ACTIVE_DUR]
-        self._inactive_duration = info[Infrastructure_Constants.Sources_File_Constants.INACTIVE_DUR]
+        self._repairable: bool = info[Infrastructure_Constants.Sources_File_Constants.REPAIRABLE]
+        self._persistent: bool = info[Infrastructure_Constants.Sources_File_Constants.PERSISTENT]
+        self._active_duration: int = info[
+            Infrastructure_Constants.Sources_File_Constants.ACTIVE_DUR
+        ]
+        self._inactive_duration: int = info[
+            Infrastructure_Constants.Sources_File_Constants.INACTIVE_DUR
+        ]
         self._generated_emissions: dict[int, list[Emission]] = {}
-        self._emis_rate_source = None
-        self._emis_prod_rate = None
-        self._emis_duration = None
-        self._meth_spat_covs = None
-        self._emis_rep_delay = None
-        self._emis_rep_cost = None
+        self._emis_rate_source: EmissionsSource = None
+        self._emis_prod_rate: float = None
+        self._emis_duration: int = None
+        self._meth_spat_covs: dict[str, float] = None
+        self._emis_rep_delay: int = None
+        self._emis_rep_cost: float = None
         self._update_prop_params(info=info, prop_params=prop_params)
         self._set_source_properties(prop_params=prop_params)
         self._next_emission: Emission = None


### PR DESCRIPTION
# Pull Request Key Information

## Reason for change

There is a reasonable need for users to be able to define equipment
characteristics for site types instead of for sites.

## What was changed

Added the ability to define Equipment in Site Type File and some bugfixes

## Intended Purpose

Allow Equipment to be defined in the Site Type File

## Level of version change required

N/A

## Testing Completed

Manual Testing

## Target Issue

N/A

## Additional Information

N/A
