### PR TITLE
V4 uncertainty visualizations

### DIFF
--- a/LDAR_Sim/src/file_processing/output_processing/multi_simulation_outputs.py
+++ b/LDAR_Sim/src/file_processing/output_processing/multi_simulation_outputs.py
@@ -23,81 +23,12 @@ from pathlib import Path
 import numpy as np
 import pandas as pd
 import re
+from LDAR_Sim.src.file_processing.output_processing import output_constants
+
 from file_processing.output_processing.output_utils import (
     TIMESERIES_COL_ACCESSORS as tca,
     EMIS_DATA_COL_ACCESSORS as eca,
 )
-
-
-class TS_SUMMARY_COLUMNS_ACCESSORS:
-    PROG_NAME = "Program Name"
-    SIM = "Simulation"
-    AVG_T_DAILY_EMIS = 'Average "True" Daily Emissions (Kg Methane)'
-    AVG_T_MIT_DAILY_EMIS = 'Average "True" Mitigable Daily Emissions (Kg Methane)'
-    AVG_T_NON_MIT_DAILY_EMIS = 'Average "True" Non-Mitigable Daily Emissions (Kg Methane)'
-    T_DAILY_EMIS_95 = '95th Percentile "True" Daily Emissions (Kg Methane)'
-    T_MIT_DAILY_EMIS_95 = '95th Percentile "True" Mitigable Daily Emissions (Kg Methane)'
-    T_NON_MIT_DAILY_EMIS_95 = '95th Percentile "True" Non-Mitigable Daily Emissions (Kg Methane)'
-    T_DAILY_EMIS_5 = '5th Percentile "True" Daily Emissions (Kg Methane)'
-    T_MIT_DAILT_EMIS_5 = '5th Percentile "True" Mitigable Daily Emissions (Kg Methane)'
-    T_NON_MIT_DAILY_EMIS_5 = '5th Percentile "True" Non-Mitigable Daily Emissions (Kg Methane)'
-    AVG_DAILY_COST = "Average Daily Cost ($)"
-    DAILY_COST_95 = "95th Percentile Daily Cost ($)"
-    DAILY_COST_5 = "5th Percentile Daily Cost ($)"
-
-
-class EMIS_SUMMARY_COLUMNS_ACCESSORS:
-    PROG_NAME = "Program Name"
-    SIM = "Simulation"
-    T_TOTAL_EMIS = 'Total "True" Emissions (Kg Methane)'
-    EST_TOTAL_EMIS = 'Total "Estimated" Emissions (Kg Methane)'
-    T_TOTAL_MIT_EMIS = 'Total "True" Mitigable Emissions (Kg Methane)'
-    T_TOTAL_NON_MIT_EMIS = 'Total "True" Non-Mitigable Emissions (Kg Methane)'
-    AVG_T_EMIS_RATE = 'Average "True" Emissions Rate (g/s)'
-    T_EMIS_RATE_95 = '95th Percentile "True" Emissions Rate (g/s)'
-    T_EMIS_RATE_5 = '5th Percentile "True" Emissions Rate (g/s)'
-    T_AVG_EMIS_AMOUNT = '"True" Average Emissions Amount (Kg Methane)'
-    T_EMIS_AMOUNT_95 = '95th Percentile "True" Emissions Amount (Kg Methane)'
-    T_EMIS_AMOUNT_5 = '5th Percentile "True" Emissions Amount (Kg Methane)'
-    EST_AVG_EMIS_AMOUNT = '"Estimated" Average Emissions Amount (Kg Methane)'
-    EST_EMIS_AMOUNT_95 = '95th Percentile "Estimated" Emissions Amount (Kg Methane)'
-    EST_EMIS_AMOUNT_5 = '5th Percentile "Estimated" Emissions Amount (Kg Methane)'
-
-
-TS_SUMMARY_COLUMNS = [
-    TS_SUMMARY_COLUMNS_ACCESSORS.PROG_NAME,
-    TS_SUMMARY_COLUMNS_ACCESSORS.SIM,
-    TS_SUMMARY_COLUMNS_ACCESSORS.AVG_T_DAILY_EMIS,
-    TS_SUMMARY_COLUMNS_ACCESSORS.AVG_T_MIT_DAILY_EMIS,
-    TS_SUMMARY_COLUMNS_ACCESSORS.AVG_T_NON_MIT_DAILY_EMIS,
-    TS_SUMMARY_COLUMNS_ACCESSORS.T_DAILY_EMIS_95,
-    TS_SUMMARY_COLUMNS_ACCESSORS.T_MIT_DAILY_EMIS_95,
-    TS_SUMMARY_COLUMNS_ACCESSORS.T_NON_MIT_DAILY_EMIS_95,
-    TS_SUMMARY_COLUMNS_ACCESSORS.T_DAILY_EMIS_5,
-    TS_SUMMARY_COLUMNS_ACCESSORS.T_MIT_DAILT_EMIS_5,
-    TS_SUMMARY_COLUMNS_ACCESSORS.T_NON_MIT_DAILY_EMIS_5,
-    TS_SUMMARY_COLUMNS_ACCESSORS.AVG_DAILY_COST,
-    TS_SUMMARY_COLUMNS_ACCESSORS.DAILY_COST_95,
-    TS_SUMMARY_COLUMNS_ACCESSORS.DAILY_COST_5,
-]
-
-EMIS_SUMMARY_COLUMNS = [
-    EMIS_SUMMARY_COLUMNS_ACCESSORS.PROG_NAME,
-    EMIS_SUMMARY_COLUMNS_ACCESSORS.SIM,
-    EMIS_SUMMARY_COLUMNS_ACCESSORS.T_TOTAL_EMIS,
-    EMIS_SUMMARY_COLUMNS_ACCESSORS.EST_TOTAL_EMIS,
-    EMIS_SUMMARY_COLUMNS_ACCESSORS.T_TOTAL_MIT_EMIS,
-    EMIS_SUMMARY_COLUMNS_ACCESSORS.T_TOTAL_NON_MIT_EMIS,
-    EMIS_SUMMARY_COLUMNS_ACCESSORS.AVG_T_EMIS_RATE,
-    EMIS_SUMMARY_COLUMNS_ACCESSORS.T_EMIS_RATE_95,
-    EMIS_SUMMARY_COLUMNS_ACCESSORS.T_EMIS_RATE_5,
-    EMIS_SUMMARY_COLUMNS_ACCESSORS.T_AVG_EMIS_AMOUNT,
-    EMIS_SUMMARY_COLUMNS_ACCESSORS.T_EMIS_AMOUNT_95,
-    EMIS_SUMMARY_COLUMNS_ACCESSORS.T_EMIS_AMOUNT_5,
-    EMIS_SUMMARY_COLUMNS_ACCESSORS.EST_AVG_EMIS_AMOUNT,
-    EMIS_SUMMARY_COLUMNS_ACCESSORS.EST_EMIS_AMOUNT_95,
-    EMIS_SUMMARY_COLUMNS_ACCESSORS.EST_EMIS_AMOUNT_5,
-]
 
 
 def get_mean_val(df: pd.DataFrame, column: str) -> float:
@@ -118,65 +49,77 @@ def get_nth_percentile(df: pd.DataFrame, column: str, percentile: float) -> floa
     return np.percentile(df[column], percentile, method="median_unbiased")
 
 
-TS_MAPPING_TO_SUMMARY_COLS = {
-    TS_SUMMARY_COLUMNS_ACCESSORS.AVG_T_DAILY_EMIS: lambda df: get_mean_val(df, tca.EMIS),
-    TS_SUMMARY_COLUMNS_ACCESSORS.AVG_T_MIT_DAILY_EMIS: lambda df: get_mean_val(df, tca.EMIS_MIT),
-    TS_SUMMARY_COLUMNS_ACCESSORS.AVG_T_NON_MIT_DAILY_EMIS: lambda df: get_mean_val(
-        df, tca.EMIS_NON_MIT
+(TS_MAPPING_TO_SUMMARY_COLS) = {
+    output_constants.TS_SUMMARY_COLUMNS_ACCESSORS.AVG_T_DAILY_EMIS: lambda df: (
+        get_mean_val(df, tca.EMIS)
     ),
-    TS_SUMMARY_COLUMNS_ACCESSORS.T_DAILY_EMIS_95: lambda df: get_nth_percentile(df, tca.EMIS, 95),
-    TS_SUMMARY_COLUMNS_ACCESSORS.T_MIT_DAILY_EMIS_95: lambda df: get_nth_percentile(
-        df, tca.EMIS_MIT, 95
+    output_constants.TS_SUMMARY_COLUMNS_ACCESSORS.AVG_T_MIT_DAILY_EMIS: lambda df: (
+        get_mean_val(df, tca.EMIS_MIT)
     ),
-    TS_SUMMARY_COLUMNS_ACCESSORS.T_NON_MIT_DAILY_EMIS_95: lambda df: get_nth_percentile(
-        df, tca.EMIS_NON_MIT, 95
+    output_constants.TS_SUMMARY_COLUMNS_ACCESSORS.AVG_T_NON_MIT_DAILY_EMIS: lambda df: (
+        get_mean_val(df, tca.EMIS_NON_MIT)
     ),
-    TS_SUMMARY_COLUMNS_ACCESSORS.T_DAILY_EMIS_5: lambda df: get_nth_percentile(df, tca.EMIS, 5),
-    TS_SUMMARY_COLUMNS_ACCESSORS.T_MIT_DAILT_EMIS_5: lambda df: get_nth_percentile(
-        df, tca.EMIS_MIT, 5
+    output_constants.TS_SUMMARY_COLUMNS_ACCESSORS.T_DAILY_EMIS_95: lambda df: (
+        get_nth_percentile(df, tca.EMIS, 95)
     ),
-    TS_SUMMARY_COLUMNS_ACCESSORS.T_NON_MIT_DAILY_EMIS_5: lambda df: get_nth_percentile(
-        df, tca.EMIS_NON_MIT, 5
+    output_constants.TS_SUMMARY_COLUMNS_ACCESSORS.T_MIT_DAILY_EMIS_95: lambda df: (
+        get_nth_percentile(df, tca.EMIS_MIT, 95)
     ),
-    TS_SUMMARY_COLUMNS_ACCESSORS.AVG_DAILY_COST: lambda df: get_mean_val(df, tca.COST),
-    TS_SUMMARY_COLUMNS_ACCESSORS.DAILY_COST_95: lambda df: get_nth_percentile(df, tca.COST, 95),
-    TS_SUMMARY_COLUMNS_ACCESSORS.DAILY_COST_5: lambda df: get_nth_percentile(df, tca.COST, 5),
+    output_constants.TS_SUMMARY_COLUMNS_ACCESSORS.T_NON_MIT_DAILY_EMIS_95: lambda df: (
+        get_nth_percentile(df, tca.EMIS_NON_MIT, 95)
+    ),
+    output_constants.TS_SUMMARY_COLUMNS_ACCESSORS.T_DAILY_EMIS_5: lambda df: (
+        get_nth_percentile(df, tca.EMIS, 5)
+    ),
+    output_constants.TS_SUMMARY_COLUMNS_ACCESSORS.T_MIT_DAILT_EMIS_5: lambda df: (
+        get_nth_percentile(df, tca.EMIS_MIT, 5)
+    ),
+    output_constants.TS_SUMMARY_COLUMNS_ACCESSORS.T_NON_MIT_DAILY_EMIS_5: lambda df: (
+        get_nth_percentile(df, tca.EMIS_NON_MIT, 5)
+    ),
+    output_constants.TS_SUMMARY_COLUMNS_ACCESSORS.AVG_DAILY_COST: lambda df: (
+        get_mean_val(df, tca.COST)
+    ),
+    output_constants.TS_SUMMARY_COLUMNS_ACCESSORS.DAILY_COST_95: lambda df: (
+        get_nth_percentile(df, tca.COST, 95)
+    ),
+    output_constants.TS_SUMMARY_COLUMNS_ACCESSORS.DAILY_COST_5: lambda df: (
+        get_nth_percentile(df, tca.COST, 5)
+    ),
 }
 
 EMIS_MAPPING_TO_SUMMARY_COLS = {
-    EMIS_SUMMARY_COLUMNS_ACCESSORS.T_TOTAL_EMIS: lambda df: get_sum(df, eca.T_VOL_EMIT),
-    EMIS_SUMMARY_COLUMNS_ACCESSORS.EST_TOTAL_EMIS: lambda df: get_sum(df, eca.EST_VOL_EMIT),
-    EMIS_SUMMARY_COLUMNS_ACCESSORS.T_TOTAL_MIT_EMIS: lambda df: get_sum(
-        df.loc[df[eca.REPAIRABLE]], eca.T_VOL_EMIT
+    output_constants.EMIS_SUMMARY_COLUMNS_ACCESSORS.T_TOTAL_EMIS: lambda df: get_sum(
+        df, eca.T_VOL_EMIT
     ),
-    EMIS_SUMMARY_COLUMNS_ACCESSORS.T_TOTAL_NON_MIT_EMIS: lambda df: get_sum(
-        df.loc[~df[eca.REPAIRABLE]], eca.T_VOL_EMIT
-    ),
-    EMIS_SUMMARY_COLUMNS_ACCESSORS.AVG_T_EMIS_RATE: lambda df: get_mean_val(df, eca.T_RATE),
-    EMIS_SUMMARY_COLUMNS_ACCESSORS.T_EMIS_RATE_95: lambda df: get_nth_percentile(
-        df, eca.T_RATE, 95
-    ),
-    EMIS_SUMMARY_COLUMNS_ACCESSORS.T_EMIS_RATE_5: lambda df: get_nth_percentile(df, eca.T_RATE, 5),
-    EMIS_SUMMARY_COLUMNS_ACCESSORS.T_AVG_EMIS_AMOUNT: lambda df: get_mean_val(df, eca.T_VOL_EMIT),
-    EMIS_SUMMARY_COLUMNS_ACCESSORS.T_EMIS_AMOUNT_95: lambda df: get_nth_percentile(
-        df, eca.T_VOL_EMIT, 95
-    ),
-    EMIS_SUMMARY_COLUMNS_ACCESSORS.T_EMIS_AMOUNT_5: lambda df: get_nth_percentile(
-        df, eca.T_VOL_EMIT, 5
-    ),
-    EMIS_SUMMARY_COLUMNS_ACCESSORS.EST_AVG_EMIS_AMOUNT: lambda df: get_mean_val(
+    output_constants.EMIS_SUMMARY_COLUMNS_ACCESSORS.EST_TOTAL_EMIS: lambda df: get_sum(
         df, eca.EST_VOL_EMIT
     ),
-    EMIS_SUMMARY_COLUMNS_ACCESSORS.EST_EMIS_AMOUNT_95: lambda df: get_nth_percentile(
-        df, eca.EST_VOL_EMIT, 95
+    output_constants.EMIS_SUMMARY_COLUMNS_ACCESSORS.T_TOTAL_MIT_EMIS: lambda df: get_sum(
+        df.loc[df[eca.REPAIRABLE]], eca.T_VOL_EMIT
     ),
-    EMIS_SUMMARY_COLUMNS_ACCESSORS.EST_EMIS_AMOUNT_5: lambda df: get_nth_percentile(
-        df, eca.EST_VOL_EMIT, 5
+    output_constants.EMIS_SUMMARY_COLUMNS_ACCESSORS.T_TOTAL_NON_MIT_EMIS: lambda df: get_sum(
+        df.loc[~df[eca.REPAIRABLE]], eca.T_VOL_EMIT
+    ),
+    output_constants.EMIS_SUMMARY_COLUMNS_ACCESSORS.AVG_T_EMIS_RATE: lambda df: get_mean_val(
+        df, eca.T_RATE
+    ),
+    output_constants.EMIS_SUMMARY_COLUMNS_ACCESSORS.T_EMIS_RATE_95: lambda df: get_nth_percentile(
+        df, eca.T_RATE, 95
+    ),
+    output_constants.EMIS_SUMMARY_COLUMNS_ACCESSORS.T_EMIS_RATE_5: lambda df: get_nth_percentile(
+        df, eca.T_RATE, 5
+    ),
+    output_constants.EMIS_SUMMARY_COLUMNS_ACCESSORS.T_AVG_EMIS_AMOUNT: lambda df: get_mean_val(
+        df, eca.T_VOL_EMIT
+    ),
+    output_constants.EMIS_SUMMARY_COLUMNS_ACCESSORS.T_EMIS_AMOUNT_95: lambda df: get_nth_percentile(
+        df, eca.T_VOL_EMIT, 95
+    ),
+    output_constants.EMIS_SUMMARY_COLUMNS_ACCESSORS.T_EMIS_AMOUNT_5: lambda df: get_nth_percentile(
+        df, eca.T_VOL_EMIT, 5
     ),
 }
-
-TS_SUMMARY_FILENAME = "daily_summary_stats.csv"
-EMIS_SUMMARY_FILENAME = "emissions_summary_stats.csv"
 
 TS_PATTERN = re.compile(r".*timeseries\.csv$")
 EMIS_PATTERN = re.compile(r".*emissions_summary\.csv$")
@@ -188,7 +131,7 @@ OUTPUT_KEEP_REGEX = re.compile(re.escape(OUTPUT_KEEP_STR))
 
 
 def gen_ts_summary(dir: Path):
-    ts_summary_df = pd.DataFrame(columns=TS_SUMMARY_COLUMNS)
+    ts_summary_df = pd.DataFrame(columns=output_constants.TS_SUMMARY_COLUMNS)
     with os.scandir(dir) as entries:
         for entry in entries:
             if (
@@ -198,10 +141,10 @@ def gen_ts_summary(dir: Path):
             ):
                 new_summary_row = {}
                 ts_data: pd.DataFrame = pd.read_csv(entry.path)
-                new_summary_row[TS_SUMMARY_COLUMNS_ACCESSORS.PROG_NAME] = (
+                new_summary_row[output_constants.TS_SUMMARY_COLUMNS_ACCESSORS.PROG_NAME] = (
                     OUTPUTS_NAME_SIM_EXTRACTION_REGEX.match(entry.name).group(1)
                 )
-                new_summary_row[TS_SUMMARY_COLUMNS_ACCESSORS.SIM] = (
+                new_summary_row[output_constants.TS_SUMMARY_COLUMNS_ACCESSORS.SIM] = (
                     OUTPUTS_NAME_SIM_EXTRACTION_REGEX.match(entry.name).group(2)
                 )
                 for sum_stat, calc in TS_MAPPING_TO_SUMMARY_COLS.items():
@@ -211,7 +154,7 @@ def gen_ts_summary(dir: Path):
 
 
 def gen_emissions_summary(dir: Path):
-    emis_summary_df = pd.DataFrame(columns=EMIS_SUMMARY_COLUMNS)
+    emis_summary_df = pd.DataFrame(columns=output_constants.EMIS_SUMMARY_COLUMNS)
     with os.scandir(dir) as entries:
         for entry in entries:
             if (
@@ -221,10 +164,10 @@ def gen_emissions_summary(dir: Path):
             ):
                 new_summary_row = {}
                 emis_data: pd.DataFrame = pd.read_csv(entry.path)
-                new_summary_row[EMIS_SUMMARY_COLUMNS_ACCESSORS.PROG_NAME] = (
+                new_summary_row[output_constants.EMIS_SUMMARY_COLUMNS_ACCESSORS.PROG_NAME] = (
                     OUTPUTS_NAME_SIM_EXTRACTION_REGEX.match(entry.name).group(1)
                 )
-                new_summary_row[EMIS_SUMMARY_COLUMNS_ACCESSORS.SIM] = (
+                new_summary_row[output_constants.EMIS_SUMMARY_COLUMNS_ACCESSORS.SIM] = (
                     OUTPUTS_NAME_SIM_EXTRACTION_REGEX.match(entry.name).group(2)
                 )
                 for sum_stat, calc in EMIS_MAPPING_TO_SUMMARY_COLS.items():
@@ -266,8 +209,8 @@ def mark_outputs_to_keep(dir: Path):
 
 
 def concat_output_data(out_dir: Path, clear_outputs: bool):
-    leg_ts_sum: pd.DataFrame = get_summary_file(out_dir, TS_SUMMARY_FILENAME)
-    leg_emis_sum: pd.DataFrame = get_summary_file(out_dir, EMIS_SUMMARY_FILENAME)
+    leg_ts_sum: pd.DataFrame = get_summary_file(out_dir, output_constants.TS_SUMMARY_FILENAME)
+    leg_emis_sum: pd.DataFrame = get_summary_file(out_dir, output_constants.EMIS_SUMMARY_FILENAME)
     program_dirs = [f.path for f in os.scandir(out_dir) if f.is_dir()]
     prog_ts_sum_dfs: list[pd.DataFrame] = []
     prog_emis_sum_dfs: list[pd.DataFrame] = []
@@ -283,10 +226,10 @@ def concat_output_data(out_dir: Path, clear_outputs: bool):
         new_ts_sum: pd.DataFrame = pd.concat(prog_ts_sum_dfs, ignore_index=True)
         prog_emis_sum_dfs.insert(0, leg_emis_sum)
         new_emis_sum: pd.DataFrame = pd.concat(prog_emis_sum_dfs, ignore_index=True)
-        save_summary_file(new_ts_sum, out_dir, TS_SUMMARY_FILENAME)
-        save_summary_file(new_emis_sum, out_dir, EMIS_SUMMARY_FILENAME)
+        save_summary_file(new_ts_sum, out_dir, output_constants.TS_SUMMARY_FILENAME)
+        save_summary_file(new_emis_sum, out_dir, output_constants.EMIS_SUMMARY_FILENAME)
     else:
         new_ts_sum: pd.DataFrame = pd.concat(prog_ts_sum_dfs, ignore_index=True)
         new_emis_sum: pd.DataFrame = pd.concat(prog_emis_sum_dfs, ignore_index=True)
-        save_summary_file(new_ts_sum, out_dir, TS_SUMMARY_FILENAME)
-        save_summary_file(new_emis_sum, out_dir, EMIS_SUMMARY_FILENAME)
+        save_summary_file(new_ts_sum, out_dir, output_constants.TS_SUMMARY_FILENAME)
+        save_summary_file(new_emis_sum, out_dir, output_constants.EMIS_SUMMARY_FILENAME)

--- a/LDAR_Sim/src/file_processing/output_processing/multi_simulation_outputs.py
+++ b/LDAR_Sim/src/file_processing/output_processing/multi_simulation_outputs.py
@@ -49,7 +49,7 @@ def get_nth_percentile(df: pd.DataFrame, column: str, percentile: float) -> floa
     return np.percentile(df[column], percentile, method="median_unbiased")
 
 
-(TS_MAPPING_TO_SUMMARY_COLS) = {
+TS_MAPPING_TO_SUMMARY_COLS = {
     output_constants.TS_SUMMARY_COLUMNS_ACCESSORS.AVG_T_DAILY_EMIS: lambda df: (
         get_mean_val(df, tca.EMIS)
     ),

--- a/LDAR_Sim/src/file_processing/output_processing/multi_simulation_outputs.py
+++ b/LDAR_Sim/src/file_processing/output_processing/multi_simulation_outputs.py
@@ -23,7 +23,7 @@ from pathlib import Path
 import numpy as np
 import pandas as pd
 import re
-from LDAR_Sim.src.file_processing.output_processing import output_constants
+from file_processing.output_processing import output_constants
 
 from file_processing.output_processing.output_utils import (
     TIMESERIES_COL_ACCESSORS as tca,

--- a/LDAR_Sim/src/file_processing/output_processing/multi_simulation_visualizations.py
+++ b/LDAR_Sim/src/file_processing/output_processing/multi_simulation_visualizations.py
@@ -1,16 +1,37 @@
+"""
+------------------------------------------------------------------------------
+Program:     The LDAR Simulator (LDAR-Sim)
+File:        multi_simulation_visualizations.py
+Purpose: Functionality for visualizations across multiple simulations.
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the MIT License as published
+by the Free Software Foundation, version 3.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+MIT License for more details.
+You should have received a copy of the MIT License
+along with this program.  If not, see <https://opensource.org/licenses/MIT>.
+
+------------------------------------------------------------------------------
+"""
+
 import os
 from pathlib import Path
-from typing import Tuple
+from typing import Tuple, Union
 import pandas as pd
 import seaborn as sns
 from matplotlib import pyplot as plt
 from matplotlib import ticker, lines
 
-from file_processing.output_processing import output_constants
-from file_processing.output_processing import output_utils
+from file_processing.output_processing import output_constants, output_utils
 
 
 def gen_cross_program_summary_plots(out_dir: Path, baseline_program: str):
+
+    print(output_constants.SUMMARRY_PLOT_GENERATION_MESSAGE)
 
     summary_program_plots_directory = out_dir / output_constants.SUMMARY_PROGRAM_PLOTS_DIRECTORY
 
@@ -50,21 +71,11 @@ def plot_hist(
     y_label: str,
     legend_label: str = None,
     bin_width: float = 0,
-    bins: int = 0,
+    bins: Union[int, str] = "auto",
     x_locator: ticker.Locator = ticker.AutoLocator(),
     y_locator: ticker.Locator = ticker.MaxNLocator(nbins="auto", integer=True, prune=None),
 ):
-    if bins != 0:
-        sns.histplot(
-            x_values,
-            kde=True,
-            color=color,
-            element="step",
-            ax=ax,
-            binrange=bin_range,
-            bins=bins,
-        )
-    elif bin_width != 0:
+    if bin_width != 0:
         sns.histplot(
             x_values,
             kde=True,
@@ -82,6 +93,7 @@ def plot_hist(
             element="step",
             ax=ax,
             binrange=bin_range,
+            bins=bins,
         )
 
     legend_elements.append(
@@ -142,6 +154,7 @@ def gen_estimated_vs_true_emissions_percent_difference_plot(
         comb_fig: plt.Figure = plt.figure()
         comb_ax: plt.Axes = plt.gca()
 
+    # TODO for all plots - account for colorblind palette
     colors = sns.color_palette("husl", n_colors=len(program_names))
 
     legend_elements = []

--- a/LDAR_Sim/src/file_processing/output_processing/multi_simulation_visualizations.py
+++ b/LDAR_Sim/src/file_processing/output_processing/multi_simulation_visualizations.py
@@ -1,0 +1,50 @@
+from pathlib import Path
+import pandas as pd
+import seaborn as sns
+from matplotlib import pyplot as plt
+from matplotlib import ticker, lines
+
+from src.file_processing.output_processing import output_constants
+from src.file_processing.output_processing import output_utils
+
+
+def gen_estimated_vs_true_emissions_plot(out_dir: Path):
+    emis_summary_info: pd.DataFrame = pd.read_csv(out_dir / output_constants.EMIS_SUMMARY_FILENAME)
+
+    estimated_vs_true_total_emis_percent_diff = output_utils.percent_difference(
+        emis_summary_info[output_constants.EMIS_SUMMARY_COLUMNS_ACCESSORS.T_TOTAL_EMIS],
+        emis_summary_info[output_constants.EMIS_SUMMARY_COLUMNS_ACCESSORS.EST_TOTAL_EMIS],
+    )
+
+    fig, ax = plt.subplots()
+    sns.histplot(
+        estimated_vs_true_total_emis_percent_diff,
+        kde=True,
+        color="b",
+        element="step",
+        ax=ax,
+        bins=30,
+    )
+    fig: plt.Figure
+    ax: plt.Axes
+    # sns.histplot(normal_dist_samples2, kde=True, color="orange", element="step", ax=ax, bins=30)
+    ax.set(xlabel="Difference between Estimated and True Emissions", ylabel="Number of Occurences")
+    ax.xaxis.set_major_formatter(ticker.FuncFormatter(output_utils.percentage_formatter))
+    # ax.set_title("Distribution of Variation between Estimated and True values")
+    plt.axvline(0, color="black", linestyle="--")
+    plt.ylim(0, 110)
+    legend_elements = [
+        lines.Line2D(
+            [0], [0], color="blue", label="Measured Only", markerfacecolor="blue", markersize=15
+        ),
+        lines.Line2D(
+            [0],
+            [0],
+            color="orange",
+            label="Measured + Calculated",
+            markerfacecolor="orange",
+            markersize=15,
+        ),
+    ]
+    plt.legend(handles=legend_elements)
+    plt.savefig("Sample PD Fig1")

--- a/LDAR_Sim/src/file_processing/output_processing/multi_simulation_visualizations.py
+++ b/LDAR_Sim/src/file_processing/output_processing/multi_simulation_visualizations.py
@@ -1,50 +1,390 @@
+import os
 from pathlib import Path
+from typing import Tuple
 import pandas as pd
 import seaborn as sns
 from matplotlib import pyplot as plt
 from matplotlib import ticker, lines
 
-from src.file_processing.output_processing import output_constants
-from src.file_processing.output_processing import output_utils
+from file_processing.output_processing import output_constants
+from file_processing.output_processing import output_utils
 
 
-def gen_estimated_vs_true_emissions_plot(out_dir: Path):
+def gen_cross_program_summary_plots(out_dir: Path):
+
+    summary_program_plots_directory = out_dir / output_constants.SUMMARY_PROGRAM_PLOTS_DIRECTORY
+
+    os.makedirs(summary_program_plots_directory)
+
     emis_summary_info: pd.DataFrame = pd.read_csv(out_dir / output_constants.EMIS_SUMMARY_FILENAME)
 
-    estimated_vs_true_total_emis_percent_diff = output_utils.percent_difference(
-        emis_summary_info[output_constants.EMIS_SUMMARY_COLUMNS_ACCESSORS.T_TOTAL_EMIS],
-        emis_summary_info[output_constants.EMIS_SUMMARY_COLUMNS_ACCESSORS.EST_TOTAL_EMIS],
+    estimate_vs_true_constants = output_constants.ESTIMATE_VS_TRUE_PLOTTING_CONSTANTS
+    gen_estimated_vs_true_emissions_percent_difference_plot(
+        emis_summary_info, summary_program_plots_directory, estimate_vs_true_constants
+    )
+    gen_estimated_vs_true_emissions_relative_difference_plot(
+        emis_summary_info, summary_program_plots_directory, estimate_vs_true_constants
+    )
+    gen_paired_estimate_and_true_emission_distributions(
+        emis_summary_info, summary_program_plots_directory, estimate_vs_true_constants
     )
 
-    fig, ax = plt.subplots()
-    sns.histplot(
-        estimated_vs_true_total_emis_percent_diff,
-        kde=True,
-        color="b",
-        element="step",
-        ax=ax,
-        bins=30,
-    )
-    fig: plt.Figure
-    ax: plt.Axes
-    # sns.histplot(normal_dist_samples2, kde=True, color="orange", element="step", ax=ax, bins=30)
-    ax.set(xlabel="Difference between Estimated and True Emissions", ylabel="Number of Occurences")
-    ax.xaxis.set_major_formatter(ticker.FuncFormatter(output_utils.percentage_formatter))
-    # ax.set_title("Distribution of Variation between Estimated and True values")
-    plt.axvline(0, color="black", linestyle="--")
-    plt.ylim(0, 110)
-    legend_elements = [
-        lines.Line2D(
-            [0], [0], color="blue", label="Measured Only", markerfacecolor="blue", markersize=15
-        ),
+
+def plot_hist(
+    legend_elements: list,
+    ax: plt.Axes,
+    percent_diff_list,
+    program_name: str,
+    color: Tuple[float, float, float],
+    bin_range: Tuple[int, int],
+    x_label: str,
+    y_label: str,
+    legend_label: str = None,
+    bin_width: float = 0,
+    bins: int = 0,
+):
+    if bins != 0:
+        sns.histplot(
+            percent_diff_list,
+            kde=True,
+            color=color,
+            element="step",
+            ax=ax,
+            binrange=bin_range,
+            bins=bins,
+        )
+    elif bin_width != 0:
+        sns.histplot(
+            percent_diff_list,
+            kde=True,
+            color=color,
+            element="step",
+            ax=ax,
+            binwidth=bin_width,
+            binrange=bin_range,
+        )
+    else:
+        sns.histplot(
+            percent_diff_list,
+            kde=True,
+            color=color,
+            element="step",
+            ax=ax,
+            binrange=bin_range,
+        )
+
+    legend_elements.append(
         lines.Line2D(
             [0],
             [0],
-            color="orange",
-            label="Measured + Calculated",
-            markerfacecolor="orange",
+            color=color,
+            label=legend_label if legend_label else program_name,
+            markerfacecolor=color,
             markersize=15,
+        )
+    )
+    if x_label and y_label:
+        ax.set(
+            xlabel=x_label,
+            ylabel=y_label,
+        )
+
+
+def gen_estimated_vs_true_emissions_percent_difference_plot(
+    emis_summary_info: pd.DataFrame,
+    out_dir: Path,
+    estimate_vs_true_constants: output_constants.ESTIMATE_VS_TRUE_PLOTTING_CONSTANTS,
+    combine_plots: bool = False,
+    save_separate_plots: bool = True,
+):
+
+    emis_summary_info["percent_diff"] = emis_summary_info.apply(
+        lambda row: output_utils.percent_difference(
+            row[output_constants.EMIS_SUMMARY_COLUMNS_ACCESSORS.EST_TOTAL_EMIS],
+            row[output_constants.EMIS_SUMMARY_COLUMNS_ACCESSORS.T_TOTAL_EMIS],
         ),
-    ]
-    plt.legend(handles=legend_elements)
-    plt.savefig("Sample PD Fig1")
+        axis=1,
+    )
+
+    program_names = emis_summary_info[
+        output_constants.EMIS_SUMMARY_COLUMNS_ACCESSORS.PROG_NAME
+    ].unique()
+    percent_diff_lists = {}
+
+    for program_name in program_names:
+        percent_diff_list = emis_summary_info.loc[
+            emis_summary_info[output_constants.EMIS_SUMMARY_COLUMNS_ACCESSORS.PROG_NAME]
+            == program_name,
+            "percent_diff",
+        ].tolist()
+        percent_diff_lists[program_name] = percent_diff_list
+
+    if combine_plots:
+        comb_fig: plt.Figure = plt.figure()
+        comb_ax: plt.Axes = plt.gca()
+
+    colors = sns.color_palette("husl", n_colors=len(program_names))
+
+    legend_elements = []
+
+    for i, (program_name, percent_diff_list) in enumerate(percent_diff_lists.items()):
+        if save_separate_plots:
+            fig_sep: plt.Figure = plt.figure()  # noqa: 481
+            ax_sep: plt.Axes = plt.gca()
+
+            plot_hist(
+                legend_elements=legend_elements,
+                ax=ax_sep,
+                percent_diff_list=percent_diff_list,
+                program_name=program_name,
+                color=colors[i],
+                bin_width=1.0,
+                bin_range=(0, 200),
+                x_label='Percent Difference between "Estimated" and "True" Emissions',
+                y_label="Number of Occurrences",
+            )
+
+            ax_sep.xaxis.set_major_formatter(
+                ticker.FuncFormatter(output_utils.percentage_formatter)
+            )
+            plt.legend(handles=[legend_elements[i]])
+            save_path = out_dir / " ".join(
+                [program_name, output_constants.TRUE_VS_ESTIMATED_PERCENT_DIFF_PLOT]
+            )
+            plt.savefig(save_path)
+
+        if combine_plots:
+            plt.figure(comb_fig.number)
+            plot_hist(
+                legend_elements=legend_elements,
+                ax=comb_ax,
+                percent_diff_list=percent_diff_list,
+                program_name=program_name,
+                color=colors[i],
+                bin_width=1.0,
+                bin_range=(0, 200),
+            )
+
+    if combine_plots:
+        comb_ax.set(
+            xlabel='Percent Difference between "Estimated" and "True" Emissions',
+            ylabel="Number of Occurrences",
+        )
+        comb_ax.xaxis.set_major_formatter(ticker.FuncFormatter(output_utils.percentage_formatter))
+        plt.legend(handles=legend_elements)
+        save_path = out_dir / output_constants.TRUE_VS_ESTIMATED_PERCENT_DIFF_PLOT
+        plt.savefig(save_path)
+
+
+def gen_estimated_vs_true_emissions_relative_difference_plot(
+    emis_summary_info: pd.DataFrame,
+    out_dir: Path,
+    estimate_vs_true_constants: output_constants.ESTIMATE_VS_TRUE_PLOTTING_CONSTANTS,
+    combine_plots: bool = False,
+    save_separate_plots: bool = True,
+):
+
+    emis_summary_info["relative_diff"] = emis_summary_info.apply(
+        lambda row: output_utils.relative_difference(
+            row[output_constants.EMIS_SUMMARY_COLUMNS_ACCESSORS.EST_TOTAL_EMIS],
+            row[output_constants.EMIS_SUMMARY_COLUMNS_ACCESSORS.T_TOTAL_EMIS],
+        ),
+        axis=1,
+    )
+
+    program_names = emis_summary_info[
+        output_constants.EMIS_SUMMARY_COLUMNS_ACCESSORS.PROG_NAME
+    ].unique()
+    relative_diff_lists = {}
+
+    for program_name in program_names:
+        relative_diff_list = emis_summary_info.loc[
+            emis_summary_info[output_constants.EMIS_SUMMARY_COLUMNS_ACCESSORS.PROG_NAME]
+            == program_name,
+            "relative_diff",
+        ].tolist()
+        relative_diff_lists[program_name] = relative_diff_list
+
+    if combine_plots:
+        comb_fig: plt.Figure = plt.figure()
+        comb_ax: plt.Axes = plt.gca()
+
+    colors = sns.color_palette("husl", n_colors=len(program_names))
+    plot_bin_range = (-100, max(emis_summary_info["relative_diff"].max() + 10, 100))
+
+    legend_elements = []
+
+    for i, (program_name, relative_diff_list) in enumerate(relative_diff_lists.items()):
+        if save_separate_plots:
+            fig_sep: plt.Figure = plt.figure()  # noqa: 481
+            ax_sep: plt.Axes = plt.gca()
+
+            plot_hist(
+                legend_elements=legend_elements,
+                ax=ax_sep,
+                percent_diff_list=relative_diff_list,
+                program_name=program_name,
+                color=colors[i],
+                bin_width=1.0,
+                bin_range=plot_bin_range,
+                x_label="Relative Difference between Estimated and True Emissions",
+                y_label="Number of Occurrences",
+            )
+
+            ax_sep.xaxis.set_major_formatter(
+                ticker.FuncFormatter(output_utils.percentage_formatter)
+            )
+            plt.axvline(0, color="black", linestyle="--")
+            plt.legend(handles=[legend_elements[i]])
+            save_path = out_dir / " ".join(
+                [program_name, output_constants.TRUE_VS_ESTIMATED_RELATIVE_DIFF_PLOT]
+            )
+            plt.savefig(save_path)
+
+        if combine_plots:
+            plt.figure(comb_fig.number)
+            plot_hist(
+                legend_elements=legend_elements,
+                ax=comb_ax,
+                percent_diff_list=relative_diff_list,
+                program_name=program_name,
+                color=colors[i],
+                bin_width=1.0,
+                bin_range=plot_bin_range,
+            )
+
+    if combine_plots:
+        comb_ax.set(
+            xlabel="Relative Difference between Estimated and True Emissions",
+            ylabel="Number of Occurrences",
+        )
+        comb_ax.xaxis.set_major_formatter(ticker.FuncFormatter(output_utils.percentage_formatter))
+        plt.axvline(0, color="black", linestyle="--")
+        plt.legend(handles=legend_elements)
+        save_path = out_dir / output_constants.TRUE_VS_ESTIMATED_RELATIVE_DIFF_PLOT
+        plt.savefig(save_path)
+
+
+def gen_paired_estimate_and_true_emission_distributions(
+    emis_summary_info: pd.DataFrame,
+    out_dir: Path,
+    estimate_vs_true_constants: output_constants.ESTIMATE_VS_TRUE_PLOTTING_CONSTANTS,
+    combine_plots: bool = False,
+    save_separate_plots: bool = True,
+):
+
+    program_names = emis_summary_info[
+        output_constants.EMIS_SUMMARY_COLUMNS_ACCESSORS.PROG_NAME
+    ].unique()
+    paired_emissions_lists = {}
+
+    for program_name in program_names:
+        true_emis_list = emis_summary_info.loc[
+            emis_summary_info[output_constants.EMIS_SUMMARY_COLUMNS_ACCESSORS.PROG_NAME]
+            == program_name,
+            output_constants.EMIS_SUMMARY_COLUMNS_ACCESSORS.T_TOTAL_EMIS,
+        ].tolist()
+        est_emis_list = emis_summary_info.loc[
+            emis_summary_info[output_constants.EMIS_SUMMARY_COLUMNS_ACCESSORS.PROG_NAME]
+            == program_name,
+            output_constants.EMIS_SUMMARY_COLUMNS_ACCESSORS.EST_TOTAL_EMIS,
+        ].tolist()
+        paired_emissions_lists[program_name] = (true_emis_list, est_emis_list)
+
+    if combine_plots:
+        comb_fig: plt.Figure = plt.figure()
+        comb_ax: plt.Axes = plt.gca()
+
+    colors = sns.color_palette("husl", n_colors=len(program_names))
+    dark_pallete = [output_utils.luminance_shift(color, lighten=False) for color in colors]
+    light_pallete = [output_utils.luminance_shift(color, lighten=True) for color in colors]
+    plot_bin_range = (
+        0,
+        max(
+            emis_summary_info[output_constants.EMIS_SUMMARY_COLUMNS_ACCESSORS.T_TOTAL_EMIS].max(),
+            emis_summary_info[output_constants.EMIS_SUMMARY_COLUMNS_ACCESSORS.EST_TOTAL_EMIS].max(),
+        ),
+    )
+
+    legend_elements = []
+
+    for i, (program_name, paired_emis_list) in enumerate(paired_emissions_lists.items()):
+        if save_separate_plots:
+            fig_sep: plt.Figure = plt.figure()  # noqa: 481
+            ax_sep: plt.Axes = plt.gca()
+
+            plot_hist(
+                legend_elements=legend_elements,
+                ax=ax_sep,
+                percent_diff_list=paired_emis_list[0],
+                program_name=program_name,
+                color=dark_pallete[i],
+                bin_range=plot_bin_range,
+                x_label="emissions (Kg Methane)",
+                y_label="Number of Occurrences",
+                bins=30,
+                legend_label=" ".join(
+                    [program_name, estimate_vs_true_constants.TRUE_EMISSIONS_SUFFIX]
+                ),
+            )
+
+            plot_hist(
+                legend_elements=legend_elements,
+                ax=ax_sep,
+                percent_diff_list=paired_emis_list[1],
+                program_name=program_name,
+                color=light_pallete[i],
+                bin_range=plot_bin_range,
+                x_label="Emissions (Kg Methane)",
+                y_label="Number of Occurrences",
+                bins=30,
+                legend_label=" ".join(
+                    [program_name, estimate_vs_true_constants.ESTIMATED_EMISSIONS_SUFFIX]
+                ),
+            )
+
+            plt.legend(handles=legend_elements[(i * 2) : (i * 2 + 2)])  # noqa: 481
+            save_path = out_dir / " ".join(
+                [
+                    program_name,
+                    output_constants.TRUE_AND_ESTIMATED_PAIRED_EMISSIONS_DISTRIBUTION_PLOT,
+                ]
+            )
+            plt.savefig(save_path)
+
+        if combine_plots:
+            plt.figure(comb_fig.number)
+            plot_hist(
+                legend_elements=legend_elements,
+                ax=comb_ax,
+                percent_diff_list=paired_emis_list[0],
+                program_name=program_name,
+                color=dark_pallete[i],
+                bin_range=plot_bin_range,
+                bins=30,
+                legend_label=" ".join(
+                    [program_name, estimate_vs_true_constants.TRUE_EMISSIONS_SUFFIX]
+                ),
+            )
+
+            plot_hist(
+                legend_elements=legend_elements,
+                ax=comb_ax,
+                percent_diff_list=paired_emis_list[1],
+                program_name=program_name,
+                color=light_pallete[i],
+                bin_range=plot_bin_range,
+                bins=30,
+                legend_label=" ".join(
+                    [program_name, estimate_vs_true_constants.ESTIMATED_EMISSIONS_SUFFIX]
+                ),
+            )
+
+    if combine_plots:
+        comb_ax.set(
+            xlabel="emissions (Kg Methane)",
+            ylabel="Number of Occurrences",
+        )
+        plt.legend(handles=legend_elements)
+        save_path = out_dir / output_constants.TRUE_AND_ESTIMATED_PAIRED_EMISSIONS_DISTRIBUTION_PLOT
+        plt.savefig(save_path)

--- a/LDAR_Sim/src/file_processing/output_processing/output_constants.py
+++ b/LDAR_Sim/src/file_processing/output_processing/output_constants.py
@@ -7,6 +7,17 @@ class ProgTsConstants:
 
 TS_SUMMARY_FILENAME = "daily_summary_stats.csv"
 EMIS_SUMMARY_FILENAME = "emissions_summary_stats.csv"
+TRUE_VS_ESTIMATED_PERCENT_DIFF_PLOT = "True_vs_Estimated_Emissions_percent_differences.png"
+TRUE_VS_ESTIMATED_RELATIVE_DIFF_PLOT = "True_vs_Estimated_Emissions_relative_differences.png"
+TRUE_AND_ESTIMATED_PAIRED_EMISSIONS_DISTRIBUTION_PLOT = (
+    "True_and_Estimated_Paired_Emissions_Distribution.png"
+)
+SUMMARY_PROGRAM_PLOTS_DIRECTORY = "program_summary_plots"
+
+
+class ESTIMATE_VS_TRUE_PLOTTING_CONSTANTS:
+    TRUE_EMISSIONS_SUFFIX = '"True" Total Emissions (Kg Methane)'
+    ESTIMATED_EMISSIONS_SUFFIX = '"Estimated" Total Emissions (Kg Methane)'
 
 
 class TS_SUMMARY_COLUMNS_ACCESSORS:

--- a/LDAR_Sim/src/file_processing/output_processing/output_constants.py
+++ b/LDAR_Sim/src/file_processing/output_processing/output_constants.py
@@ -1,3 +1,24 @@
+"""
+------------------------------------------------------------------------------
+Program:     The LDAR Simulator (LDAR-Sim)
+File:        output_constants.py
+Purpose: All output related constants.
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the MIT License as published
+by the Free Software Foundation, version 3.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+MIT License for more details.
+You should have received a copy of the MIT License
+along with this program.  If not, see <https://opensource.org/licenses/MIT>.
+
+------------------------------------------------------------------------------
+"""
+
+
 class ProgTsConstants:
     TITLE = "{name_str} Emissions Timeseries"
     X_AXIS_TITLE = "Date"
@@ -14,10 +35,13 @@ TRUE_AND_ESTIMATED_PAIRED_EMISSIONS_DISTRIBUTION_PLOT = (
 )
 SUMMARY_PROGRAM_PLOTS_DIRECTORY = "program_summary_plots"
 
+SUMMARRY_PLOT_GENERATION_MESSAGE = "Generating cross-program summary plots"
+
 
 class ESTIMATE_VS_TRUE_PLOTTING_CONSTANTS:
     TRUE_EMISSIONS_SUFFIX = '"True" Total Emissions (Kg Methane)'
     ESTIMATED_EMISSIONS_SUFFIX = '"Estimated" Total Emissions (Kg Methane)'
+    # TODO Look into ways to allow users to chose from a set of bin width options
     HISTOGRAM_BIN_WIDTH = 8.0
 
 

--- a/LDAR_Sim/src/file_processing/output_processing/output_constants.py
+++ b/LDAR_Sim/src/file_processing/output_processing/output_constants.py
@@ -1,0 +1,80 @@
+class ProgTsConstants:
+    TITLE = "{name_str} Emissions Timeseries"
+    X_AXIS_TITLE = "Date"
+    Y_AXIS_TITLE = "Daily Emissions (kg Methane)"
+    FILENAME = "Timeseries"
+
+
+TS_SUMMARY_FILENAME = "daily_summary_stats.csv"
+EMIS_SUMMARY_FILENAME = "emissions_summary_stats.csv"
+
+
+class TS_SUMMARY_COLUMNS_ACCESSORS:
+    PROG_NAME = "Program Name"
+    SIM = "Simulation"
+    AVG_T_DAILY_EMIS = 'Average "True" Daily Emissions (Kg Methane)'
+    AVG_T_MIT_DAILY_EMIS = 'Average "True" Mitigable Daily Emissions (Kg Methane)'
+    AVG_T_NON_MIT_DAILY_EMIS = 'Average "True" Non-Mitigable Daily Emissions (Kg Methane)'
+    T_DAILY_EMIS_95 = '95th Percentile "True" Daily Emissions (Kg Methane)'
+    T_MIT_DAILY_EMIS_95 = '95th Percentile "True" Mitigable Daily Emissions (Kg Methane)'
+    T_NON_MIT_DAILY_EMIS_95 = '95th Percentile "True" Non-Mitigable Daily Emissions (Kg Methane)'
+    T_DAILY_EMIS_5 = '5th Percentile "True" Daily Emissions (Kg Methane)'
+    T_MIT_DAILT_EMIS_5 = '5th Percentile "True" Mitigable Daily Emissions (Kg Methane)'
+    T_NON_MIT_DAILY_EMIS_5 = '5th Percentile "True" Non-Mitigable Daily Emissions (Kg Methane)'
+    AVG_DAILY_COST = "Average Daily Cost ($)"
+    DAILY_COST_95 = "95th Percentile Daily Cost ($)"
+    DAILY_COST_5 = "5th Percentile Daily Cost ($)"
+
+
+class EMIS_SUMMARY_COLUMNS_ACCESSORS:
+    PROG_NAME = "Program Name"
+    SIM = "Simulation"
+    T_TOTAL_EMIS = 'Total "True" Emissions (Kg Methane)'
+    EST_TOTAL_EMIS = 'Total "Estimated" Emissions (Kg Methane)'
+    T_TOTAL_MIT_EMIS = 'Total "True" Mitigable Emissions (Kg Methane)'
+    T_TOTAL_NON_MIT_EMIS = 'Total "True" Non-Mitigable Emissions (Kg Methane)'
+    AVG_T_EMIS_RATE = 'Average "True" Emissions Rate (g/s)'
+    T_EMIS_RATE_95 = '95th Percentile "True" Emissions Rate (g/s)'
+    T_EMIS_RATE_5 = '5th Percentile "True" Emissions Rate (g/s)'
+    T_AVG_EMIS_AMOUNT = '"True" Average Emissions Amount (Kg Methane)'
+    T_EMIS_AMOUNT_95 = '95th Percentile "True" Emissions Amount (Kg Methane)'
+    T_EMIS_AMOUNT_5 = '5th Percentile "True" Emissions Amount (Kg Methane)'
+    EST_AVG_EMIS_AMOUNT = '"Estimated" Average Emissions Amount (Kg Methane)'
+    EST_EMIS_AMOUNT_95 = '95th Percentile "Estimated" Emissions Amount (Kg Methane)'
+    EST_EMIS_AMOUNT_5 = '5th Percentile "Estimated" Emissions Amount (Kg Methane)'
+
+
+TS_SUMMARY_COLUMNS = [
+    TS_SUMMARY_COLUMNS_ACCESSORS.PROG_NAME,
+    TS_SUMMARY_COLUMNS_ACCESSORS.SIM,
+    TS_SUMMARY_COLUMNS_ACCESSORS.AVG_T_DAILY_EMIS,
+    TS_SUMMARY_COLUMNS_ACCESSORS.AVG_T_MIT_DAILY_EMIS,
+    TS_SUMMARY_COLUMNS_ACCESSORS.AVG_T_NON_MIT_DAILY_EMIS,
+    TS_SUMMARY_COLUMNS_ACCESSORS.T_DAILY_EMIS_95,
+    TS_SUMMARY_COLUMNS_ACCESSORS.T_MIT_DAILY_EMIS_95,
+    TS_SUMMARY_COLUMNS_ACCESSORS.T_NON_MIT_DAILY_EMIS_95,
+    TS_SUMMARY_COLUMNS_ACCESSORS.T_DAILY_EMIS_5,
+    TS_SUMMARY_COLUMNS_ACCESSORS.T_MIT_DAILT_EMIS_5,
+    TS_SUMMARY_COLUMNS_ACCESSORS.T_NON_MIT_DAILY_EMIS_5,
+    TS_SUMMARY_COLUMNS_ACCESSORS.AVG_DAILY_COST,
+    TS_SUMMARY_COLUMNS_ACCESSORS.DAILY_COST_95,
+    TS_SUMMARY_COLUMNS_ACCESSORS.DAILY_COST_5,
+]
+
+EMIS_SUMMARY_COLUMNS = [
+    EMIS_SUMMARY_COLUMNS_ACCESSORS.PROG_NAME,
+    EMIS_SUMMARY_COLUMNS_ACCESSORS.SIM,
+    EMIS_SUMMARY_COLUMNS_ACCESSORS.T_TOTAL_EMIS,
+    EMIS_SUMMARY_COLUMNS_ACCESSORS.EST_TOTAL_EMIS,
+    EMIS_SUMMARY_COLUMNS_ACCESSORS.T_TOTAL_MIT_EMIS,
+    EMIS_SUMMARY_COLUMNS_ACCESSORS.T_TOTAL_NON_MIT_EMIS,
+    EMIS_SUMMARY_COLUMNS_ACCESSORS.AVG_T_EMIS_RATE,
+    EMIS_SUMMARY_COLUMNS_ACCESSORS.T_EMIS_RATE_95,
+    EMIS_SUMMARY_COLUMNS_ACCESSORS.T_EMIS_RATE_5,
+    EMIS_SUMMARY_COLUMNS_ACCESSORS.T_AVG_EMIS_AMOUNT,
+    EMIS_SUMMARY_COLUMNS_ACCESSORS.T_EMIS_AMOUNT_95,
+    EMIS_SUMMARY_COLUMNS_ACCESSORS.T_EMIS_AMOUNT_5,
+    EMIS_SUMMARY_COLUMNS_ACCESSORS.EST_AVG_EMIS_AMOUNT,
+    EMIS_SUMMARY_COLUMNS_ACCESSORS.EST_EMIS_AMOUNT_95,
+    EMIS_SUMMARY_COLUMNS_ACCESSORS.EST_EMIS_AMOUNT_5,
+]

--- a/LDAR_Sim/src/file_processing/output_processing/output_constants.py
+++ b/LDAR_Sim/src/file_processing/output_processing/output_constants.py
@@ -18,6 +18,7 @@ SUMMARY_PROGRAM_PLOTS_DIRECTORY = "program_summary_plots"
 class ESTIMATE_VS_TRUE_PLOTTING_CONSTANTS:
     TRUE_EMISSIONS_SUFFIX = '"True" Total Emissions (Kg Methane)'
     ESTIMATED_EMISSIONS_SUFFIX = '"Estimated" Total Emissions (Kg Methane)'
+    HISTOGRAM_BIN_WIDTH = 8.0
 
 
 class TS_SUMMARY_COLUMNS_ACCESSORS:

--- a/LDAR_Sim/src/file_processing/output_processing/output_utils.py
+++ b/LDAR_Sim/src/file_processing/output_processing/output_utils.py
@@ -83,6 +83,15 @@ class TIMESERIES_COL_ACCESSORS:
     METH_DAILY_SURVEY_TIME = "{method} Survey Time (Minutes)"
 
 
+def percent_difference(a, b):
+    return abs(a - b) / ((a + b) / 2) * 100
+
+
+def percentage_formatter(x, pos):
+    x = x / 100
+    return f"{x:.0%}"
+
+
 @dataclass
 class TsEmisData:
     daily_emis: float = 0

--- a/LDAR_Sim/src/file_processing/output_processing/output_utils.py
+++ b/LDAR_Sim/src/file_processing/output_processing/output_utils.py
@@ -85,10 +85,14 @@ class TIMESERIES_COL_ACCESSORS:
 
 
 def percent_difference(a: float, b: float) -> float:
+    if a == 0 and b == 0:
+        return 0
     return abs(a - b) / ((a + b) / 2) * 100
 
 
 def relative_difference(aquired_value: float, true_value: float) -> float:
+    if true_value == 0:
+        return 0
     return (aquired_value - true_value) / true_value * 100
 
 

--- a/LDAR_Sim/src/file_processing/output_processing/output_utils.py
+++ b/LDAR_Sim/src/file_processing/output_processing/output_utils.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+from typing import Tuple
 from numpy import NaN
 
 
@@ -83,13 +84,27 @@ class TIMESERIES_COL_ACCESSORS:
     METH_DAILY_SURVEY_TIME = "{method} Survey Time (Minutes)"
 
 
-def percent_difference(a, b):
+def percent_difference(a: float, b: float) -> float:
     return abs(a - b) / ((a + b) / 2) * 100
 
 
-def percentage_formatter(x, pos):
+def relative_difference(aquired_value: float, true_value: float) -> float:
+    return (aquired_value - true_value) / true_value * 100
+
+
+def percentage_formatter(x: float, pos):
     x = x / 100
     return f"{x:.0%}"
+
+
+def luminance_shift(
+    color: Tuple[float, float, float], factor: float = 0.3, lighten: bool = True
+) -> Tuple[float, float, float]:
+    if not lighten:
+        factor = -factor
+        return (max(color[0] + factor, 0), max(color[1] + factor, 0), max(color[2] + factor, 0))
+    else:
+        return (min(color[0] + factor, 1), min(color[1] + factor, 1), min(color[2] + factor, 1))
 
 
 @dataclass

--- a/LDAR_Sim/src/file_processing/output_processing/output_visualization_constants.py
+++ b/LDAR_Sim/src/file_processing/output_processing/output_visualization_constants.py
@@ -1,5 +1,0 @@
-class ProgTsConstants:
-    TITLE = "{name_str} Emissions Timeseries"
-    X_AXIS_TITLE = "Date"
-    Y_AXIS_TITLE = "Daily Emissions (kg Methane)"
-    FILENAME = "Timeseries"

--- a/LDAR_Sim/src/file_processing/output_processing/program_specific_visualizations.py
+++ b/LDAR_Sim/src/file_processing/output_processing/program_specific_visualizations.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 import pandas as pd
 import matplotlib.pyplot as plt
-from file_processing.output_processing.output_visualization_constants import ProgTsConstants as pts
+from LDAR_Sim.src.file_processing.output_processing.output_constants import ProgTsConstants as pts
 from file_processing.output_processing.output_utils import TIMESERIES_COL_ACCESSORS as tca
 
 

--- a/LDAR_Sim/src/file_processing/output_processing/program_specific_visualizations.py
+++ b/LDAR_Sim/src/file_processing/output_processing/program_specific_visualizations.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 import pandas as pd
 import matplotlib.pyplot as plt
-from LDAR_Sim.src.file_processing.output_processing.output_constants import ProgTsConstants as pts
+from file_processing.output_processing.output_constants import ProgTsConstants as pts
 from file_processing.output_processing.output_utils import TIMESERIES_COL_ACCESSORS as tca
 
 

--- a/LDAR_Sim/src/ldar_sim_run.py
+++ b/LDAR_Sim/src/ldar_sim_run.py
@@ -27,6 +27,9 @@ import sys
 import shutil
 from pathlib import Path
 from datetime import date
+from file_processing.output_processing.multi_simulation_visualizations import (
+    gen_cross_program_summary_plots,
+)
 from file_processing.output_processing.multi_simulation_outputs import (
     concat_output_data,
 )
@@ -35,8 +38,6 @@ from file_processing.output_processing.multi_simulation_outputs import (
 from initialization.initialize_infrastructure import initialize_infrastructure
 from initialization.preseed import gen_seed_emis
 from virtual_world.infrastructure import Infrastructure
-from stdout_redirect import stdout_redirect
-from virtual_world.sites import Site
 from weather.daylight_calculator import DaylightCalculatorAve
 from weather.weather_lookup import WeatherLookup as WL
 from utils.file_name_constants import PARAMETER_FILE, GENERATOR_FOLDER
@@ -302,3 +303,4 @@ if __name__ == "__main__":
             # -- Batch Report --
             print(f"...Cleaning up batch {batch_count} data")
             concat_output_data(out_dir, batch_count != 0)
+    gen_cross_program_summary_plots(out_dir)

--- a/LDAR_Sim/src/ldar_sim_run.py
+++ b/LDAR_Sim/src/ldar_sim_run.py
@@ -303,4 +303,4 @@ if __name__ == "__main__":
             # -- Batch Report --
             print(f"...Cleaning up batch {batch_count} data")
             concat_output_data(out_dir, batch_count != 0)
-    gen_cross_program_summary_plots(out_dir)
+    gen_cross_program_summary_plots(out_dir, base_program)

--- a/LDAR_Sim/testing/unit_testing/test_file_processing/test_output_processing/test_multi_simulation_outputs/test_concat_output_data.py
+++ b/LDAR_Sim/testing/unit_testing/test_file_processing/test_output_processing/test_multi_simulation_outputs/test_concat_output_data.py
@@ -22,10 +22,12 @@ import os
 from pathlib import Path
 
 import pandas as pd
+from LDAR_Sim.src.file_processing.output_processing.output_constants import (
+    EMIS_SUMMARY_FILENAME,
+    TS_SUMMARY_FILENAME,
+)
 
 from src.file_processing.output_processing.multi_simulation_outputs import (  # noqa
-    TS_SUMMARY_FILENAME,
-    EMIS_SUMMARY_FILENAME,
     gen_ts_summary,
     TS_SUMMARY_COLUMNS_ACCESSORS as tsca,
     gen_emissions_summary,


### PR DESCRIPTION
# Pull Request Key Information

## Reason for change

Visualizations to communicate variation between simulated "estimated" and "true" emissions will greatly assist modellers in understanding the effectiveness of a measurement strategy

## What was changed

Added 3 visualizations to communicate "uncertainty" in a measurement strategy

1. The percentage difference between "estimated" and "true" emissions
2. The relative difference between "estimated" and "true" emissions
3. The paired distributions of "estimated" and "true" emissions

## Intended Purpose

Visualizations to assist in evaluating the performance of a measurement strategy

## Level of version change required

N/A

## Testing Completed

Manual testing.

## Target Issue

N/A

## Additional Information

N/A
