### PR TITLE
Add non-repairable emissions functionality

### DIFF
--- a/LDAR_Sim/src/default_parameters/virtual_world_default.yml
+++ b/LDAR_Sim/src/default_parameters/virtual_world_default.yml
@@ -19,13 +19,12 @@ repairs:
     vals: [14.0] # Can either be a single number, a list of numbers (for example [1,2,3]) 
     # or the name of a column in the repair delays file to sample from
 emissions:
-  consider_venting: False # True/False
-  emissions_file: "_placeholder_str_" #File containing sample emissions rates or emissions distributions.
+  emissions_file: "_placeholder_str_" # File containing sample emissions rates or emissions distributions.
   ERS: "_placeholder_str_" # The name of a column in the emissions file
-  non_rep_ERS: "_placeholder_str_" # The name of a column in the emissions file
-  LPR: 0.0065
-  max_leak_rate: 100000.0
+  LPR: "_placeholder_float_" # The production rate of repairable emissions
+  NR_ERS: "_placeholder_str_" # The name of a column in the emissions file
+  NR_EPR: "_placeholder_float_" # The production rate of non-repairable emissions
+  max_leak_rate: 100000.0 # Maximum emission rate
   units: ["kilogram", "hour"]
-NRd: 365
-n_init_leaks_prob: "_placeholder_float_"
-n_init_days: "_placeholder_int_"
+  NRd: 365 # Natural repair delay of repairable emissions
+  duration: 365 # Duration of non-repairable emissions

--- a/LDAR_Sim/src/default_parameters/virtual_world_default.yml
+++ b/LDAR_Sim/src/default_parameters/virtual_world_default.yml
@@ -2,11 +2,11 @@ version: "4.0"
 parameter_level: "virtual_world"
 start_date: [2023, 1, 1]
 end_date: [2027, 12, 31]
-weather_file: "weather_alberta.nc"
+weather_file: "_placeholder_str_"
 consider_weather: False # True/False
 infrastructure:
   site_type_file: "_placeholder_str_" # Infrastructure file defining site types
-  sites_file: "facilities_alberta.csv" #Infrastructure file defining sites
+  sites_file: "_placeholder_str_" #Infrastructure file defining sites
   equipment_group_file: "_placeholder_str_" #Infrastructure file defining equipment groups at sites
   sources_file: "_placeholder_str_" #Infrastructure file defining emissions sources at equipment
 site_samples: 500

--- a/LDAR_Sim/src/file_processing/output_processing/output_utils.py
+++ b/LDAR_Sim/src/file_processing/output_processing/output_utils.py
@@ -18,14 +18,16 @@ class EMIS_DATA_COL_ACCESSORS:
     INIT_DETECT_DATE = "Initially Detected Date"
     TAGGED = "Tagged"
     TAGGED_BY = "Tagged By"
-    EQUIP = "Equipment"
+    COMP = "Component"
+    RECORDED = "Recorded"
+    RECORDED_BY = "Recorded By"
 
 
 EMIS_DATA_FINAL_COL_ORDER = [
     EMIS_DATA_COL_ACCESSORS.EMIS_ID,
     EMIS_DATA_COL_ACCESSORS.SITE_ID,
     EMIS_DATA_COL_ACCESSORS.EQG,
-    EMIS_DATA_COL_ACCESSORS.EQUIP,
+    EMIS_DATA_COL_ACCESSORS.COMP,
     EMIS_DATA_COL_ACCESSORS.STATUS,
     EMIS_DATA_COL_ACCESSORS.DAYS_ACT,
     EMIS_DATA_COL_ACCESSORS.DATE_BEG,
@@ -38,6 +40,8 @@ EMIS_DATA_FINAL_COL_ORDER = [
     EMIS_DATA_COL_ACCESSORS.INIT_DETECT_DATE,
     EMIS_DATA_COL_ACCESSORS.TAGGED,
     EMIS_DATA_COL_ACCESSORS.TAGGED_BY,
+    EMIS_DATA_COL_ACCESSORS.RECORDED,
+    EMIS_DATA_COL_ACCESSORS.RECORDED_BY,
 ]
 
 TIMESERIES_COLUMNS = [
@@ -121,8 +125,9 @@ class CrewDeploymentStats:
 
 
 @dataclass
-class EmisRepairInfo:
+class EmisInfo:
     leaks_repaired: int = 0
     leaks_nat_repaired: int = 0
     repair_cost: int = 0
     nat_repair_cost: int = 0
+    emis_expired: int = 0

--- a/LDAR_Sim/src/ldar_sim.py
+++ b/LDAR_Sim/src/ldar_sim.py
@@ -34,7 +34,7 @@ from file_processing.output_processing.output_utils import (
     EMIS_DATA_FINAL_COL_ORDER,
     TIMESERIES_COLUMNS,
     TIMESERIES_COL_ACCESSORS as tca,
-    EmisRepairInfo,
+    EmisInfo,
     TsEmisData,
     TsMethodData,
 )
@@ -89,7 +89,7 @@ class LdarSim:
             )
             total_emissions_count += new_row[tca.NEW_LEAKS]
             ts_methods_info: list[TsMethodData] = self._program.do_daily_program_deployment()
-            ts_emis_rep_info: EmisRepairInfo = EmisRepairInfo()
+            ts_emis_rep_info: EmisInfo = EmisInfo()
             ts_emis_info: TsEmisData = self._infrastructure.update_emissions_state(ts_emis_rep_info)
             self._update_ts_row_w_emis_info(
                 new_row=new_row, ts_emis_info=ts_emis_info, ts_emis_rep_info=ts_emis_rep_info
@@ -138,7 +138,7 @@ class LdarSim:
         return new_ts_row
 
     def _update_ts_row_w_emis_info(
-        self, new_row: dict[str, Any], ts_emis_info: TsEmisData, ts_emis_rep_info: EmisRepairInfo
+        self, new_row: dict[str, Any], ts_emis_info: TsEmisData, ts_emis_rep_info: EmisInfo
     ):
         new_row[tca.EMIS] = ts_emis_info.daily_emis
         new_row[tca.ACT_LEAKS] = ts_emis_info.active_leaks

--- a/LDAR_Sim/src/virtual_world/emissions.py
+++ b/LDAR_Sim/src/virtual_world/emissions.py
@@ -23,7 +23,7 @@ from typing import Any
 
 from numpy.random import binomial
 from file_processing.output_processing.output_utils import (
-    EmisRepairInfo,
+    EmisInfo,
     EMIS_DATA_COL_ACCESSORS as eca,
 )
 
@@ -84,7 +84,7 @@ class Emission:
         emission.__setstate__(state)
         return emission
 
-    def update(self, emis_rep_info: EmisRepairInfo) -> bool:
+    def update(self, emis_rep_info: EmisInfo) -> bool:
         """
         Increments duration values
         """
@@ -151,16 +151,7 @@ class Emission:
         summary_dict.update({(eca.INIT_DETECT_DATE, self._init_detect_date)})
         summary_dict.update({(eca.TAGGED, "N/A")})
         summary_dict.update({(eca.TAGGED_BY, "N/A")})
+        summary_dict.update({(eca.RECORDED, "N/A")})
+        summary_dict.update({(eca.RECORDED_BY, "N/A")})
         summary_dict.update(self._tech_spat_covs)
         return summary_dict
-
-
-class NonRepairableEmission(Emission):
-    def __init__(self, emission_n, source_id, rate, start_date, simulation_sd, repairable):
-        super().__init__(
-            emission_n,
-            rate,
-            start_date,
-            simulation_sd,
-            repairable,
-        )

--- a/LDAR_Sim/src/virtual_world/equipment_groups.py
+++ b/LDAR_Sim/src/virtual_world/equipment_groups.py
@@ -22,7 +22,7 @@ from datetime import date
 
 import pandas as pd
 from file_processing.output_processing.output_utils import (
-    EmisRepairInfo,
+    EmisInfo,
     TsEmisData,
 )
 from file_processing.input_processing.emissions_source_processing import (
@@ -131,7 +131,7 @@ class Equipment_Group:
             new_emissions += equipment.activate_emissions(date, sim_number)
         return new_emissions
 
-    def update_emissions_state(self, emis_rep_info: EmisRepairInfo) -> TsEmisData:
+    def update_emissions_state(self, emis_rep_info: EmisInfo) -> TsEmisData:
         emis_data = TsEmisData()
         for equip in self._equipment:
             emis_data += equip.update_emissions_state(emis_rep_info)

--- a/LDAR_Sim/src/virtual_world/fugitive_emission.py
+++ b/LDAR_Sim/src/virtual_world/fugitive_emission.py
@@ -23,7 +23,7 @@ from math import ceil
 from numpy import random
 from typing import Any
 from typing_extensions import override
-from file_processing.output_processing.output_utils import EmisRepairInfo
+from file_processing.output_processing.output_utils import EmisInfo, EMIS_DATA_COL_ACCESSORS as eca
 
 from virtual_world.emissions import Emission
 
@@ -74,7 +74,7 @@ class FugitiveEmission(Emission):
         instance.__setstate__(state)
         return instance
 
-    def check_if_repaired(self, emis_rep_info: EmisRepairInfo) -> bool:
+    def check_if_repaired(self, emis_rep_info: EmisInfo) -> bool:
         """
         Checks the days since tagged against the repair delay
         Repairs the emission if possible
@@ -90,9 +90,6 @@ class FugitiveEmission(Emission):
                 return True
         return False
 
-    def get_init_detect_company(self):
-        return self._init_detect_by
-
     def tagged_today(self) -> bool:
         return (
             self._tagged and (self._days_since_tagged == 0)
@@ -107,7 +104,7 @@ class FugitiveEmission(Emission):
     def get_daily_emissions(self) -> float:
         return self._rate * 86.4
 
-    def natural_repair(self, emis_rep_info: EmisRepairInfo):
+    def natural_repair(self, emis_rep_info: EmisInfo):
         self._tagged = True
         self._tagged_by_company = "natural"
         self._status = "repaired"
@@ -160,7 +157,7 @@ class FugitiveEmission(Emission):
         return True
 
     @override
-    def update(self, emis_rep_info: EmisRepairInfo) -> bool:
+    def update(self, emis_rep_info: EmisInfo) -> bool:
         is_active: bool = super().update(emis_rep_info)
         if is_active:
             if self._tagged:
@@ -175,9 +172,9 @@ class FugitiveEmission(Emission):
     @override
     def get_summary_dict(self) -> dict[str, Any]:
         summary_dict: dict[str, Any] = super().get_summary_dict()
-        summary_dict.update({("Date Repaired", self._repair_date)})
-        summary_dict.update({("Tagged", self._tagged)})
-        summary_dict.update({("Tagged By", self._tagged_by_company)})
+        summary_dict.update({(eca.DATE_REP, self._repair_date)})
+        summary_dict.update({(eca.TAGGED, self._tagged)})
+        summary_dict.update({(eca.TAGGED_BY, self._tagged_by_company)})
         return summary_dict
 
     @override

--- a/LDAR_Sim/src/virtual_world/infrastructure.py
+++ b/LDAR_Sim/src/virtual_world/infrastructure.py
@@ -30,8 +30,8 @@ from file_processing.input_processing.repair_delay_processing import (
     read_in_repair_delay_sources_file,
 )
 from virtual_world.infrastructure_const import (
-    Infrastructure_Constants,
-    Virtual_World_To_Prop_Params_Mapping,
+    Infrastructure_Constants as IC,
+    Virtual_World_To_Prop_Params_Mapping as VW,
 )
 from virtual_world.sites import Site
 from file_processing.input_processing.infrastructure_processing import (
@@ -73,19 +73,18 @@ class Infrastructure:
         for (
             param,
             mapping,
-        ) in Virtual_World_To_Prop_Params_Mapping.PROPAGATING_PARAMS.items():
+        ) in VW.PROPAGATING_PARAMS.items():
             mapping: str
             access_path = mapping.split(".")
             val = virtual_world
             for path in access_path:
                 val = val[path]
             prop_params_dict[param] = val
-
         prop_params_dict["Method_Specific_Params"] = {}
         for (
             param,
             mapping,
-        ) in Virtual_World_To_Prop_Params_Mapping.METH_SPEC_PROP_PARAMS.items():
+        ) in VW.METH_SPEC_PROP_PARAMS.items():
             prop_params_dict["Method_Specific_Params"][param] = {}
             for method in methods:
                 access_path: list[str] = mapping.split(".")
@@ -94,7 +93,6 @@ class Infrastructure:
                 for path in access_path:
                     val = val[path]
                 prop_params_dict["Method_Specific_Params"][param][method] = val
-
         return prop_params_dict
 
     def update_propagating_params(
@@ -106,28 +104,26 @@ class Infrastructure:
     ) -> None:
         if site_type_info is not None:
             # Updating propagating parameters with site type info
-            for param in Infrastructure_Constants.Site_Type_File_Constants.PROPAGATING_PARAMS:
+            for param in IC.Site_Type_File_Constants.PROPAGATING_PARAMS:
                 site_type_val = site_type_info.get(param, None)
                 if site_type_val is not None:
                     prop_params[param] = site_type_val
 
             for method in methods:
-                for (
-                    param
-                ) in Infrastructure_Constants.Site_Type_File_Constants.METH_SPEC_PROP_PARAMS:
+                for param in IC.Site_Type_File_Constants.METH_SPEC_PROP_PARAMS:
                     site_type_val = site_type_info.get(method + param, None)
                     if site_type_val is not None:
                         prop_params["Method_Specific_Params"][param][method] = site_type_val
 
             # Updating propagating parameters with site info
-            for param in Infrastructure_Constants.Sites_File_Constants.PROPAGATING_PARAMS:
+            for param in IC.Sites_File_Constants.PROPAGATING_PARAMS:
                 site_val = site_row_df_info.get(param, None)
                 if site_val is not None:
                     prop_params[param] = site_val
 
             # Update method specific propagating params with site info
             for method in methods:
-                for param in Infrastructure_Constants.Sites_File_Constants.METH_SPEC_PROP_PARAMS:
+                for param in IC.Sites_File_Constants.METH_SPEC_PROP_PARAMS:
                     site_val = site_row_df_info.get(method + param, None)
                     if site_val is not None:
                         prop_params["Method_Specific_Params"][param][method] = site_val
@@ -203,7 +199,7 @@ class Infrastructure:
 
         sites: list[Site] = []
 
-        for header in Infrastructure_Constants.Sites_File_Constants.OPTIONAL_SHARED_HEADERS:
+        for header in IC.Sites_File_Constants.OPTIONAL_SHARED_HEADERS:
             if (
                 header not in sites_to_make.columns.to_list()
                 and sites_types_provided
@@ -220,10 +216,9 @@ class Infrastructure:
             site_type_info = None
             if sites_types_provided:
                 site_types_info = infrastructure_inputs["site_types"]
-                site_type = srow[Infrastructure_Constants.Sites_File_Constants.TYPE]
+                site_type = srow[IC.Sites_File_Constants.TYPE]
                 site_types_info = site_types_info.loc[
-                    site_types_info[Infrastructure_Constants.Site_Type_File_Constants.TYPE]
-                    == site_type
+                    site_types_info[IC.Site_Type_File_Constants.TYPE] == site_type
                 ].iloc[0]
             propagating_params = self.generate_propagating_params(
                 virtual_world=virtual_world, methods=methods
@@ -235,10 +230,10 @@ class Infrastructure:
                 methods=methods,
             )
             new_site = Site(
-                id=srow[Infrastructure_Constants.Sites_File_Constants.ID],
-                lat=srow[Infrastructure_Constants.Sites_File_Constants.LAT],
-                long=srow[Infrastructure_Constants.Sites_File_Constants.LON],
-                equipment_groups=srow[Infrastructure_Constants.Sites_File_Constants.EQG],
+                id=srow[IC.Sites_File_Constants.ID],
+                lat=srow[IC.Sites_File_Constants.LAT],
+                long=srow[IC.Sites_File_Constants.LON],
+                equipment_groups=srow[IC.Sites_File_Constants.EQG],
                 propagating_params=propagating_params,
                 infrastructure_inputs=infrastructure_inputs,
                 start_date=date(*virtual_world["start_date"]),

--- a/LDAR_Sim/src/virtual_world/infrastructure.py
+++ b/LDAR_Sim/src/virtual_world/infrastructure.py
@@ -21,7 +21,7 @@ along with this program.  If not, see <https://opensource.org/licenses/MIT>.
 from datetime import date
 import numpy as np
 import pandas as pd
-from file_processing.output_processing.output_utils import EmisRepairInfo, TsEmisData
+from file_processing.output_processing.output_utils import EmisInfo, TsEmisData
 from file_processing.input_processing.emissions_source_processing import (
     EmissionsSource,
     process_emission_sources,
@@ -165,7 +165,7 @@ class Infrastructure:
             new_emissions += site.activate_emissions(date, sim_number)
         return new_emissions
 
-    def update_emissions_state(self, emis_rep_info: EmisRepairInfo) -> TsEmisData:
+    def update_emissions_state(self, emis_rep_info: EmisInfo) -> TsEmisData:
         emis_data = TsEmisData()
         for site in self._sites:
             emis_data += site.update_emissions_state(emis_rep_info)

--- a/LDAR_Sim/src/virtual_world/infrastructure_const.py
+++ b/LDAR_Sim/src/virtual_world/infrastructure_const.py
@@ -32,6 +32,10 @@ class Infrastructure_Constants:
         REP_EMIS_RC = "repairable_RC"  # Repairable Emissions : Repair Cost
         REP_EMIS_ED = "repairable_ED"  # Repairable Emissions : Emissions Duration
         NON_REP_EMIS_ERS = "non_repairable_ERS"  # Non-Repairable Emissions: Emissions Rate Source
+        NON_REP_EMIS_EPR = (
+            "non_repairable_EPR"  # Non-Repairable Emissions: Emissions Production Rate
+        )
+        NON_REP_EMIS_ED = "non_repairable_ED"  # Non-Repairable Emissions: Emissions Duration
         SURVEY_FREQUENCY_PLACEHOLDER = "_surveyfreq"  # Survey Frequency - Method specific
         DEPLOYMENT_YEARS_PLACEHOLDER = "_deploy_year"  # Deployment Year - Method specific
         DEPLOYMENT_MONTHS_PLACEHOLDER = "_deploy_month"  # Deployment Month - Method specific
@@ -49,6 +53,8 @@ class Infrastructure_Constants:
             REP_EMIS_RC,
             REP_EMIS_ED,
             NON_REP_EMIS_ERS,
+            NON_REP_EMIS_EPR,
+            NON_REP_EMIS_ED,
         ]
 
         METH_SPEC_PROP_PARAMS: list[str] = [
@@ -70,6 +76,8 @@ class Infrastructure_Constants:
         REP_EMIS_RC = "repairable_RC"  # Repairable Emissions Repair Cost
         REP_EMIS_ED = "repairable_ED"  # Repairable Emissions Emissions Duration
         NON_REP_EMIS_ERS = "non_repairable_ERS"  # Non-Repairable Emissions Rate Source
+        NON_REP_EMIS_EPR = "non_repairable_EPR"  # Non-Repairable Emissions Production Rate
+        NON_REP_EMIS_ED = "non_repairable_ED"  # Non-Repairable Emissions: Emissions Duration
         SURVEY_TIME_PLACEHOLDER = "_surveytime"  # Survey Time - Method specific
         SURVEY_COST_PLACEHOLDER = "_surveycost"  # Survey Cost - Method specific
         SPATIAL_PLACEHOLDER = "_spatial"  # Spatial coverage - Method specific
@@ -99,6 +107,10 @@ class Infrastructure_Constants:
         REP_EMIS_RC = "repairable_RC"  # Repairable Emissions : Repair Cost
         REP_EMIS_ED = "repairable_ED"  # Repairable Emissions : Emissions Duration
         NON_REP_EMIS_ERS = "non_repairable_ERS"  # Non-Repairable Emissions: Emissions Rate Source
+        NON_REP_EMIS_EPR = (
+            "non_repairable_EPR"  # Non-Repairable Emissions: Emissions Production Rate
+        )
+        NON_REP_EMIS_ED = "non_repairable_ED"  # Non-Repairable Emissions: Emissions Duration
         SURVEY_FREQUENCY_PLACEHOLDER = "_surveyfreq"  # Survey Frequency - Method specific
         SPATIAL_PLACEHOLDER = "_spatial"  # Spatial coverage - Method specific
         SURVEY_TIME_PLACEHOLDER = "_surveytime"  # Survey Time - Method specific
@@ -116,6 +128,8 @@ class Infrastructure_Constants:
             REP_EMIS_RC,
             REP_EMIS_ED,
             NON_REP_EMIS_ERS,
+            NON_REP_EMIS_EPR,
+            NON_REP_EMIS_ED,
         ]
 
         METH_SPEC_PROP_PARAMS: list[str] = [
@@ -134,8 +148,10 @@ class Virtual_World_To_Prop_Params_Mapping:
         Infrastructure_Constants.Sites_File_Constants.REP_EMIS_EPR: "emissions.LPR",
         Infrastructure_Constants.Sites_File_Constants.REP_EMIS_RD: "repairs.delay",
         Infrastructure_Constants.Sites_File_Constants.REP_EMIS_RC: "repairs.cost",
-        Infrastructure_Constants.Sites_File_Constants.REP_EMIS_ED: "NRd",
-        Infrastructure_Constants.Sites_File_Constants.NON_REP_EMIS_ERS: "emissions.non_rep_ERS",
+        Infrastructure_Constants.Sites_File_Constants.REP_EMIS_ED: "emissions.NRd",
+        Infrastructure_Constants.Sites_File_Constants.NON_REP_EMIS_ERS: "emissions.NR_ERS",
+        Infrastructure_Constants.Sites_File_Constants.NON_REP_EMIS_EPR: "emissions.NR_EPR",
+        Infrastructure_Constants.Sites_File_Constants.NON_REP_EMIS_ED: "emissions.duration",
     }
 
     METH_SPEC_PROP_PARAMS: dict[str, str] = {

--- a/LDAR_Sim/src/virtual_world/nonfugitive_emissions.py
+++ b/LDAR_Sim/src/virtual_world/nonfugitive_emissions.py
@@ -1,0 +1,145 @@
+"""
+------------------------------------------------------------------------------
+Program:     The LDAR Simulator (LDAR-Sim)
+File:        nonfugitive_emissions
+Purpose: The nonfugitive emissions module.
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the MIT License as published
+by the Free Software Foundation, version 3.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+MIT License for more details.
+You should have received a copy of the MIT License
+along with this program.  If not, see <https://opensource.org/licenses/MIT>.
+
+------------------------------------------------------------------------------
+"""
+
+from datetime import date, timedelta
+from typing import Any
+from math import ceil
+from typing_extensions import override
+from virtual_world.emissions import Emission
+from file_processing.output_processing.output_utils import EmisInfo, EMIS_DATA_COL_ACCESSORS as eca
+
+EXPIRE = "expired"
+
+
+class NonRepairableEmission(Emission):
+    def __init__(
+        self,
+        emission_n: int,
+        rate: float,
+        start_date: date,
+        simulation_sd: date,
+        repairable: bool,
+        tech_spat_cov_probs: dict[str, float],
+        duration: int,
+    ):
+        super().__init__(
+            emission_n,
+            rate,
+            start_date,
+            simulation_sd,
+            repairable,
+            tech_spat_cov_probs,
+        )
+        self._record: bool = False
+        self._recorded_by_company: str = None
+        self._recorded_by_crew: str = None
+        self._expiry_date: date = None
+        self._duration: int = duration
+        days_active_b4_sim: int = (simulation_sd - start_date).days
+        self._days_active_b4_sim = days_active_b4_sim if days_active_b4_sim > 0 else 0
+
+    def __reduce__(self):
+        return self._reconstruct_nonfugitive_emission, (self.__dict__,)
+
+    def __setstate__(self, state):
+        self.__dict__.update(state)
+
+    @classmethod
+    def _reconstruct_nonfugitive_emission(cls, state):
+        instance = cls.__new__(cls)
+        instance.__setstate__(state)
+        return instance
+
+    def get_daily_emissions(self) -> float:
+        return self._rate * 86.4
+
+    def expire(self, emis_info: EmisInfo):
+        """
+        Checks the days since start against the duration
+        Ends the emission if possible
+        """
+        self._recorded_by_company = EXPIRE
+        self._status = EXPIRE
+        emis_info.emis_expired += 1
+        self._expiry_date = self._start_date + timedelta(days=(self._active_days))
+
+    def estimate_start_date(self, cur_date: date, t_since_ldar: int) -> None:
+        """Estimates the start date and days activate of the fugitive emission based on
+        the time since the last LDAR-SIm and the current date (discovery date)
+
+        Args:
+            cur_date (date): The current date in the simulation
+            t_since_ldar (int): THe time in days since the site at which the emissions
+            was discovered last received LDAR
+        """
+        half_duration: int = ceil((t_since_ldar / 2))
+        self._estimated_days_active = half_duration
+        self._estimated_date_began = cur_date - timedelta(days=half_duration)
+
+    def record_emission(
+        self,
+        measured_rate: float,
+        cur_date: date,
+        t_since_ldar: int,
+        company: str,
+        crew_id: str,
+    ):
+        """Attempts to record an emission. If an emission is not recorded
+            This function will record. If it is already record, the
+            function will return false.
+
+        Returns:
+            [bool]: Is the emission new?
+        """
+        if self._record:
+            return False
+
+        self._record = True
+
+        self._measured_rate = measured_rate
+        self.estimate_start_date(cur_date, t_since_ldar)
+
+        self._recorded_by_company = company
+        self._recorded_by_crew = crew_id
+        return True
+
+    @override
+    def update(self, emis_info: EmisInfo) -> bool:
+        is_active: bool = super().update(emis_info)
+        if is_active:
+            if self._active_days + self._days_active_b4_sim >= self._duration:
+                self.expire(emis_info)
+                is_active = False
+        return is_active
+
+    @override
+    def get_summary_dict(self) -> dict[str, Any]:
+        summary_dict: dict[str, Any] = super().get_summary_dict()
+        summary_dict.update({(eca.RECORDED, self._record)})
+        summary_dict.update({(eca.RECORDED_BY, self._recorded_by_company)})
+        return summary_dict
+
+    @override
+    def activate(self, date: date) -> bool:
+        if self._start_date <= date:
+            self._status = "Active"
+            return True
+        else:
+            return False

--- a/LDAR_Sim/src/virtual_world/sources.py
+++ b/LDAR_Sim/src/virtual_world/sources.py
@@ -31,13 +31,10 @@ from file_processing.input_processing.emissions_source_processing import (
 from virtual_world.emissions import Emission
 from virtual_world.fugitive_emission import FugitiveEmission
 from virtual_world.infrastructure_const import Infrastructure_Constants
+from virtual_world.nonfugitive_emissions import NonRepairableEmission
 
 
 class Source:
-    WIP_NON_FUG_EMIS_GENERATION_MSG = (
-        "Error: Non-Fugitive Emissions generation is still in development."
-        " Please remove these sources for now"
-    )
     INVALID_REPAIR_DELAY_COL_MSG = "Error, Invalid repair delay column provided: {key}"
     INVALID_REPAIR_DELAY_ERR_MSG = "Error, Invalid repair delay provided: {delay}"
     REP_PREFIX = "repairable_"
@@ -211,8 +208,15 @@ class Source:
                 nrd=self._get_emis_duration(),
             )
         else:
-            print(Source.WIP_NON_FUG_EMIS_GENERATION_MSG)
-            sys.exit()
+            return NonRepairableEmission(
+                emission_n=leak_count,
+                rate=self._get_rate(emission_rate_source_dictionary),
+                start_date=start_date,
+                simulation_sd=sim_start_date,
+                repairable=self._get_repairable(),
+                tech_spat_cov_probs=self._meth_spat_covs,
+                duration=self._get_emis_duration(),
+            )
 
     def generate_emissions(
         self,

--- a/LDAR_Sim/testing/unit_testing/test_virtual_world/test_nonfugitive_emissions/nonfugitive_emission_testing_fixtures.py
+++ b/LDAR_Sim/testing/unit_testing/test_virtual_world/test_nonfugitive_emissions/nonfugitive_emission_testing_fixtures.py
@@ -1,0 +1,154 @@
+from datetime import date
+from typing import Tuple
+import pytest
+
+from src.virtual_world.nonfugitive_emissions import NonRepairableEmission
+
+
+@pytest.fixture(name="mock_simple_nonfugitive_emission_for_activate_testing_1")
+def mock_simple_nonfugitive_emission_for_activate_testing_1_fix() -> NonRepairableEmission:
+    return NonRepairableEmission(1, 1, date(*[2018, 1, 1]), date(*[2017, 1, 1]), False, {}, 365)
+
+
+@pytest.fixture(name="mock_simple_emission_for_get_summary_dict")
+def mock_simple_emission_for_get_summary_dict_1_fix() -> (
+    Tuple[NonRepairableEmission, dict[str, int]]
+):
+    return (
+        NonRepairableEmission(
+            1,
+            1,
+            date(*[2018, 1, 1]),
+            date(*[2017, 1, 1]),
+            False,
+            {"M_OGI1": 1, "M_AIR1": 1, "M_OGI2": 0, "M_AIR2": 0},
+            365,
+        ),
+        {
+            "Emissions ID": "0000000001",
+            "Status": "Inactive",
+            "Days Active": 0,
+            '"True" Volume Emitted (Kg Methane)': 0.0,
+            '"Estimated" Volume Emitted (Kg Methane)': 0.0,
+            '"True" Rate (g/s)': 1,
+            '"Measured" Rate (g/s)': None,
+            "Date Began": date(2018, 1, 1),
+            "Initially Detected By": None,
+            "Initially Detected Date": None,
+            "Tagged": "N/A",
+            "Tagged By": "N/A",
+            "Recorded": False,
+            "Recorded By": None,
+        },
+    )
+
+
+@pytest.fixture(name="mock_simple_nonfugitive_emission_for_expire_testing_1")
+def mock_simple_nonfugitive_emission_for_expire_testing_1_fix() -> (
+    Tuple[NonRepairableEmission, date]
+):
+    to_ret = NonRepairableEmission(1, 1, date(*[2018, 1, 1]), date(*[2017, 1, 1]), True, {}, 365)
+    to_ret._days_since_tagged = 30
+    to_ret._active_days = 60
+    return to_ret, date(*[2018, 3, 2])
+
+
+@pytest.fixture(name="mock_nonfugitive_emission_for_update_no_status_change")
+def mock_nonfugitive_emission_for_update_no_status_change_fix() -> NonRepairableEmission:
+    to_ret = NonRepairableEmission(1, 1, date(*[2018, 1, 1]), date(*[2017, 1, 1]), True, {}, 365)
+    to_ret._active_days = 60
+    to_ret._status = "Active"
+    return to_ret
+
+
+@pytest.fixture(name="mock_nonfugitive_emission_for_update_no_status_change_emission_tagged")
+def mock_nonfugitive_emission_for_update_no_status_change_emission_tagged_fix() -> (
+    NonRepairableEmission
+):
+    to_ret = NonRepairableEmission(1, 1, date(*[2018, 1, 1]), date(*[2017, 1, 1]), True, {}, 365)
+    to_ret._active_days = 60
+    to_ret._status = "Active"
+    to_ret._record = True
+    to_ret._days_since_tagged = 1
+    return to_ret
+
+
+@pytest.fixture(name="mock_simple_nonfugitive_emission_for_tagged_today_testing_just_tagged")
+def mock_simple_nonfugitive_emission_for_tagged_today_testing_just_tagged_fix() -> (
+    NonRepairableEmission
+):
+    to_ret = NonRepairableEmission(1, 1, date(*[2018, 1, 1]), date(*[2017, 1, 1]), True, {}, 365)
+    to_ret._days_since_tagged = 0
+    to_ret._record = True
+    to_ret._tagged_by_company = "Test"
+    return to_ret
+
+
+@pytest.fixture(name="mock_simple_nonfugitive_emission_for_tagged_today_testing_not_tagged")
+def mock_simple_nonfugitive_emission_for_tagged_today_testing_not_tagged_fix() -> (
+    NonRepairableEmission
+):
+    to_ret = NonRepairableEmission(1, 1, date(*[2018, 1, 1]), date(*[2017, 1, 1]), True, {}, 365)
+    to_ret._record = False
+    return to_ret
+
+
+@pytest.fixture(name="mock_simple_nonfugitive_emission_for_tagged_today_testing_tagged_by_expire")
+def mock_simple_nonfugitive_emission_for_tagged_today_testing_tagged_by_expire_fix() -> (
+    NonRepairableEmission
+):
+    to_ret = NonRepairableEmission(1, 1, date(*[2018, 1, 1]), date(*[2017, 1, 1]), True, {}, 365)
+    to_ret._days_since_tagged = 0
+    to_ret._record = True
+    to_ret._tagged_by_company = "expired"
+    return to_ret
+
+
+@pytest.fixture(name="mock_simple_nonfugitive_emission_for_tagged_today_testing_tagged_previously")
+def mock_simple_nonfugitive_emission_for_tagged_today_testing_tagged_previously_fix() -> (
+    NonRepairableEmission
+):
+    to_ret = NonRepairableEmission(1, 1, date(*[2018, 1, 1]), date(*[2017, 1, 1]), True, {}, 365)
+    to_ret._days_since_tagged = 60
+    to_ret._record = True
+    to_ret._tagged_by_company = "Test"
+    return to_ret
+
+
+@pytest.fixture(name="mock_simple_nonfugitive_emission_for_record_testing_1")
+def mock_simple_nonfugitive_emission_for_record_testing_1_fix() -> Tuple[
+    NonRepairableEmission,
+    Tuple[float, date, int, str, str, int],
+]:
+    to_ret = NonRepairableEmission(1, 1, date(*[2018, 1, 1]), date(*[2017, 1, 1]), True, {}, 365)
+    to_ret._active_days = 60
+    return to_ret, (1, date(*[2017, 6, 1]), 1, "test", "test")
+
+
+@pytest.fixture(name="mock_simple_nonfugitive_emission_for_record_testing_already_recorded")
+def mock_simple_nonfugitive_emission_for_record_testing_already_recorded_fix() -> Tuple[
+    NonRepairableEmission,
+    Tuple[float, date, int, str, str, int],
+]:
+    to_ret = NonRepairableEmission(1, 1, date(*[2018, 1, 1]), date(*[2017, 1, 1]), True, {}, 365)
+    to_ret._active_days = 60
+    to_ret._record = True
+    return to_ret, (1.0, date(*[2017, 6, 1]), 1, "test", "test")
+
+
+@pytest.fixture(name="mock_nonfugitive_emission_for_update_detection_records_no_prior_detection")
+def mock_nonfugitive_emission_for_update_detection_records_no_prior_detection_fix() -> (
+    NonRepairableEmission
+):
+    to_ret = NonRepairableEmission(1, 1, date(*[2018, 1, 1]), date(*[2017, 1, 1]), True, {}, 365)
+    return to_ret
+
+
+@pytest.fixture(name="mock_nonfugitive_emission_for_update_detection_records_w_prior_detection")
+def mock_nonfugitive_emission_for_update_detection_records_w_prior_detection_fix() -> (
+    NonRepairableEmission
+):
+    to_ret = NonRepairableEmission(1, 1, date(*[2018, 1, 1]), date(*[2017, 1, 1]), True, {}, 365)
+    to_ret._init_detect_by = "test"
+    to_ret._init_detect_date = date(*[2018, 1, 2])
+    return to_ret

--- a/LDAR_Sim/testing/unit_testing/test_virtual_world/test_nonfugitive_emissions/test_activate.py
+++ b/LDAR_Sim/testing/unit_testing/test_virtual_world/test_nonfugitive_emissions/test_activate.py
@@ -1,0 +1,35 @@
+from datetime import date
+from src.virtual_world.nonfugitive_emissions import NonRepairableEmission
+
+from testing.unit_testing.test_virtual_world.test_nonfugitive_emissions.nonfugitive_emission_testing_fixtures import (  # noqa
+    mock_simple_nonfugitive_emission_for_activate_testing_1_fix,
+)
+
+
+def test_000_activate_returns_inactive_when_nonfugitive_emissions_start_date_not_yet_reached_and_status_inactive(  # noqa
+    mock_simple_nonfugitive_emission_for_activate_testing_1: NonRepairableEmission,
+):
+    mock_simple_nonfugitive_emission_for_activate_testing_1.activate(date(*[2017, 1, 1]))
+    assert (
+        mock_simple_nonfugitive_emission_for_activate_testing_1._status
+        == "Inactive"
+    )
+
+
+def test_000_activate_returns_already_active_when_nonfugitive_emissions_status_active(
+    mock_simple_nonfugitive_emission_for_activate_testing_1: NonRepairableEmission,
+):
+    mock_simple_nonfugitive_emission_for_activate_testing_1._status = "Active"
+    mock_simple_nonfugitive_emission_for_activate_testing_1.activate(date(*[2017, 1, 1]))
+    assert (
+        mock_simple_nonfugitive_emission_for_activate_testing_1._status == "Active"
+    )
+
+
+def test_000_activate_returns_newly_active_when_nonfugitive_emissions_start_date_passed_as_activate_date(  # noqa
+    mock_simple_nonfugitive_emission_for_activate_testing_1: NonRepairableEmission,
+):
+    mock_simple_nonfugitive_emission_for_activate_testing_1.activate(date(*[2018, 1, 1]))
+    assert (
+        mock_simple_nonfugitive_emission_for_activate_testing_1._status == "Active"
+    )

--- a/LDAR_Sim/testing/unit_testing/test_virtual_world/test_nonfugitive_emissions/test_estimate_start_date.py
+++ b/LDAR_Sim/testing/unit_testing/test_virtual_world/test_nonfugitive_emissions/test_estimate_start_date.py
@@ -1,0 +1,32 @@
+from datetime import date, timedelta
+from math import ceil
+from typing import Tuple
+from hypothesis import given, strategies as st
+from src.virtual_world.nonfugitive_emissions import NonRepairableEmission
+
+
+def mock_simple_nonfugitive_emission_for_est_start_date_testing_1() -> NonRepairableEmission:
+    return NonRepairableEmission(1, 1, date(*[2018, 1, 1]), date(*[2017, 1, 1]), False, {}, 365)
+
+
+@st.composite
+def gen_valid_est_start_date_testing_data(draw):
+    t_since_ldar: int = draw(st.integers(min_value=1, max_value=365))
+    current_date = draw(st.dates(min_value=date(2000, 1, 1), max_value=date(2023, 12, 31)))
+    expected_est_sd = current_date - timedelta(days=ceil(t_since_ldar / 2))
+    expected_est_days_active = ceil(t_since_ldar / 2)
+    return t_since_ldar, current_date, (expected_est_sd, expected_est_days_active)
+
+
+@given(test_data=gen_valid_est_start_date_testing_data())
+def test_000_estimate_start_date_estimates_correct_with_with_valid_t_since_ldar(
+    test_data: Tuple[int, date, date],
+) -> None:
+    nonrep_emis: NonRepairableEmission = (
+        mock_simple_nonfugitive_emission_for_est_start_date_testing_1()
+    )
+    time_since_ldar, cur_dt, ans = test_data
+    exp_est_dt, est_days_active = ans
+    nonrep_emis.estimate_start_date(cur_dt, time_since_ldar)
+    assert nonrep_emis._estimated_date_began == exp_est_dt
+    assert nonrep_emis._estimated_days_active == est_days_active

--- a/LDAR_Sim/testing/unit_testing/test_virtual_world/test_nonfugitive_emissions/test_expire.py
+++ b/LDAR_Sim/testing/unit_testing/test_virtual_world/test_nonfugitive_emissions/test_expire.py
@@ -1,0 +1,23 @@
+from datetime import date
+from typing import Tuple
+from testing.unit_testing.test_virtual_world.test_nonfugitive_emissions.nonfugitive_emission_testing_fixtures import (  # noqa
+    mock_simple_nonfugitive_emission_for_expire_testing_1_fix,
+)
+from src.virtual_world.nonfugitive_emissions import NonRepairableEmission
+from src.file_processing.output_processing.output_utils import EmisInfo
+
+
+def test_000_expire_applies_correctly_to_simple_case(
+    mock_simple_nonfugitive_emission_for_expire_testing_1: Tuple[NonRepairableEmission, date],
+):
+    emis: EmisInfo = EmisInfo()
+    mock_simple_nonfugitive_emission_for_expire_testing_1[0].expire(emis)
+    assert mock_simple_nonfugitive_emission_for_expire_testing_1[0]._record is False
+    assert (
+        mock_simple_nonfugitive_emission_for_expire_testing_1[0]._recorded_by_company == "expired"
+    )
+    assert mock_simple_nonfugitive_emission_for_expire_testing_1[0]._status == "expired"
+    assert (
+        mock_simple_nonfugitive_emission_for_expire_testing_1[0]._expiry_date
+        == mock_simple_nonfugitive_emission_for_expire_testing_1[1]
+    )

--- a/LDAR_Sim/testing/unit_testing/test_virtual_world/test_nonfugitive_emissions/test_get_summary_dict.py
+++ b/LDAR_Sim/testing/unit_testing/test_virtual_world/test_nonfugitive_emissions/test_get_summary_dict.py
@@ -1,0 +1,13 @@
+from typing import Any, Tuple
+from testing.unit_testing.test_virtual_world.test_nonfugitive_emissions.nonfugitive_emission_testing_fixtures import (  # noqa
+    mock_simple_emission_for_get_summary_dict_1_fix,
+)
+from src.virtual_world.nonfugitive_emissions import NonRepairableEmission
+
+
+def test_000_get_summary_dict_fe_returns_expected_values_for_simple_case(
+    mock_simple_emission_for_get_summary_dict: Tuple[NonRepairableEmission, dict[str, int]]
+) -> None:
+    emission, expected_result = mock_simple_emission_for_get_summary_dict
+    summary_dict: dict[str, Any] = emission.get_summary_dict()
+    assert summary_dict == expected_result

--- a/LDAR_Sim/testing/unit_testing/test_virtual_world/test_nonfugitive_emissions/test_record_emission.py
+++ b/LDAR_Sim/testing/unit_testing/test_virtual_world/test_nonfugitive_emissions/test_record_emission.py
@@ -1,0 +1,99 @@
+from datetime import date
+from typing import Tuple
+from src.virtual_world.nonfugitive_emissions import NonRepairableEmission
+
+from testing.unit_testing.test_virtual_world.test_nonfugitive_emissions.nonfugitive_emission_testing_fixtures import (  # noqa
+    mock_simple_nonfugitive_emission_for_record_testing_1_fix,
+    mock_simple_nonfugitive_emission_for_record_testing_already_recorded_fix,
+)
+
+
+def test_000_record_correctly_sets_record_to_true(
+    mock_simple_nonfugitive_emission_for_record_testing_1: Tuple[
+        NonRepairableEmission, Tuple[float, date, int, str, str, int]
+    ],
+) -> None:
+    nonrep_emis: NonRepairableEmission = mock_simple_nonfugitive_emission_for_record_testing_1[0]
+    (
+        measured_rate,
+        cur_date,
+        t_since_ldar,
+        company,
+        crew_id,
+    ) = mock_simple_nonfugitive_emission_for_record_testing_1[1]
+    nonrep_emis.record_emission(measured_rate, cur_date, t_since_ldar, company, crew_id)
+    assert nonrep_emis._record is True
+
+
+def test_000_record_correctly_returns_false_with_no_overwrite_when_already_recorded(
+    mock_simple_nonfugitive_emission_for_record_testing_already_recorded: Tuple[
+        NonRepairableEmission, Tuple[float, date, int, str, str, int]
+    ],
+) -> None:
+    nonrep_emis: NonRepairableEmission = (
+        mock_simple_nonfugitive_emission_for_record_testing_already_recorded[0]
+    )
+    (
+        measured_rate,
+        cur_date,
+        t_since_ldar,
+        company,
+        crew_id,
+    ) = mock_simple_nonfugitive_emission_for_record_testing_already_recorded[1]
+    new_leak = nonrep_emis.record_emission(measured_rate, cur_date, t_since_ldar, company, crew_id)
+    assert not new_leak
+
+
+def test_000_record_correctly_sets_input_args(
+    mock_simple_nonfugitive_emission_for_record_testing_1: Tuple[
+        NonRepairableEmission, Tuple[float, date, int, str, str, int]
+    ],
+) -> None:
+    nonrep_emis: NonRepairableEmission = mock_simple_nonfugitive_emission_for_record_testing_1[0]
+    (
+        measured_rate,
+        cur_date,
+        t_since_ldar,
+        company,
+        crew_id,
+    ) = mock_simple_nonfugitive_emission_for_record_testing_1[1]
+    nonrep_emis.record_emission(measured_rate, cur_date, t_since_ldar, company, crew_id)
+    assert nonrep_emis._measured_rate == measured_rate
+    assert nonrep_emis._recorded_by_company == company
+    assert nonrep_emis._recorded_by_crew == crew_id
+
+
+def test_000_record_correctly_calls_estimate_start_days(
+    mocker,
+    mock_simple_nonfugitive_emission_for_record_testing_1: Tuple[
+        NonRepairableEmission, Tuple[float, date, int, str, str, int]
+    ],
+) -> None:
+    nonrep_emis: NonRepairableEmission = mock_simple_nonfugitive_emission_for_record_testing_1[0]
+    mocker.patch.object(nonrep_emis, "estimate_start_date")
+    (
+        measured_rate,
+        cur_date,
+        t_since_ldar,
+        company,
+        crew_id,
+    ) = mock_simple_nonfugitive_emission_for_record_testing_1[1]
+    nonrep_emis.record_emission(measured_rate, cur_date, t_since_ldar, company, crew_id)
+    nonrep_emis.estimate_start_date.assert_called_once()
+
+
+def test_000_record_returns_true_for_new_record(
+    mock_simple_nonfugitive_emission_for_record_testing_1: Tuple[
+        NonRepairableEmission, Tuple[float, date, int, str, str, int]
+    ],
+) -> None:
+    nonrep_emis: NonRepairableEmission = mock_simple_nonfugitive_emission_for_record_testing_1[0]
+    (
+        measured_rate,
+        cur_date,
+        t_since_ldar,
+        company,
+        crew_id,
+    ) = mock_simple_nonfugitive_emission_for_record_testing_1[1]
+    new_leak = nonrep_emis.record_emission(measured_rate, cur_date, t_since_ldar, company, crew_id)
+    assert new_leak

--- a/LDAR_Sim/testing/unit_testing/test_virtual_world/test_nonfugitive_emissions/test_update.py
+++ b/LDAR_Sim/testing/unit_testing/test_virtual_world/test_nonfugitive_emissions/test_update.py
@@ -1,0 +1,36 @@
+from src.virtual_world.nonfugitive_emissions import NonRepairableEmission
+
+from testing.unit_testing.test_virtual_world.test_nonfugitive_emissions.nonfugitive_emission_testing_fixtures import (  # noqa
+    mock_nonfugitive_emission_for_update_ready_for_nat_repair_fix,
+    mock_nonfugitive_emission_for_update_no_status_change_fix,
+    mock_nonfugitive_emission_for_update_no_status_change_emission_tagged_fix,
+    mock_nonfugitive_emission_for_update_newly_repaired_fix,
+)
+
+
+def test_000_update_returns_nat_repair_and_calls_nat_repair_if_ready_for_nat_repair(
+    mock_fugitive_emission_for_update_ready_for_nat_repair: NonRepairableEmission,
+) -> None:
+    update_status: str = mock_fugitive_emission_for_update_ready_for_nat_repair.update()
+    assert update_status == "expired"
+
+
+def test_000_update_returns_no_status_change_when_no_change_to_status_emission_active(
+    mock_fugitive_emission_for_update_no_status_change: NonRepairableEmission,
+) -> None:
+    update_status: str = mock_fugitive_emission_for_update_no_status_change.update()
+    assert update_status == "no_status_change"
+
+
+def test_000_update_returns_no_status_change_when_no_change_to_status_emission_tagged_but_not_repaired(  # noqa
+    mock_fugitive_emission_for_update_no_status_change_emission_tagged: NonRepairableEmission,
+) -> None:
+    update_status: str = mock_fugitive_emission_for_update_no_status_change_emission_tagged.update()
+    assert update_status == "no_status_change"
+
+
+def test_000_update_returns_repaired_if_leak_newly_repaired(
+    mock_fugitive_emission_for_update_newly_repaired: NonRepairableEmission,
+) -> None:
+    update_status: str = mock_fugitive_emission_for_update_newly_repaired.update()
+    assert update_status == "expired"

--- a/LDAR_Sim/testing/unit_testing/test_virtual_world/test_nonfugitive_emissions/test_update_detection_records.py
+++ b/LDAR_Sim/testing/unit_testing/test_virtual_world/test_nonfugitive_emissions/test_update_detection_records.py
@@ -1,0 +1,49 @@
+import copy
+from datetime import date
+from src.virtual_world.nonfugitive_emissions import NonRepairableEmission
+from testing.unit_testing.test_virtual_world.test_nonfugitive_emissions.nonfugitive_emission_testing_fixtures import (  # noqa
+    mock_nonfugitive_emission_for_update_detection_records_no_prior_detection_fix,
+    mock_nonfugitive_emission_for_update_detection_records_w_prior_detection_fix,
+)
+
+
+def test_000_update_detection_records_correctly_sets_detection_info_where_no_prior_detection(
+    mock_nonfugitive_emission_for_update_detection_records_no_prior_detection: NonRepairableEmission,
+) -> None:
+    detec_company = "Testing"
+    detec_date = date(*[2020, 1, 1])
+    mock_nonfugitive_emission_for_update_detection_records_no_prior_detection.update_detection_records(
+        detec_company, detec_date
+    )
+    assert (
+        mock_nonfugitive_emission_for_update_detection_records_no_prior_detection._init_detect_by
+        == detec_company
+    )
+    assert (
+        mock_nonfugitive_emission_for_update_detection_records_no_prior_detection._init_detect_date
+        == detec_date
+    )
+
+
+def test_000_update_detection_records_does_not_overwrite_prior_detection_record_if_existing(
+    mock_nonfugitive_emission_for_update_detection_records_w_prior_detection: NonRepairableEmission,
+) -> None:
+    prev_detect_company = copy.deepcopy(
+        mock_nonfugitive_emission_for_update_detection_records_w_prior_detection._init_detect_by
+    )
+    prev_detect_date = copy.deepcopy(
+        mock_nonfugitive_emission_for_update_detection_records_w_prior_detection._init_detect_date
+    )
+    detec_company = "Testing"
+    detec_date = date(*[2020, 1, 1])
+    mock_nonfugitive_emission_for_update_detection_records_w_prior_detection.update_detection_records(
+        detec_company, detec_date
+    )
+    assert (
+        mock_nonfugitive_emission_for_update_detection_records_w_prior_detection._init_detect_by
+        == prev_detect_company
+    )
+    assert (
+        mock_nonfugitive_emission_for_update_detection_records_w_prior_detection._init_detect_date
+        == prev_detect_date
+    )


### PR DESCRIPTION
# Pull Request Key Information

## Reason for change

Non-repairable emissions logic did not exist, other than as a placeholder. 

## What was changed

Added in the logic for non-repairable emissions.

## Intended Purpose

Allow users to simulate non-repairable emissions in addition to repairable emissions. 

## Testing Completed

The following manual E2E testing was done.
Simulations using just the virtual world parameters to set non-repairable emission parameters.
Simulations where the source/equipment file specified the non-repairable emission parameters. 

In addition, unit tests were created, based on the existing fugitive emission unit tests. 
