### PR TITLE
<UPD> Update version handling

### DIFF
--- a/LDAR_Sim/src/file_processing/input_processing/input_manager.py
+++ b/LDAR_Sim/src/file_processing/input_processing/input_manager.py
@@ -40,6 +40,7 @@ from initialization.versioning import (
     CURRENT_MINOR_VERSION,
     LEGACY_PARAMETER_WARNING,
     MAJOR_VERSION_ONLY_WARNING,
+    NEWER_PARAMETER_WARNING,
     MINOR_VERSION_MISMATCH_WARNING,
     check_major_version,
 )
@@ -148,12 +149,19 @@ class InputManager:
                 if str(parameters["version"]) == CURRENT_MAJOR_VERSION:
                     print(MAJOR_VERSION_ONLY_WARNING)
                     sys.exit()
-                elif not check_major_version(str(parameters["version"]), CURRENT_MAJOR_VERSION):
-                    print(LEGACY_PARAMETER_WARNING)
-                    sys.exit()
                 else:
-                    print(MINOR_VERSION_MISMATCH_WARNING)
-                    self.old_params = True
+                    major_version_check = check_major_version(
+                        str(parameters["version"]), CURRENT_MAJOR_VERSION
+                    )
+                    if major_version_check == 1:
+                        print(NEWER_PARAMETER_WARNING)
+                        sys.exit()
+                    elif major_version_check == -1:
+                        print(LEGACY_PARAMETER_WARNING)
+                        sys.exit()
+                    else:
+                        print(MINOR_VERSION_MISMATCH_WARNING)
+                        self.old_params = True
         return
 
     def map_simulation_settings(self, parameters) -> None:

--- a/LDAR_Sim/src/initialization/versioning.py
+++ b/LDAR_Sim/src/initialization/versioning.py
@@ -21,8 +21,15 @@
 
 def check_major_version(version_string, major_version):
     try:
-        major_part, minor_part = map(str, version_string.split("."))
-        return major_part == major_version
+        major_part, _ = map(int, version_string.split("."))
+        major_version = int(major_version)
+
+        if major_part < major_version:
+            return -1
+        elif major_part == major_version:
+            return 0
+        else:
+            return 1
     except ValueError:
         return False
 
@@ -42,7 +49,21 @@ LEGACY_PARAMETER_WARNING = (
     "See https://github.com/LDAR-Sim/LDAR_Sim/blob/master/changelog.md"
     " to find a record of what has changed with LDAR-Sim\n"
 )
-
+NEWER_PARAMETER_WARNING = (
+    "\nLDAR-Sim has detected an attempt to run a simulation model"
+    " with newer parameter files. \n\n"
+    "If the goal is to reproduce previously modelled results "
+    "using newer parameters, please download the newer version "
+    "of LDAR-Sim compatible with newer parameters.\n"
+    "Versioned releases can be found at: https://github.com/LDAR-Sim/LDAR_Sim/releases.\n\n"
+    "Otherwise, please visit: "
+    "https://github.com/LDAR-Sim/LDAR_Sim/blob/master/ParameterMigrationGuide.md"
+    " for guidance on how to update parameter files to the other versions.\n"
+    "Please rerun the model once you have successfully"
+    " migrated your parameters to the correct version. \n\n"
+    "See https://github.com/LDAR-Sim/LDAR_Sim/blob/master/changelog.md"
+    " to find a record of what has changed with LDAR-Sim\n"
+)
 MINOR_VERSION_MISMATCH_WARNING = (
     "\nLDAR-Sim has detected an attempt to run a simulation model"
     " with out of date parameter files. \n\n"


### PR DESCRIPTION
# Pull Request Key Information

## Reason for change

The original version handling did not take into account if users were using parameters that were newer versions than the simulator itself. It always outputs that the version of parameters are legacy versions compared to the simulator if the major versions do not match.

## What was changed

Version handling correct message based on version comparison

## Intended Purpose

Update the version handling to check for newer/older versions before outputting the corresponding message.

## Testing Completed

Manual testing using parameter files set to higher and lower version numbers
