### PR TITLE
V4 add total measured emissions

### DIFF
--- a/LDAR_Sim/src/file_processing/output_processing/multi_simulation_outputs.py
+++ b/LDAR_Sim/src/file_processing/output_processing/multi_simulation_outputs.py
@@ -44,12 +44,16 @@ class EMIS_SUMMARY_COLUMNS_ACCESSORS:
     PROG_NAME = "Program Name"
     SIM = "Simulation"
     T_TOTAL_EMIS = 'Total "True" Emissions (Kg Methane)'
+    EST_TOTAL_EMIS = 'Total "Estimated" Emissions (Kg Methane)'
     AVG_T_EMIS_RATE = 'Average "True" Emissions Rate (g/s)'
     T_EMIS_RATE_95 = '95th Percentile "True" Emissions Rate (g/s)'
     T_EMIS_RATE_5 = '5th Percentile "True" Emissions Rate (g/s)'
     T_AVG_EMIS_AMOUNT = '"True" Average Emissions Amount (Kg Methane)'
     T_EMIS_AMOUNT_95 = '95th Percentile "True" Emissions Amount (Kg Methane)'
     T_EMIS_AMOUNT_5 = '5th Percentile "True" Emissions Amount (Kg Methane)'
+    EST_AVG_EMIS_AMOUNT = '"Estimated" Average Emissions Amount (Kg Methane)'
+    EST_EMIS_AMOUNT_95 = '95th Percentile "Estimated" Emissions Amount (Kg Methane)'
+    EST_EMIS_AMOUNT_5 = '5th Percentile "Estimated" Emissions Amount (Kg Methane)'
 
 
 TS_SUMMARY_COLUMNS = [
@@ -67,12 +71,16 @@ EMIS_SUMMARY_COLUMNS = [
     EMIS_SUMMARY_COLUMNS_ACCESSORS.PROG_NAME,
     EMIS_SUMMARY_COLUMNS_ACCESSORS.SIM,
     EMIS_SUMMARY_COLUMNS_ACCESSORS.T_TOTAL_EMIS,
+    EMIS_SUMMARY_COLUMNS_ACCESSORS.EST_TOTAL_EMIS,
     EMIS_SUMMARY_COLUMNS_ACCESSORS.AVG_T_EMIS_RATE,
     EMIS_SUMMARY_COLUMNS_ACCESSORS.T_EMIS_RATE_95,
     EMIS_SUMMARY_COLUMNS_ACCESSORS.T_EMIS_RATE_5,
     EMIS_SUMMARY_COLUMNS_ACCESSORS.T_AVG_EMIS_AMOUNT,
     EMIS_SUMMARY_COLUMNS_ACCESSORS.T_EMIS_AMOUNT_95,
     EMIS_SUMMARY_COLUMNS_ACCESSORS.T_EMIS_AMOUNT_5,
+    EMIS_SUMMARY_COLUMNS_ACCESSORS.EST_AVG_EMIS_AMOUNT,
+    EMIS_SUMMARY_COLUMNS_ACCESSORS.EST_EMIS_AMOUNT_95,
+    EMIS_SUMMARY_COLUMNS_ACCESSORS.EST_EMIS_AMOUNT_5,
 ]
 
 
@@ -105,6 +113,7 @@ TS_MAPPING_TO_SUMMARY_COLS = {
 
 EMIS_MAPPING_TO_SUMMARY_COLS = {
     EMIS_SUMMARY_COLUMNS_ACCESSORS.T_TOTAL_EMIS: lambda df: get_sum(df, eca.T_VOL_EMIT),
+    EMIS_SUMMARY_COLUMNS_ACCESSORS.EST_TOTAL_EMIS: lambda df: get_sum(df, eca.EST_VOL_EMIT),
     EMIS_SUMMARY_COLUMNS_ACCESSORS.AVG_T_EMIS_RATE: lambda df: get_mean_val(df, eca.T_RATE),
     EMIS_SUMMARY_COLUMNS_ACCESSORS.T_EMIS_RATE_95: lambda df: get_nth_percentile(
         df, eca.T_RATE, 95
@@ -116,6 +125,15 @@ EMIS_MAPPING_TO_SUMMARY_COLS = {
     ),
     EMIS_SUMMARY_COLUMNS_ACCESSORS.T_EMIS_AMOUNT_5: lambda df: get_nth_percentile(
         df, eca.T_VOL_EMIT, 5
+    ),
+    EMIS_SUMMARY_COLUMNS_ACCESSORS.EST_AVG_EMIS_AMOUNT: lambda df: get_mean_val(
+        df, eca.EST_VOL_EMIT
+    ),
+    EMIS_SUMMARY_COLUMNS_ACCESSORS.EST_EMIS_AMOUNT_95: lambda df: get_nth_percentile(
+        df, eca.EST_VOL_EMIT, 95
+    ),
+    EMIS_SUMMARY_COLUMNS_ACCESSORS.EST_EMIS_AMOUNT_5: lambda df: get_nth_percentile(
+        df, eca.EST_VOL_EMIT, 5
     ),
 }
 

--- a/LDAR_Sim/src/file_processing/output_processing/output_utils.py
+++ b/LDAR_Sim/src/file_processing/output_processing/output_utils.py
@@ -9,6 +9,7 @@ class EMIS_DATA_COL_ACCESSORS:
     STATUS = "Status"
     DAYS_ACT = "Days Active"
     T_VOL_EMIT = '"True" Volume Emitted (Kg Methane)'
+    EST_VOL_EMIT = '"Estimated" Volume Emitted (Kg Methane)'
     T_RATE = '"True" Rate (g/s)'
     M_RATE = '"Measured" Rate (g/s)'
     DATE_BEG = "Date Began"
@@ -30,6 +31,7 @@ EMIS_DATA_FINAL_COL_ORDER = [
     EMIS_DATA_COL_ACCESSORS.DATE_BEG,
     EMIS_DATA_COL_ACCESSORS.DATE_REP,
     EMIS_DATA_COL_ACCESSORS.T_VOL_EMIT,
+    EMIS_DATA_COL_ACCESSORS.EST_VOL_EMIT,
     EMIS_DATA_COL_ACCESSORS.T_RATE,
     EMIS_DATA_COL_ACCESSORS.M_RATE,
     EMIS_DATA_COL_ACCESSORS.INIT_DETECT_BY,

--- a/LDAR_Sim/src/virtual_world/emissions.py
+++ b/LDAR_Sim/src/virtual_world/emissions.py
@@ -36,6 +36,7 @@ class Emission:
         eca.STATUS: "object",
         eca.DAYS_ACT: "int32",
         eca.T_VOL_EMIT: "float64",
+        eca.EST_VOL_EMIT: "float64",
         eca.T_RATE: "float64",
         eca.M_RATE: "float64",
         eca.DATE_BEG: "datetime64",
@@ -103,8 +104,15 @@ class Emission:
     def activate() -> bool:
         return False
 
-    def get_emis_vol(self) -> float:
+    def calc_true_emis_vol(self) -> float:
         return self._active_days * self._rate * GRAMS_PER_SECOND_TO_KG_PER_DAY
+
+    def calc_est_emis_vol(self) -> float:
+        return (
+            self._estimated_days_active
+            * (self._measured_rate if self._measured_rate is not None else 0)
+            * GRAMS_PER_SECOND_TO_KG_PER_DAY
+        )
 
     def update_detection_records(self, company: str, detect_date: date):
         if self._init_detect_by is None:
@@ -134,7 +142,8 @@ class Emission:
         summary_dict.update({(eca.EMIS_ID, self._emissions_id)})
         summary_dict.update({(eca.STATUS, self._status)})
         summary_dict.update({(eca.DAYS_ACT, self._active_days)})
-        summary_dict.update({(eca.T_VOL_EMIT, self.get_emis_vol())})
+        summary_dict.update({(eca.T_VOL_EMIT, self.calc_true_emis_vol())})
+        summary_dict.update({(eca.EST_VOL_EMIT, self.calc_est_emis_vol())})
         summary_dict.update({(eca.T_RATE, self._rate)})
         summary_dict.update({(eca.M_RATE, self._measured_rate)})
         summary_dict.update({(eca.DATE_BEG, self._start_date)})


### PR DESCRIPTION
# Pull Request Key Information

## Reason for change

When trying to understand uncertainty and the different between true
emissions and emissions as observed, "Estimated" total emissions are
key.

## What was changed

Program emissions summary outputs now contain column with "Estimated"
total volume emitted for each emission.

Added Total, Average, 95th and 5th percentile "Estimated" emissions
to the overall emissions summary outputs to match the "True" emissions
values reported.

## Intended Purpose

Add reporting for "Estimated" emissions

## Level of version change required

N/A

## Testing Completed

Manual testing

## Target Issue

N/A

## Additional Information

N/A
