### PR TITLE
Add Probit plots

### DIFF
--- a/LDAR_Sim/src/constants/output_file_constants.py
+++ b/LDAR_Sim/src/constants/output_file_constants.py
@@ -98,6 +98,7 @@ class ProbitConstants:
     BEST_FIT_LINE_STYLE = "--"
     PLOTTING_POSITION_ALPHA = 1.0 / 3.0
     PLOTTING_POSITION_BETA = 1.0 / 3.0
+    QUANTILES = [1, 2, 5, 10, 20, 30, 40, 50, 60, 70, 80, 90, 95, 98, 99]
 
 
 class HistogramConstants:

--- a/LDAR_Sim/src/constants/output_file_constants.py
+++ b/LDAR_Sim/src/constants/output_file_constants.py
@@ -31,6 +31,7 @@ class FileNames:
     TRUE_AND_ESTIMATED_PAIRED_EMISSIONS_DISTRIBUTION_PLOT = (
         "True_and_Estimated_Paired_Emissions_Distribution"
     )
+    TRUE_AND_ESTIMATED_PAIRED_PROBIT_PLOT = "True and Estimated Emissions Probit"
 
 
 @dataclass
@@ -57,6 +58,19 @@ class SummaryFileColumns:
 class SummaryVisualizationStatistics:
     PERCENT_DIFFERENCE = "Percent Difference"
     RELATIVE_DIFFERENCE = "Relative Difference"
+
+
+class PlottingConstants:
+    AXIS_COLOR = "black"
+
+
+class ProbitConstants:
+    X_AXIS_LABEL = "Total Annual Emissions (Kg Methane) at all {n_sites} sites"
+    Y_AXIS_LABEL = (
+        "Probability of observing Total Annual Emissions \n at all {n_sites} sites greater than x"
+    )
+    TRUE_EMISSIONS_SUFFIX = '"True" Total Emissions'
+    ESTIMATED_EMISSIONS_SUFFIX = '"Estimated" Total Emissions'
 
 
 class HistogramConstants:

--- a/LDAR_Sim/src/constants/output_file_constants.py
+++ b/LDAR_Sim/src/constants/output_file_constants.py
@@ -25,7 +25,8 @@ class FileDirectory:
     SUMMARY_PROGRAM_PLOTS_DIRECTORY = "program_summary_plots"
 
 
-class FileNames:
+@dataclass
+class SummaryOutputVizFileNames:
     TRUE_VS_ESTIMATED_PERCENT_DIFF_PLOT = "True_vs_Estimated_Emissions_percent_differences"
     TRUE_VS_ESTIMATED_RELATIVE_DIFF_PLOT = "True_vs_Estimated_Emissions_relative_differences"
     TRUE_AND_ESTIMATED_PAIRED_EMISSIONS_DISTRIBUTION_PLOT = (
@@ -33,12 +34,30 @@ class FileNames:
     )
     TRUE_AND_ESTIMATED_PAIRED_PROBIT_PLOT = "True and Estimated Emissions Probit"
 
+    def __iter__(self):
+        for attr_name, attr_value in vars(self.__class__).items():
+            if not callable(attr_value) and not attr_name.startswith("__"):
+                yield attr_value
+
+
+@dataclass
+class SummaryVisualizationSettingsMapper:
+    class TrueEstimatedProbitSettings:
+        SHOW_MARKERS = "Show Markers"
+
+    MAPPINGS = {
+        SummaryOutputVizFileNames.TRUE_AND_ESTIMATED_PAIRED_PROBIT_PLOT: {
+            TrueEstimatedProbitSettings.SHOW_MARKERS: "show_markers"
+        },
+    }
+
 
 @dataclass
 class OutputConfigCategories:
     PROGRAM_OUTPUTS = "Program Outputs"
     SUMMARY_OUTPUTS = "Summary Outputs"
     SUMMARY_VISUALIZATIONS = "Summary Visualizations"
+    SUMMARY_VISUALIZATION_SETTINGS = "Summary Visualization Settings"
 
     @dataclass
     class SummaryOutputCatageories:
@@ -71,6 +90,14 @@ class ProbitConstants:
     )
     TRUE_EMISSIONS_SUFFIX = '"True" Total Emissions'
     ESTIMATED_EMISSIONS_SUFFIX = '"Estimated" Total Emissions'
+    Y_SCALE = "quantile"
+    X_SCALE = "log"
+    MARKER = "d"
+    X_LABEL_SIZE = 8
+    X_TICK_ROTATION = 45
+    BEST_FIT_LINE_STYLE = "--"
+    PLOTTING_POSITION_ALPHA = 1.0 / 3.0
+    PLOTTING_POSITION_BETA = 1.0 / 3.0
 
 
 class HistogramConstants:

--- a/LDAR_Sim/src/constants/param_default_const.py
+++ b/LDAR_Sim/src/constants/param_default_const.py
@@ -157,7 +157,7 @@ class Output_Params:
     PROGRAM_EMISSIONS = "Program Emissions"
     PROGRAM_TIMESERIES = "Program Timeseries"
     SUMMARY_OUTPUTS = "Summary Outputs"
-    SUMMARY_OUTPUT_SETTINGS = "Summary Output Settings"
+    SUMMARY_VISUALIZATION_SETTINGS = "Summary Visualization Settings"
     SUMMARY_FILES = "Summary Files"
     TIMESERIES_SUMMARY = "Timeseries Summary"
     EMISSIONS_SUMMARY = "Emissions Summary"

--- a/LDAR_Sim/src/constants/param_default_const.py
+++ b/LDAR_Sim/src/constants/param_default_const.py
@@ -157,6 +157,7 @@ class Output_Params:
     PROGRAM_EMISSIONS = "Program Emissions"
     PROGRAM_TIMESERIES = "Program Timeseries"
     SUMMARY_OUTPUTS = "Summary Outputs"
+    SUMMARY_OUTPUT_SETTINGS = "Summary Output Settings"
     SUMMARY_FILES = "Summary Files"
     TIMESERIES_SUMMARY = "Timeseries Summary"
     EMISSIONS_SUMMARY = "Emissions Summary"
@@ -193,3 +194,4 @@ class Output_Params:
     EMISSIONS_SUMMARY_AVERAGE_AMOUNT = 'Average "True" Emissions Amount (Kg Methane)'
     EMISSIONS_SUMMARY_PERCENTILE_95_AMOUNT = '95th Percentile "True" Emissions Amount (Kg Methane)'
     EMISSIONS_SUMMARY_PERCENTILE_5_AMOUNT = '5th Percentile "True" Emissions Amount (Kg Methane)'
+    SHOW_MARKERS = "Show Markers"

--- a/LDAR_Sim/src/default_parameters/outputs_default.yml
+++ b/LDAR_Sim/src/default_parameters/outputs_default.yml
@@ -36,3 +36,4 @@ Summary Visualizations:
   True_vs_Estimated_Emissions_percent_differences: true
   True_vs_Estimated_Emissions_relative_differences: true
   True_and_Estimated_Paired_Emissions_Distribution: true
+  True and Estimated Emissions Probit: true

--- a/LDAR_Sim/src/default_parameters/outputs_default.yml
+++ b/LDAR_Sim/src/default_parameters/outputs_default.yml
@@ -37,3 +37,6 @@ Summary Visualizations:
   True_vs_Estimated_Emissions_relative_differences: true
   True_and_Estimated_Paired_Emissions_Distribution: true
   True and Estimated Emissions Probit: true
+Summary Visualization Settings:
+  True and Estimated Emissions Probit: 
+    Show Markers: true

--- a/LDAR_Sim/src/file_processing/input_processing/input_manager.py
+++ b/LDAR_Sim/src/file_processing/input_processing/input_manager.py
@@ -235,7 +235,7 @@ class InputManager:
                     default_output_params = yaml.load(f.read(), Loader=yaml.SafeLoader)
                 check_types(default_output_params, new_parameters)
                 new_outputs = copy.deepcopy(default_output_params)
-                self.retain_update(default_output_params, new_parameters)
+                self.retain_update(new_outputs, new_parameters)
                 self.simulation_parameters[pc.Levels.OUTPUTS] = new_outputs
             else:
                 sys.exit(

--- a/LDAR_Sim/src/file_processing/output_processing/scaling.py
+++ b/LDAR_Sim/src/file_processing/output_processing/scaling.py
@@ -1,0 +1,57 @@
+import matplotlib.scale as mscale
+import matplotlib.ticker
+import numpy as np
+from scipy import stats
+
+
+class QuantileFormatter(matplotlib.ticker.Formatter):
+    def __call__(self, x, pos=None):
+        formatted_number = "{:.2f}".format((1 - x) * 100)
+        return formatted_number
+
+
+class QuantileScale(mscale.ScaleBase):
+    name = "quantile"
+
+    def __init__(self, axis, **kwargs):
+        mscale.ScaleBase.__init__(self, axis)
+        self.dist = stats.distributions.norm
+        self._transform = self.ProbabilityTransform()
+
+    def _get_quantiles(self):
+        return np.array([1, 2, 5, 10, 20, 30, 40, 50, 60, 70, 80, 90, 95, 98, 99]) / 100.0
+
+    def get_transform(self):
+        return self._transform
+
+    def set_default_locators_and_formatters(self, axis) -> None:
+        axis.set_major_locator(matplotlib.ticker.FixedLocator(self._get_quantiles()))
+        axis.set_major_formatter(matplotlib.ticker.FuncFormatter(QuantileFormatter()))
+        axis.set_minor_locator(matplotlib.ticker.NullLocator())
+        axis.set_minor_formatter(matplotlib.ticker.NullFormatter())
+
+    class ProbabilityTransform(mscale.Transform):
+        input_dims = 1
+        output_dims = 1
+        is_separable = True
+        has_inverse = True
+
+        def transform_non_affine(self, a):
+            a = np.ma.masked_where(~np.isfinite(a), a)
+            return np.ma.filled(stats.norm.ppf(a), -np.inf)
+
+        def inverted(self):
+            return QuantileScale.QuantileTransform()
+
+    class QuantileTransform(mscale.Transform):
+        input_dims = 1
+        output_dims = 1
+        is_separable = True
+        has_inverse = True
+
+        def transform_non_affine(self, a):
+            a = np.ma.masked_invalid(a)
+            return np.ma.filled(stats.norm.cdf(a), 0.0)
+
+        def inverted(self):
+            return QuantileScale.ProbabilityTransform()

--- a/LDAR_Sim/src/file_processing/output_processing/scaling.py
+++ b/LDAR_Sim/src/file_processing/output_processing/scaling.py
@@ -2,6 +2,7 @@ import matplotlib.scale as mscale
 import matplotlib.ticker
 import numpy as np
 from scipy import stats
+from constants.output_file_constants import ProbitConstants
 
 
 class QuantileFormatter(matplotlib.ticker.Formatter):
@@ -19,7 +20,7 @@ class QuantileScale(mscale.ScaleBase):
         self._transform = self.ProbabilityTransform()
 
     def _get_quantiles(self):
-        return np.array([1, 2, 5, 10, 20, 30, 40, 50, 60, 70, 80, 90, 95, 98, 99]) / 100.0
+        return np.array(ProbitConstants.QUANTILES) / 100.0
 
     def get_transform(self):
         return self._transform

--- a/LDAR_Sim/src/file_processing/output_processing/summary_visualization_helpers.py
+++ b/LDAR_Sim/src/file_processing/output_processing/summary_visualization_helpers.py
@@ -209,3 +209,27 @@ def calculate_histogram_bin_range(
     else:
         min_val: float = histogram_properties["bin_range"][0]
     histogram_properties["bin_range"] = (min_val, max_val)
+
+
+def format_major_minor_ticks_log_scale(base: int, min_val: float, max_val: float):
+    # Calculate the number of major ticks
+    number_major_ticks = int(max_val - min_val + 1)
+
+    # Calculate the number of minor ticks per major interval
+    number_minor_ticks = int((max_val - min_val + 1) * 2)
+
+    if number_major_ticks > 10:
+        major_subs = np.arange(1, base, 2)
+    else:
+        major_subs = np.arange(1, base)
+
+    if number_minor_ticks > 10:
+        minor_subs = np.arange(1, base, 1)
+    else:
+        minor_subs = np.arange(1, base, 0.5)
+
+    # Create the major and minor locators
+    major_locator = ticker.LogLocator(base=base, subs=major_subs)
+    minor_locator = ticker.LogLocator(base=base, subs=minor_subs)
+
+    return major_locator, minor_locator

--- a/LDAR_Sim/src/file_processing/output_processing/summary_visualization_manager.py
+++ b/LDAR_Sim/src/file_processing/output_processing/summary_visualization_manager.py
@@ -32,16 +32,18 @@ from file_processing.output_processing.summary_visualization_mapper import (
 
 class SummaryVisualizationManager:
     OUTPUT_VISUALIZATION_FUNCTIONS_MAP = {
-        output_file_constants.FileNames.TRUE_VS_ESTIMATED_PERCENT_DIFF_PLOT: (
+        output_file_constants.SummaryOutputVizFileNames.TRUE_VS_ESTIMATED_PERCENT_DIFF_PLOT: (
             summary_visualizations.gen_estimated_vs_true_emissions_percent_difference_plot
         ),
-        output_file_constants.FileNames.TRUE_VS_ESTIMATED_RELATIVE_DIFF_PLOT: (
+        output_file_constants.SummaryOutputVizFileNames.TRUE_VS_ESTIMATED_RELATIVE_DIFF_PLOT: (
             summary_visualizations.gen_estimated_vs_true_emissions_relative_difference_plot
         ),
-        output_file_constants.FileNames.TRUE_AND_ESTIMATED_PAIRED_EMISSIONS_DISTRIBUTION_PLOT: (
+        (
+            output_file_constants.SummaryOutputVizFileNames
+        ).TRUE_AND_ESTIMATED_PAIRED_EMISSIONS_DISTRIBUTION_PLOT: (
             summary_visualizations.gen_true_and_estimated_paired_emissions_distribution_plot
         ),
-        output_file_constants.FileNames.TRUE_AND_ESTIMATED_PAIRED_PROBIT_PLOT: (
+        output_file_constants.SummaryOutputVizFileNames.TRUE_AND_ESTIMATED_PAIRED_PROBIT_PLOT: (
             summary_visualizations.gen_true_and_estimated_paired_probit_plot
         ),
     }
@@ -59,6 +61,12 @@ class SummaryVisualizationManager:
         )
         self._visualization_mapper: SummaryVisualizationMapper = SummaryVisualizationMapper(
             site_count
+        )
+
+        self._visualization_mapper.update_with_user_defined_summary_settings(
+            output_config[
+                output_file_constants.OutputConfigCategories.SUMMARY_VISUALIZATION_SETTINGS
+            ]
         )
 
     def gen_visualizations(self):

--- a/LDAR_Sim/src/file_processing/output_processing/summary_visualization_manager.py
+++ b/LDAR_Sim/src/file_processing/output_processing/summary_visualization_manager.py
@@ -41,6 +41,9 @@ class SummaryVisualizationManager:
         output_file_constants.FileNames.TRUE_AND_ESTIMATED_PAIRED_EMISSIONS_DISTRIBUTION_PLOT: (
             summary_visualizations.gen_true_and_estimated_paired_emissions_distribution_plot
         ),
+        output_file_constants.FileNames.TRUE_AND_ESTIMATED_PAIRED_PROBIT_PLOT: (
+            summary_visualizations.gen_true_and_estimated_paired_probit_plot
+        ),
     }
 
     def __init__(

--- a/LDAR_Sim/src/file_processing/output_processing/summary_visualization_mapper.py
+++ b/LDAR_Sim/src/file_processing/output_processing/summary_visualization_mapper.py
@@ -77,11 +77,41 @@ class SummaryVisualizationMapper:
             ),
         }
 
+        self._probit_properties_lookup = {
+            output_file_constants.FileNames.TRUE_AND_ESTIMATED_PAIRED_PROBIT_PLOT: {
+                "probit0": {
+                    "x_label": output_file_constants.ProbitConstants.X_AXIS_LABEL.format(
+                        n_sites=site_count
+                    ),
+                    "y_label": output_file_constants.ProbitConstants.Y_AXIS_LABEL.format(
+                        n_sites=site_count
+                    ),
+                    "legend_label": (
+                        output_file_constants.ESTIMATE_VS_TRUE_PLOTTING_CONSTANTS
+                    ).TRUE_EMISSIONS_SUFFIX,
+                },
+                "probit1": {
+                    "x_label": output_file_constants.ProbitConstants.X_AXIS_LABEL.format(
+                        n_sites=site_count
+                    ),
+                    "y_label": output_file_constants.ProbitConstants.Y_AXIS_LABEL.format(
+                        n_sites=site_count
+                    ),
+                    "legend_label": (
+                        output_file_constants.ESTIMATE_VS_TRUE_PLOTTING_CONSTANTS
+                    ).ESTIMATED_EMISSIONS_SUFFIX,
+                },
+            }
+        }
+
     def get_summary_stat_function(self, stat_type: str):
         return self._summary_stat_functions.get(stat_type)
 
     def get_histogram_properties(self, visualization_name: str):
         return self._histogram_properties_lookup.get(visualization_name)
+
+    def get_probit_properties(self, visualization_name: str):
+        return self._probit_properties_lookup.get(visualization_name)
 
     def get_x_axis_formatter(self, visualization_name: str):
         return self._axis_formatter_lookup.get(visualization_name)

--- a/LDAR_Sim/src/file_processing/output_processing/summary_visualization_mapper.py
+++ b/LDAR_Sim/src/file_processing/output_processing/summary_visualization_mapper.py
@@ -1,3 +1,4 @@
+from typing import Any
 from matplotlib import ticker
 from file_processing.output_processing import output_utils
 from file_processing.output_processing.output_utils import percent_difference, relative_difference
@@ -16,7 +17,7 @@ class SummaryVisualizationMapper:
         }
 
         self._histogram_properties_lookup = {
-            output_file_constants.FileNames.TRUE_VS_ESTIMATED_PERCENT_DIFF_PLOT: {
+            output_file_constants.SummaryOutputVizFileNames.TRUE_VS_ESTIMATED_PERCENT_DIFF_PLOT: {
                 "hist0": {
                     "bin_width": (
                         (
@@ -30,7 +31,7 @@ class SummaryVisualizationMapper:
                     "y_label": output_file_constants.HistogramConstants.Y_AXIS_LABEL,
                 }
             },
-            output_file_constants.FileNames.TRUE_VS_ESTIMATED_RELATIVE_DIFF_PLOT: {
+            output_file_constants.SummaryOutputVizFileNames.TRUE_VS_ESTIMATED_RELATIVE_DIFF_PLOT: {
                 "hist0": {
                     "bin_width": (
                         (
@@ -43,7 +44,9 @@ class SummaryVisualizationMapper:
                     "x_locator": ticker.MaxNLocator(nbins="auto", prune=None),
                 }
             },
-            output_file_constants.FileNames.TRUE_AND_ESTIMATED_PAIRED_EMISSIONS_DISTRIBUTION_PLOT: {
+            (
+                output_file_constants.SummaryOutputVizFileNames
+            ).TRUE_AND_ESTIMATED_PAIRED_EMISSIONS_DISTRIBUTION_PLOT: {
                 "hist0": {
                     "x_label": output_file_constants.HistogramConstants.X_AXIS_LABEL_PAIRED.format(
                         n_sites=site_count
@@ -69,16 +72,16 @@ class SummaryVisualizationMapper:
             },
         }
         self._axis_formatter_lookup = {
-            output_file_constants.FileNames.TRUE_VS_ESTIMATED_RELATIVE_DIFF_PLOT: (
+            output_file_constants.SummaryOutputVizFileNames.TRUE_VS_ESTIMATED_RELATIVE_DIFF_PLOT: (
                 ticker.FuncFormatter(output_utils.percentage_formatter)
             ),
-            output_file_constants.FileNames.TRUE_VS_ESTIMATED_PERCENT_DIFF_PLOT: (
+            output_file_constants.SummaryOutputVizFileNames.TRUE_VS_ESTIMATED_PERCENT_DIFF_PLOT: (
                 ticker.FuncFormatter(output_utils.percentage_formatter)
             ),
         }
 
         self._probit_properties_lookup = {
-            output_file_constants.FileNames.TRUE_AND_ESTIMATED_PAIRED_PROBIT_PLOT: {
+            output_file_constants.SummaryOutputVizFileNames.TRUE_AND_ESTIMATED_PAIRED_PROBIT_PLOT: {
                 "probit0": {
                     "x_label": output_file_constants.ProbitConstants.X_AXIS_LABEL.format(
                         n_sites=site_count
@@ -89,6 +92,7 @@ class SummaryVisualizationMapper:
                     "legend_label": (
                         output_file_constants.ESTIMATE_VS_TRUE_PLOTTING_CONSTANTS
                     ).TRUE_EMISSIONS_SUFFIX,
+                    "show_markers": True,
                 },
                 "probit1": {
                     "x_label": output_file_constants.ProbitConstants.X_AXIS_LABEL.format(
@@ -100,9 +104,15 @@ class SummaryVisualizationMapper:
                     "legend_label": (
                         output_file_constants.ESTIMATE_VS_TRUE_PLOTTING_CONSTANTS
                     ).ESTIMATED_EMISSIONS_SUFFIX,
+                    "show_markers": True,
                 },
             }
         }
+
+    def _get_summary_visualization_lookups(
+        self,
+    ) -> list[dict[str, dict[str, dict[str, Any]]]]:
+        return [self._histogram_properties_lookup, self._probit_properties_lookup]
 
     def get_summary_stat_function(self, stat_type: str):
         return self._summary_stat_functions.get(stat_type)
@@ -115,3 +125,22 @@ class SummaryVisualizationMapper:
 
     def get_x_axis_formatter(self, visualization_name: str):
         return self._axis_formatter_lookup.get(visualization_name)
+
+    def update_with_user_defined_summary_settings(
+        self, user_defined_settings: dict[dict[str, Any]]
+    ) -> None:
+        summary_file_names: output_file_constants.SummaryOutputVizFileNames = (
+            output_file_constants.SummaryOutputVizFileNames()
+        )
+        for summary_viz in summary_file_names:
+            if summary_viz in user_defined_settings:
+                for visualization_lookup_type in self._get_summary_visualization_lookups():
+                    for label, properties in visualization_lookup_type.items():
+                        if label == summary_viz:
+                            for _, plot_settings in properties.items():
+                                for setting, value in user_defined_settings[summary_viz].items():
+                                    setting_key: str = (
+                                        output_file_constants.SummaryVisualizationSettingsMapper
+                                    ).MAPPINGS[summary_viz][setting]
+                                    if setting_key in plot_settings:
+                                        plot_settings[setting_key] = value

--- a/LDAR_Sim/src/file_processing/output_processing/summary_visualizations.py
+++ b/LDAR_Sim/src/file_processing/output_processing/summary_visualizations.py
@@ -25,7 +25,6 @@ import matplotlib.scale as mscale
 import pandas as pd
 import seaborn as sns
 
-# import scipy.stats
 from constants import file_name_constants, output_file_constants
 from file_processing.output_processing import output_utils, summary_visualization_helpers
 from file_processing.output_processing.scaling import QuantileScale

--- a/LDAR_Sim/src/file_processing/output_processing/summary_visualizations.py
+++ b/LDAR_Sim/src/file_processing/output_processing/summary_visualizations.py
@@ -21,10 +21,16 @@ along with this program.  If not, see <https://opensource.org/licenses/MIT>.
 from pathlib import Path
 from typing import Tuple
 
-from matplotlib import pyplot as plt, ticker
+from matplotlib import lines, pyplot as plt, ticker
+import numpy as np
 import pandas as pd
+import matplotlib.scale as mscale
+import scipy.stats
+
+# import scipy.stats
 from constants import output_file_constants, file_name_constants
 from file_processing.output_processing import output_utils, summary_visualization_helpers
+from file_processing.output_processing.scaling import QuantileScale
 from file_processing.output_processing.summary_visualization_mapper import (
     SummaryVisualizationMapper,
 )
@@ -85,7 +91,7 @@ def plot_histograms(
 
             for val in range(hist_stat_dimensionality):
                 if legend_labels[val] is not None:
-                    legend_label_to_use = "".join([program_name, legend_labels[val]])
+                    legend_label_to_use = " ".join([program_name, legend_labels[val]])
                 else:
                     legend_label_to_use = None
                 # Plot the histogram for the program
@@ -119,7 +125,7 @@ def plot_histograms(
             plt.figure(combined_plot.number)
             for val in range(hist_stat_dimensionality):
                 if legend_labels[val] is not None:
-                    legend_label_to_use = "".join([program_name, legend_labels[val]])
+                    legend_label_to_use = " ".join([program_name, legend_labels[val]])
                 else:
                     legend_label_to_use = None
                 # Plot the histogram for the program on the combined plot
@@ -137,6 +143,202 @@ def plot_histograms(
         if x_axis_formatter:
             combined_plot_ax.xaxis.set_major_formatter(x_axis_formatter)
         plt.legend(handles=legend_elements)
+        save_path: Path = visualization_dir / visualization_name
+        plt.savefig(save_path)
+        plt.close(combined_plot)
+
+
+def plot_probit(
+    colors: Tuple[list[Tuple[float, float, float]]],
+    probit_data: dict[str, list[float] | Tuple[list[float], list[float]]],
+    combine_program_plots: bool,
+    visualization_dir: Path,
+    visualization_name: str,
+    viz_mapper: SummaryVisualizationMapper,
+    save_separate_plots: bool = True,
+):
+    probit_stat_dimensionality: int = 1
+    for key, value in probit_data.items():
+        if not isinstance(value, tuple):
+            probit_data[key] = (value,)
+            value = probit_data[key]
+        probit_stat_dimensionality = len(value)
+
+    probit_properties: dict = viz_mapper.get_probit_properties(visualization_name)
+
+    legend_elements: list = []
+
+    mscale.register_scale(QuantileScale)
+
+    if combine_program_plots:
+        combined_plot: plt.Figure = plt.figure()
+        combined_plot_ax: plt.Axes = plt.gca()
+
+    if probit_stat_dimensionality > 1:
+        legend_labels: tuple = tuple(
+            probit_properties[f"probit{dim}"].pop("legend_label", None)
+            for dim in range(probit_stat_dimensionality)
+        )
+    else:
+        legend_labels: tuple = (probit_properties.pop("legend_label", None),)
+
+    for accessor, (program_name, stat) in enumerate(probit_data.items()):
+        if save_separate_plots:
+            separated_plot: plt.Figure = plt.figure()
+            separated_plot_ax: plt.Axes = plt.gca()
+
+            for val in range(probit_stat_dimensionality):
+                if legend_labels[val] is not None:
+                    legend_label_to_use = " ".join([program_name, legend_labels[val]])
+                else:
+                    legend_label_to_use = None
+
+                x_values: np.ndarray = np.sort(stat[val])
+                x_values = x_values[x_values > 0]
+                y_values: np.ndarray = scipy.stats.mstats.plotting_positions(
+                    x_values, alpha=(1.0 / 3.0), beta=(1.0 / 3.0)
+                )
+
+                plt.scatter(
+                    x_values,
+                    y_values,
+                    color=colors[val][accessor],
+                    label=legend_label_to_use,
+                    marker="d",
+                    facecolors="none",
+                    edgecolors=colors[val][accessor],
+                    s=15,
+                )
+
+                separated_plot_ax.set_yscale("quantile")
+                separated_plot_ax.set_xscale("log")
+
+                separated_plot_ax.xaxis.set_major_formatter(
+                    ticker.FuncFormatter(
+                        summary_visualization_helpers.format_tick_labels_with_metric_prefix
+                    )
+                )
+                major_locator, minor_locator = (
+                    summary_visualization_helpers.format_major_minor_ticks_log_scale(
+                        10, x_values.max(), x_values.min()
+                    )
+                )
+                major_locator: ticker.LogLocator
+                minor_locator: ticker.LogLocator
+                separated_plot_ax.xaxis.set_major_locator(major_locator)
+                separated_plot_ax.xaxis.set_minor_locator(minor_locator)
+                separated_plot_ax.xaxis.set_minor_formatter(ticker.NullFormatter())
+                separated_plot_ax.tick_params(axis="x", which="major", labelsize=8)
+
+                plt.xticks(rotation=45)
+
+                best_fit_coefficients: np.ndarray = np.polyfit(
+                    np.log(x_values), scipy.stats.norm.ppf(y_values), 1
+                )
+
+                best_fit_line_y_intermediate: np.ndarray = (
+                    best_fit_coefficients[0] * np.log(x_values) + best_fit_coefficients[1]
+                )
+
+                best_fit_line_y_values: np.ndarray = scipy.stats.norm.cdf(
+                    best_fit_line_y_intermediate
+                )
+
+                plt.plot(
+                    x_values, best_fit_line_y_values, color=colors[val][accessor], linestyle="--"
+                )
+
+                separated_plot_ax.set_xlabel(probit_properties[f"probit{val}"]["x_label"])
+                separated_plot_ax.set_ylabel(probit_properties[f"probit{val}"]["y_label"])
+
+                legend_elements.append(
+                    lines.Line2D(
+                        [0],
+                        [0],
+                        color=colors[val][accessor],
+                        label=legend_label_to_use,
+                        markersize=15,
+                    )
+                )
+
+                plt.tight_layout()
+                plt.grid(True)
+
+            if probit_stat_dimensionality > 1:
+                plt.legend(
+                    handles=legend_elements[
+                        (accessor * probit_stat_dimensionality) : (  # noqa 481
+                            accessor * probit_stat_dimensionality
+                        )
+                        + probit_stat_dimensionality
+                    ]
+                )
+
+            save_path: Path = visualization_dir / f"{program_name}_{visualization_name}.png"
+            plt.savefig(save_path)
+            plt.close(separated_plot)
+
+        if combine_program_plots:
+            plt.figure(combined_plot.number)
+
+            for val in range(probit_stat_dimensionality):
+                if legend_labels[val] is not None:
+                    legend_label_to_use = " ".join([program_name, legend_labels[val]])
+                else:
+                    legend_label_to_use = None
+
+                x_values: np.ndarray = np.sort(stat[val])
+                y_values: np.ndarray = scipy.stats.mstats.plotting_positions(
+                    x_values, alpha=(1.0 / 3.0), beta=(1.0 / 3.0)
+                )
+
+                plt.scatter(
+                    x_values,
+                    y_values,
+                    color=colors[val][accessor],
+                    label=legend_label_to_use,
+                    marker="d",
+                    facecolors="none",
+                    edgecolors=colors[val][accessor],
+                    s=15,
+                )
+
+                combined_plot_ax.set_yscale("quantile")
+                combined_plot_ax.set_xscale("log")
+
+                combined_plot_ax.xaxis.set_major_formatter(
+                    ticker.FuncFormatter(
+                        summary_visualization_helpers.format_tick_labels_with_metric_prefix
+                    )
+                )
+                combined_plot_ax.xaxis.set_major_locator(
+                    ticker.LogLocator(base=10, subs=np.arange(0, 20))
+                )
+                combined_plot_ax.xaxis.set_minor_locator(ticker.NullLocator())
+                combined_plot_ax.xaxis.set_minor_formatter(ticker.NullFormatter())
+
+                plt.xticks(rotation=-60)
+
+                best_fit_coefficients: np.ndarray = np.polyfit(
+                    np.log(x_values), scipy.stats.norm.ppf(y_values), 1
+                )
+
+                best_fit_line_y_intermediate: np.ndarray = (
+                    best_fit_coefficients[0] * np.log(x_values) + best_fit_coefficients[1]
+                )
+
+                best_fit_line_y_values: np.ndarray = scipy.stats.norm.cdf(
+                    best_fit_line_y_intermediate
+                )
+
+                plt.plot(
+                    x_values, best_fit_line_y_values, color=colors[val][accessor], linestyle="--"
+                )
+
+                plt.tight_layout()
+                plt.grid(True)
+
+    if combine_program_plots:
         save_path: Path = visualization_dir / visualization_name
         plt.savefig(save_path)
         plt.close(combined_plot)
@@ -247,6 +449,41 @@ def gen_true_and_estimated_paired_emissions_distribution_plot(
         colors_paired,
         annualized_emissions_data,
         combine_program_histograms,
+        visualization_dir,
+        visualization_name,
+        viz_mapper,
+    )
+
+
+def gen_true_and_estimated_paired_probit_plot(
+    out_dir: Path,
+    visualization_dir: Path,
+    baseline_program: str,
+    combine_program_plots: bool,
+    viz_mapper: SummaryVisualizationMapper,
+):
+    data_source: Path = out_dir / file_name_constants.Output_Files.SummaryFileNames.EMIS_SUMMARY
+    data: pd.DataFrame = pd.read_csv(data_source.with_suffix(".csv"))
+    visualization_name: str = output_file_constants.FileNames.TRUE_AND_ESTIMATED_PAIRED_PROBIT_PLOT
+
+    program_names: list[str] = summary_visualization_helpers.get_non_baseline_prog_names(
+        data, baseline_program
+    )
+    annualized_emissions_data: dict[Tuple[list[float], list[float]]] = (
+        summary_visualization_helpers.gen_annual_emissions_summary_list(data, program_names)
+    )
+
+    colors = sns.color_palette("husl", n_colors=len(program_names))
+
+    colors_paired = (
+        [output_utils.luminance_shift(color, lighten=False) for color in colors],
+        [output_utils.luminance_shift(color, lighten=True) for color in colors],
+    )
+
+    plot_probit(
+        colors_paired,
+        annualized_emissions_data,
+        combine_program_plots,
         visualization_dir,
         visualization_name,
         viz_mapper,


### PR DESCRIPTION
# Pull Request Key Information

## Reason for change

Probit plots are a useful tool for comparing two emissions
distributions.

## What was changed

This change adds probit plots to the summary visualizations.

## Intended Purpose

Improving comprehensibility of uncertainty outputs by adding more visualizations

## Level of version change required

N/A

## Testing Completed

Manual Testing - See new outputs here: 
![P_OGI_True and Estimated Emissions Probit](https://github.com/LDAR-Sim/LDAR_Sim/assets/57332344/a592bdf8-8860-4705-8570-3d76b717a3a5)
![P_air_True and Estimated Emissions Probit](https://github.com/LDAR-Sim/LDAR_Sim/assets/57332344/f5f20161-32ce-4bbe-b846-c24285c1d2cd)

All unit tests passing: 
[unit_test_results.txt](https://github.com/LDAR-Sim/LDAR_Sim/files/15156093/unit_test_results.txt)

## Target Issue
N/A

## Additional Information

N/A
