### PR TITLE
Fix: Fix summary files overwrite bug

### DIFF
--- a/LDAR_Sim/src/file_processing/output_processing/summary_output_manager.py
+++ b/LDAR_Sim/src/file_processing/output_processing/summary_output_manager.py
@@ -80,7 +80,7 @@ class SummaryOutputManager:
         legacy_outputs: dict[str, pd.DataFrame] = {}
         for summary_output in self._summary_outputs_to_make:
             legacy_outputs[summary_output] = summary_output_helpers.get_summary_file(
-                self._output_path, summary_output
+                self._output_path, summary_output + ".csv"
             )
         return legacy_outputs
 


### PR DESCRIPTION
# Pull Request Key Information

## Reason for change

Previously only simulation summary data from the most recent batch of simulations was being saved to the summary files. This was due to an overwrite bug in the summary_output_manager.py file where legacy summary data was not being properly retrieved and thus overwritten.

## What was changed

Changed get legacy summary data to properly retrieve legacy summary data.

## Intended Purpose

Bugfix

## Level of version change required

N/A

## Testing Completed

Manual

## Target Issue

N/A

## Additional Information

N/A
