### PR TITLE
fix: Improve attribution of measured rates

### DIFF
--- a/LDAR_Sim/src/virtual_world/equipment.py
+++ b/LDAR_Sim/src/virtual_world/equipment.py
@@ -209,10 +209,12 @@ class Equipment:
         return emis_data
 
     def tag_emissions(self, tagging_info: TaggingInfo) -> None:
+        # TODO improve this logic
+        emission_rate = tagging_info.measured_rate / len(self._active_emissions)
         for emission in self._active_emissions:
             if isinstance(emission, FugitiveEmission):
                 emission.tag_leak(
-                    measured_rate=tagging_info.measured_rate,
+                    measured_rate=emission_rate,
                     cur_date=tagging_info.curr_date,
                     t_since_ldar=tagging_info.t_since_LDAR,
                     company=tagging_info.company,
@@ -224,7 +226,7 @@ class Equipment:
                 )
             elif isinstance(emission, NonRepairableEmission):
                 emission.record_emission(
-                    measured_rate=tagging_info.measured_rate,
+                    measured_rate=emission_rate,
                     cur_date=tagging_info.curr_date,
                     t_since_ldar=tagging_info.t_since_LDAR,
                     company=tagging_info.company,

--- a/LDAR_Sim/testing/unit_testing/test_virtual_world/test_equipment/test_tag_emissions.py
+++ b/LDAR_Sim/testing/unit_testing/test_virtual_world/test_equipment/test_tag_emissions.py
@@ -1,0 +1,88 @@
+"""
+------------------------------------------------------------------------------
+Program:     The LDAR Simulator (LDAR-Sim)
+File:        test_tag_emissions.py
+Purpose: Testing for the Equipment class tag_emissions method.
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the MIT License as published
+by the Free Software Foundation, version 3.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+MIT License for more details.
+You should have received a copy of the MIT License
+along with this program.  If not, see <https://opensource.org/licenses/MIT>.
+
+------------------------------------------------------------------------------
+"""
+
+from datetime import date
+from src.virtual_world.equipment import (
+    Equipment,
+    TaggingInfo,
+    FugitiveEmission,
+    NonRepairableEmission,
+)
+
+
+def mock_active_emissions(emis_count: int = 3):
+    active_emissions = []
+    for i in range(emis_count):
+        active_emissions.append(FugitiveEmission())
+    for i in range(emis_count):
+        active_emissions.append(NonRepairableEmission())
+    return active_emissions
+
+
+def mock_tagging_info():
+    return TaggingInfo(
+        measured_rate=10,
+        curr_date=date(2024, 1, 1),
+        t_since_LDAR=5,
+        company="Test Company",
+        crew="Test Crew",
+        report_delay=0,
+    )
+
+
+def mock_fugitive_emission_init(self, *args, **kwargs):
+    self._tagged = False
+    self._init_detect_by = None
+
+
+def mock_non_rep_emission_init(self, *args, **kwargs):
+    self._record = False
+    self._init_detect_by = None
+
+
+def mock_equipment_init(self, *args, **kwargs):
+    self._active_emissions = kwargs["emissions"] if kwargs else []
+
+
+def setup_mock_equipment(mocker):
+    mocker.patch.object(FugitiveEmission, "__init__", mock_fugitive_emission_init)
+    mocker.patch.object(NonRepairableEmission, "__init__", mock_non_rep_emission_init)
+    mocker.patch.object(Equipment, "__init__", mock_equipment_init)
+
+
+def test_tag_emissions_with_multiple_emissions(mocker):
+    setup_mock_equipment(mocker)
+    emissions = mock_active_emissions()
+    mock_equipment = Equipment(emissions=emissions)
+    tagging_info = mock_tagging_info()
+    expected_rates = tagging_info.measured_rate / len(emissions)
+    mock_equipment.tag_emissions(tagging_info=tagging_info)
+
+    for emission in emissions:
+        if isinstance(emission, FugitiveEmission):
+            assert emission._tagged
+            assert emission._tagged_by_company == "Test Company"
+            assert emission._tagged_by_crew == "Test Crew"
+            assert emission._measured_rate == expected_rates
+        elif isinstance(emission, NonRepairableEmission):
+            assert emission._record
+            assert emission._recorded_by_company == "Test Company"
+            assert emission._recorded_by_crew == "Test Crew"
+            assert emission._measured_rate == expected_rates


### PR DESCRIPTION
# Pull Request Key Information

## Reason for change

Previously, all emissions at a component were attributed the total measured rate at the component.

## What was changed

This change now divides the measured rate by the number of emissions before attributing a rate to each emission.

## Intended Purpose

Improve emissions attribution in modelling

## Level of version change required

N/A

## Testing Completed

Added new unit test and manual testing

## Target Issue

N/A

## Additional Information

N/A
