### PR TITLE
<FIX> EPR bug fix

### DIFF
--- a/LDAR_Sim/src/virtual_world/equipment_groups.py
+++ b/LDAR_Sim/src/virtual_world/equipment_groups.py
@@ -30,7 +30,7 @@ from file_processing.input_processing.emissions_source_processing import (
 )
 from scheduling.schedule_dataclasses import TaggingInfo
 from virtual_world.emissions import Emission
-from virtual_world.infrastructure_const import Infrastructure_Constants
+from virtual_world.infrastructure_const import Infrastructure_Constants as IC
 from virtual_world.equipment import Equipment
 
 
@@ -83,16 +83,23 @@ class Equipment_Group:
         prop_params["Method_Specific_Params"] = meth_specific_params
 
     def _create_equipment(self, infrastructure_inputs, prop_params, info) -> None:
+        tot_equip = info.sum()
+        nonrep_epr = prop_params[IC.Equipment_Group_File_Constants.NON_REP_EMIS_EPR]
+        rep_epr = prop_params[IC.Equipment_Group_File_Constants.REP_EMIS_EPR]
+        if nonrep_epr is not None and nonrep_epr > 0:
+            prop_params[IC.Equipment_Group_File_Constants.NON_REP_EMIS_EPR] = nonrep_epr / tot_equip
+        if rep_epr is not None and rep_epr > 0:
+            prop_params[IC.Equipment_Group_File_Constants.REP_EMIS_EPR] = rep_epr / tot_equip
         for col, val in info.items():
             for count in range(0, val):
                 self._equipment.append(Equipment(col, count, infrastructure_inputs, prop_params))
 
     def _set_method_specific_params(self, prop_params):
         self._meth_survey_times = prop_params["Method_Specific_Params"].pop(
-            Infrastructure_Constants.Equipment_Group_File_Constants.SURVEY_TIME_PLACEHOLDER
+            IC.Equipment_Group_File_Constants.SURVEY_TIME_PLACEHOLDER
         )
         self._meth_survey_costs = prop_params["Method_Specific_Params"].pop(
-            Infrastructure_Constants.Equipment_Group_File_Constants.SURVEY_COST_PLACEHOLDER
+            IC.Equipment_Group_File_Constants.SURVEY_COST_PLACEHOLDER
         )
 
     def generate_emissions(

--- a/LDAR_Sim/src/virtual_world/sites.py
+++ b/LDAR_Sim/src/virtual_world/sites.py
@@ -144,6 +144,7 @@ class Site:
             equipment_groups = split_eqgs
         if isinstance(equipment_groups, list) and len(equipment_groups) > 0:
             equip_groups_in: pd.DataFrame = infrastructure_inputs["equipment"]
+            equip_count = len(equipment_groups)
             for equipment_group in equipment_groups:
                 site_equipment_group = equip_groups_in.loc[
                     equip_groups_in[
@@ -152,6 +153,16 @@ class Site:
                     == equipment_group
                 ].iloc[0]
                 prop_params = copy.deepcopy(propagating_params)
+                prop_params[Infrastructure_Constants.Sites_File_Constants.REP_EMIS_EPR] = (
+                    propagating_params[Infrastructure_Constants.Sites_File_Constants.REP_EMIS_EPR]
+                    / equip_count
+                )
+                prop_params[Infrastructure_Constants.Sites_File_Constants.NON_REP_EMIS_EPR] = (
+                    propagating_params[
+                        Infrastructure_Constants.Sites_File_Constants.NON_REP_EMIS_EPR
+                    ]
+                    / equip_count
+                )
                 self._equipment_groups.append(
                     Equipment_Group(
                         site_equipment_group[
@@ -239,6 +250,14 @@ class Site:
                     {placeholder: math.ceil(equip_count / equipment_groups)}
                 )
                 prop_params = copy.deepcopy(propagating_params)
+                if rep_emis_epr is not None and rep_emis_epr > 0:
+                    prop_params[Infrastructure_Constants.Sites_File_Constants.REP_EMIS_EPR] = (
+                        rep_emis_epr / equipment_groups
+                    )
+                if nonrep_emis_epr is not None and nonrep_emis_epr > 0:
+                    prop_params[Infrastructure_Constants.Sites_File_Constants.NON_REP_EMIS_EPR] = (
+                        nonrep_emis_epr / equipment_groups
+                    )
                 self._equipment_groups.append(
                     Equipment_Group(i, infrastructure_inputs, prop_params, equip_group_info)
                 )


### PR DESCRIPTION
# Pull Request Key Information

## Reason for change

Site level and Equipment level EPR did not properly get updated as lower level components were made. This inflated the EPR and resulted in more emissions than expected.

## What was changed

Change EPR to account for additional components as they are made.

## Testing Completed

Manually checked the following cases for the EPR used to create the emissions:
- The source file specified the EPR
- Virtual world parameter was the only place EPR was specified
- Virtual world and source file both specified the EPR
