### PR TITLE
fix: prevent type error in site initialization

### DIFF
--- a/LDAR_Sim/src/virtual_world/sites.py
+++ b/LDAR_Sim/src/virtual_world/sites.py
@@ -160,16 +160,21 @@ class Site:
                     == equipment_group
                 ].iloc[0]
                 prop_params = copy.deepcopy(propagating_params)
-                prop_params[Infrastructure_Constants.Sites_File_Constants.REP_EMIS_EPR] = (
-                    propagating_params[Infrastructure_Constants.Sites_File_Constants.REP_EMIS_EPR]
-                    / equip_count
-                )
-                prop_params[Infrastructure_Constants.Sites_File_Constants.NON_REP_EMIS_EPR] = (
-                    propagating_params[
+                if (
+                    prop_params[Infrastructure_Constants.Sites_File_Constants.REP_EMIS_EPR]
+                    is not None
+                ):
+                    prop_params[
+                        Infrastructure_Constants.Sites_File_Constants.REP_EMIS_EPR
+                    ] /= equip_count
+                if (
+                    prop_params[Infrastructure_Constants.Sites_File_Constants.NON_REP_EMIS_EPR]
+                    is not None
+                ):
+                    prop_params[
                         Infrastructure_Constants.Sites_File_Constants.NON_REP_EMIS_EPR
-                    ]
-                    / equip_count
-                )
+                    ] /= equip_count
+
                 self._equipment_groups.append(
                     Equipment_Group(
                         site_equipment_group[


### PR DESCRIPTION
# Pull Request Key Information

## Reason for change

Previously a type error would occur when initializing equipment at a site where the production rate was set at the equipment level or lower. This prevent valid infrastructure configurations from being used.

## What was changed

Added logic to handle equipment initialization if no LPR is present yet in the propagating parameters.

## Intended Purpose

Bugfix

## Level of version change required

N/A

## Testing Completed

Manual testing

## Target Issue

N/A

## Additional Information

N/A
