### PR TITLE
<BUG> Account for optional header

### DIFF
--- a/LDAR_Sim/src/virtual_world/sites.py
+++ b/LDAR_Sim/src/virtual_world/sites.py
@@ -38,10 +38,7 @@ from virtual_world.infrastructure_const import (
 )
 
 PLACEHOLDER_EQUIPMENT = "Placeholder_Equipment"
-PLACEHOLDER_EQUIPMENT_COUNT = 10
-BAD_EQUIPMENT_INPUT_ERROR = (
-    "Invalid equipment input... please fix equipment inputs before re-running the simulation"
-)
+BAD_EQUIPMENT_INPUT_ERROR = "Invalid equipment input: {}"
 
 
 class Site:
@@ -157,7 +154,12 @@ class Site:
                 )
         elif isinstance(equipment_groups, (int, float)) and equipment_groups == 0:
             # special case for when equipment group isn't set
-            equip_group_info = pd.Series({PLACEHOLDER_EQUIPMENT: 1})
+            equip_count = math.ceil(
+                propagating_params[Infrastructure_Constants.Sites_File_Constants.REP_EMIS_EPR]
+                * 365
+                * 2
+            )
+            equip_group_info = pd.Series({PLACEHOLDER_EQUIPMENT: equip_count})
             prop_params = copy.deepcopy(propagating_params)
             self._equipment_groups.append(
                 Equipment_Group(
@@ -165,20 +167,21 @@ class Site:
                 )
             )
         elif isinstance(equipment_groups, (int, float)) and equipment_groups > 0:
+            equip_count = math.ceil(
+                propagating_params[Infrastructure_Constants.Sites_File_Constants.REP_EMIS_EPR]
+                * 365
+                * 2
+            )
             for i in range(0, int(equipment_groups)):
                 equip_group_info = pd.Series(
-                    {
-                        PLACEHOLDER_EQUIPMENT: math.ceil(
-                            PLACEHOLDER_EQUIPMENT_COUNT / equipment_groups
-                        )
-                    }
+                    {PLACEHOLDER_EQUIPMENT: math.ceil(equip_count / equipment_groups)}
                 )
                 prop_params = copy.deepcopy(propagating_params)
                 self._equipment_groups.append(
                     Equipment_Group(i, infrastructure_inputs, prop_params, equip_group_info)
                 )
         else:
-            print(BAD_EQUIPMENT_INPUT_ERROR)
+            print(BAD_EQUIPMENT_INPUT_ERROR.format(equipment_groups))
             sys.exit()
 
     def _set_survey_costs(self, methods: list[str]) -> float:

--- a/LDAR_Sim/src/virtual_world/sites.py
+++ b/LDAR_Sim/src/virtual_world/sites.py
@@ -22,7 +22,7 @@ import copy
 from datetime import date
 import math
 from typing import Union
-
+import sys
 
 import pandas as pd
 from file_processing.output_processing.output_utils import EmisRepairInfo, TsEmisData
@@ -39,6 +39,9 @@ from virtual_world.infrastructure_const import (
 
 PLACEHOLDER_EQUIPMENT = "Placeholder_Equipment"
 PLACEHOLDER_EQUIPMENT_COUNT = 10
+BAD_EQUIPMENT_INPUT_ERROR = (
+    "Invalid equipment input... please fix equipment inputs before re-running the simulation"
+)
 
 
 class Site:
@@ -152,7 +155,7 @@ class Site:
                         site_equipment_group[1:],
                     )
                 )
-        elif equipment_groups == 0:
+        elif isinstance(equipment_groups, (int, float)) and equipment_groups == 0:
             # special case for when equipment group isn't set
             equip_group_info = pd.Series({PLACEHOLDER_EQUIPMENT: 1})
             prop_params = copy.deepcopy(propagating_params)
@@ -161,7 +164,7 @@ class Site:
                     equipment_groups, infrastructure_inputs, prop_params, equip_group_info
                 )
             )
-        elif isinstance(equipment_groups, (int, float)):
+        elif isinstance(equipment_groups, (int, float)) and equipment_groups > 0:
             for i in range(0, int(equipment_groups)):
                 equip_group_info = pd.Series(
                     {
@@ -175,14 +178,8 @@ class Site:
                     Equipment_Group(i, infrastructure_inputs, prop_params, equip_group_info)
                 )
         else:
-            # REVIEW: Should this be an elif and have an else that does error handling for bad input
-            equip_group_info = pd.Series(
-                {PLACEHOLDER_EQUIPMENT: math.ceil(PLACEHOLDER_EQUIPMENT_COUNT)}
-            )
-            prop_params = copy.deepcopy(propagating_params)
-            self._equipment_groups.append(
-                Equipment_Group(0, infrastructure_inputs, prop_params, equip_group_info)
-            )
+            print(BAD_EQUIPMENT_INPUT_ERROR)
+            sys.exit()
 
     def _set_survey_costs(self, methods: list[str]) -> float:
         for method in methods:

--- a/LDAR_Sim/src/virtual_world/sites.py
+++ b/LDAR_Sim/src/virtual_world/sites.py
@@ -152,6 +152,15 @@ class Site:
                         site_equipment_group[1:],
                     )
                 )
+        elif equipment_groups == 0:
+            # special case for when equipment group isn't set
+            equip_group_info = pd.Series({PLACEHOLDER_EQUIPMENT: 1})
+            prop_params = copy.deepcopy(propagating_params)
+            self._equipment_groups.append(
+                Equipment_Group(
+                    equipment_groups, infrastructure_inputs, prop_params, equip_group_info
+                )
+            )
         elif isinstance(equipment_groups, (int, float)):
             for i in range(0, int(equipment_groups)):
                 equip_group_info = pd.Series(

--- a/LDAR_Sim/testing/unit_testing/test_virtual_world/test_sites/sites_testing_fixtures.py
+++ b/LDAR_Sim/testing/unit_testing/test_virtual_world/test_sites/sites_testing_fixtures.py
@@ -1,8 +1,8 @@
 import pytest
 from typing import Tuple
 
-from virtual_world.infrastructure_const import Infrastructure_Constants
-from virtual_world.sites import Site
+from src.virtual_world.infrastructure_const import Infrastructure_Constants
+from src.virtual_world.sites import Site
 from datetime import date
 
 
@@ -11,13 +11,15 @@ def mock_values_for_simple_site_construction_fix() -> Tuple[str, float, float, i
     id: str = "test"
     lat: float = 34.56
     lon: float = -44.56
+    method: list[str] = []
+    start_date: date = date(2023, 1, 1)
     equipment_groups: int = 1
     prop_params: dict = {
         Infrastructure_Constants.Sites_File_Constants.REP_EMIS_ERS: None,
         Infrastructure_Constants.Sites_File_Constants.REP_EMIS_EPR: 1,
         Infrastructure_Constants.Sites_File_Constants.REP_EMIS_ED: 1,
-        Infrastructure_Constants.Sites_File_Constants.REP_EMIS_RD: 0,
-        Infrastructure_Constants.Sites_File_Constants.REP_EMIS_RC: 100,
+        Infrastructure_Constants.Sites_File_Constants.REP_EMIS_RD: {"vals": 0},
+        Infrastructure_Constants.Sites_File_Constants.REP_EMIS_RC: {"vals": 100},
         "Method_Specific_Params": {
             Infrastructure_Constants.Sites_File_Constants.SURVEY_FREQUENCY_PLACEHOLDER: {},
             Infrastructure_Constants.Sites_File_Constants.SPATIAL_PLACEHOLDER: {},
@@ -29,7 +31,7 @@ def mock_values_for_simple_site_construction_fix() -> Tuple[str, float, float, i
         },
     }
     infra_inputs: dict = {}
-    return (id, lat, lon, equipment_groups, prop_params, infra_inputs)
+    return (id, lat, lon, start_date, equipment_groups, prop_params, infra_inputs, method)
 
 
 @pytest.fixture(name="mock_site_for_simple_generate_emissions")
@@ -42,8 +44,8 @@ def mock_site_for_simple_generate_emissions_fix() -> Tuple[Site, date, date]:
         Infrastructure_Constants.Sites_File_Constants.REP_EMIS_ERS: None,
         Infrastructure_Constants.Sites_File_Constants.REP_EMIS_EPR: 1,
         Infrastructure_Constants.Sites_File_Constants.REP_EMIS_ED: 1,
-        Infrastructure_Constants.Sites_File_Constants.REP_EMIS_RD: 0,
-        Infrastructure_Constants.Sites_File_Constants.REP_EMIS_RC: 100,
+        Infrastructure_Constants.Sites_File_Constants.REP_EMIS_RD: {"vals": 0},
+        Infrastructure_Constants.Sites_File_Constants.REP_EMIS_RC: {"vals": 100},
         "Method_Specific_Params": {
             Infrastructure_Constants.Sites_File_Constants.SURVEY_FREQUENCY_PLACEHOLDER: {},
             Infrastructure_Constants.Sites_File_Constants.SPATIAL_PLACEHOLDER: {},
@@ -74,12 +76,13 @@ def mock_site_for_simple_activate_emissions_fix() -> Tuple[Site, date, int]:
     lat: float = 34.56
     lon: float = -44.56
     equipment_groups: int = 1
+    method: list[str] = []
     prop_params: dict = {
         Infrastructure_Constants.Sites_File_Constants.REP_EMIS_ERS: None,
         Infrastructure_Constants.Sites_File_Constants.REP_EMIS_EPR: 1,
         Infrastructure_Constants.Sites_File_Constants.REP_EMIS_ED: 1,
-        Infrastructure_Constants.Sites_File_Constants.REP_EMIS_RD: 0,
-        Infrastructure_Constants.Sites_File_Constants.REP_EMIS_RC: 100,
+        Infrastructure_Constants.Sites_File_Constants.REP_EMIS_RD: {"vals": 0},
+        Infrastructure_Constants.Sites_File_Constants.REP_EMIS_RC: {"vals": 100},
         "Method_Specific_Params": {
             Infrastructure_Constants.Sites_File_Constants.SURVEY_FREQUENCY_PLACEHOLDER: {},
             Infrastructure_Constants.Sites_File_Constants.SPATIAL_PLACEHOLDER: {},
@@ -91,6 +94,8 @@ def mock_site_for_simple_activate_emissions_fix() -> Tuple[Site, date, int]:
         },
     }
     infra_inputs: dict = {}
+    simulation_start_date: date = date(*[2017, 1, 1])
+    simulation_end_date: date = date(*[2017, 1, 5])
     test_site = Site(
         id=id,
         lat=lat,
@@ -98,9 +103,9 @@ def mock_site_for_simple_activate_emissions_fix() -> Tuple[Site, date, int]:
         equipment_groups=equipment_groups,
         propagating_params=prop_params,
         infrastructure_inputs=infra_inputs,
+        methods=method,
+        start_date=simulation_start_date,
     )
-    simulation_start_date: date = date(*[2017, 1, 1])
-    simulation_end_date: date = date(*[2017, 1, 5])
     test_site.generate_emissions(
         sim_start_date=simulation_start_date, sim_end_date=simulation_end_date, sim_number=1
     )
@@ -118,8 +123,8 @@ def mock_site_for_simple_get_detectable_emissions_fix() -> Tuple[Site, str]:
         Infrastructure_Constants.Sites_File_Constants.REP_EMIS_ERS: None,
         Infrastructure_Constants.Sites_File_Constants.REP_EMIS_EPR: 1,
         Infrastructure_Constants.Sites_File_Constants.REP_EMIS_ED: 1,
-        Infrastructure_Constants.Sites_File_Constants.REP_EMIS_RD: 0,
-        Infrastructure_Constants.Sites_File_Constants.REP_EMIS_RC: 100,
+        Infrastructure_Constants.Sites_File_Constants.REP_EMIS_RD: {"vals": 0},
+        Infrastructure_Constants.Sites_File_Constants.REP_EMIS_RC: {"vals": 100},
         "Method_Specific_Params": {
             Infrastructure_Constants.Sites_File_Constants.SURVEY_FREQUENCY_PLACEHOLDER: {},
             Infrastructure_Constants.Sites_File_Constants.DEPLOYMENT_MONTHS_PLACEHOLDER: {},
@@ -130,7 +135,10 @@ def mock_site_for_simple_get_detectable_emissions_fix() -> Tuple[Site, str]:
             Infrastructure_Constants.Equipment_Group_File_Constants.SURVEY_COST_PLACEHOLDER: {},
         },
     }
+    simulation_start_date: date = date(*[2017, 1, 1])
+    simulation_end_date: date = date(*[2017, 1, 5])
     infra_inputs: dict = {}
+    method = []
     test_site = Site(
         id=id,
         lat=lat,
@@ -138,10 +146,10 @@ def mock_site_for_simple_get_detectable_emissions_fix() -> Tuple[Site, str]:
         equipment_groups=equipment_groups,
         propagating_params=prop_params,
         infrastructure_inputs=infra_inputs,
+        start_date=simulation_start_date,
+        methods=method,
     )
     test_method: str = "test"
-    simulation_start_date: date = date(*[2017, 1, 1])
-    simulation_end_date: date = date(*[2017, 1, 5])
     test_site.generate_emissions(
         sim_start_date=simulation_start_date, sim_end_date=simulation_end_date, sim_number=1
     )

--- a/LDAR_Sim/testing/unit_testing/test_virtual_world/test_sites/test_activate_emissions.py
+++ b/LDAR_Sim/testing/unit_testing/test_virtual_world/test_sites/test_activate_emissions.py
@@ -1,6 +1,6 @@
 from datetime import date
 from typing import Tuple
-from virtual_world.sites import Site
+from src.virtual_world.sites import Site
 from testing.unit_testing.test_virtual_world.test_sites.sites_testing_fixtures import (  # noqa
     mock_site_for_simple_activate_emissions_fix,
 )

--- a/LDAR_Sim/testing/unit_testing/test_virtual_world/test_sites/test_sites_constructor.py
+++ b/LDAR_Sim/testing/unit_testing/test_virtual_world/test_sites/test_sites_constructor.py
@@ -1,5 +1,5 @@
 from typing import Tuple
-from virtual_world.sites import Site
+from src.virtual_world.sites import Site
 from testing.unit_testing.test_virtual_world.test_sites.sites_testing_fixtures import (  # noqa
     mock_values_for_simple_site_construction_fix,
 )
@@ -8,13 +8,17 @@ from testing.unit_testing.test_virtual_world.test_sites.sites_testing_fixtures i
 def test_000_simple_site_is_properly_constructed(
     mock_values_for_simple_site_construction: Tuple[str, float, float, int, dict, dict]
 ):
-    id, lat, lon, equip_groups, prop_params, site_info = mock_values_for_simple_site_construction
+    id, lat, lon, start_date, equip_groups, prop_params, site_info, method = (
+        mock_values_for_simple_site_construction
+    )
     test_site = Site(
         id=id,
         lat=lat,
         long=lon,
+        start_date=start_date,
         equipment_groups=equip_groups,
         propagating_params=prop_params,
         infrastructure_inputs=site_info,
+        methods=method,
     )
     assert isinstance(test_site, Site)


### PR DESCRIPTION
# Pull Request Key Information

## Reason for change

No equipment is generated if equipment has not been set at all.

## What was changed

Generate equipment if the user does not specify the equipment

## Intended Purpose

Account for the special case when equipment is not set by the user

## Testing Completed

Manually looked through files after simulating with no equipment column. 

## Additional Information

Bug encountered while trying E2E testing the addition of non-repairable emissions.
