### PR TITLE
<UPD> Update Equipment to Component

### DIFF
--- a/LDAR_Sim/src/programs/component_level_method.py
+++ b/LDAR_Sim/src/programs/component_level_method.py
@@ -1,8 +1,8 @@
 """
 ------------------------------------------------------------------------------
 Program:     The LDAR Simulator (LDAR-Sim)
-File:        equipment_level_method
-Purpose: The module provides default behaviors for equipment level methods
+File:        component_level_method.py
+Purpose: The module provides default behaviors for component level methods
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the MIT License as published
@@ -31,15 +31,15 @@ from scheduling.schedule_dataclasses import (
     TaggingInfo,
 )
 from scheduling.workplan import Workplan
-from sensors.default_equipment_level_sensor import DefaultEquipmentLevelSensor
+from sensors.default_component_level_sensor import DefaultComponentLevelSensor
 from sensors.OGI_camera_rk import OGICameraRKSensor
 from sensors.OGI_camera_zim import OGICameraZimSensor
-from sensors.METEC_NoWind_sensor import METECNWEquipment
+from sensors.METEC_NoWind_sensor import METECNWComponent
 from virtual_world.sites import Site
 from constants.param_default_const import Method_Params as mp
 
 
-class EquipmentLevelMethod(Method):
+class ComponentLevelMethod(Method):
     MEASUREMENT_SCALE = "component"
 
     def __init__(self, name, properties, consider_weather, sites):
@@ -83,9 +83,9 @@ class EquipmentLevelMethod(Method):
                             crew=crew.crew_id,
                             report_delay=self._reporting_delay,
                         )
-                        site_to_survey.tag_emissions_at_equipment(
+                        site_to_survey.tag_emissions_at_component(
                             emission_detection_report.equipment_group,
-                            emission_detection_report.equipment,
+                            emission_detection_report.component,
                             tagging_info=tagging_info,
                         )
                         self._emissions_tagged_daily += 1
@@ -100,13 +100,13 @@ class EquipmentLevelMethod(Method):
         """
         # TODO: change to mapping?
         if sensor_info[mp.TYPE] == "default":
-            self._sensor = DefaultEquipmentLevelSensor(sensor_info[mp.MDL], sensor_info[mp.QE])
+            self._sensor = DefaultComponentLevelSensor(sensor_info[mp.MDL], sensor_info[mp.QE])
         elif sensor_info[mp.TYPE] == "OGI_camera_zim":
             self._sensor = OGICameraZimSensor(sensor_info[mp.MDL], sensor_info[mp.QE])
         elif sensor_info[mp.TYPE] == "OGI_camera_rk":
             self._sensor = OGICameraRKSensor(sensor_info[mp.MDL], sensor_info[mp.QE])
         elif sensor_info[mp.TYPE] == "METEC_no_wind":
-            self._sensor = METECNWEquipment(sensor_info[mp.MDL], sensor_info[mp.QE])
+            self._sensor = METECNWComponent(sensor_info[mp.MDL], sensor_info[mp.QE])
         else:
             print(ipm.ERR_MSG_UNKNOWN_SENS_TYPE.format(method=self._name))
             sys.exit()

--- a/LDAR_Sim/src/programs/program.py
+++ b/LDAR_Sim/src/programs/program.py
@@ -27,7 +27,7 @@ from file_processing.output_processing.output_utils import (
     TsMethodData,
 )
 from programs.equipment_group_level_method import EquipmentGroupLevelMethod
-from programs.equipment_level_method import EquipmentLevelMethod
+from programs.component_level_method import ComponentLevelMethod
 from programs.site_level_method import SiteLevelMethod
 from scheduling.scheduling_utils import create_schedule
 
@@ -97,7 +97,7 @@ class Program:
             method_name: str
             properties: dict
 
-            method: Method = EquipmentLevelMethod(method_name, properties, consider_weather, sites)
+            method: Method = ComponentLevelMethod(method_name, properties, consider_weather, sites)
 
             follow_up_method_list.append(method)
 
@@ -184,8 +184,8 @@ class Program:
                 sites=sites,
                 follow_up_schedule=follow_up_schedule,
             )
-        elif method_survey_level == EquipmentLevelMethod.MEASUREMENT_SCALE:
-            return EquipmentLevelMethod(method_name, properties, consider_weather, sites)
+        elif method_survey_level == ComponentLevelMethod.MEASUREMENT_SCALE:
+            return ComponentLevelMethod(method_name, properties, consider_weather, sites)
 
     def do_daily_program_deployment(self) -> list[TsMethodData]:
         timeseries_methods_data: list[TsMethodData] = []

--- a/LDAR_Sim/src/scheduling/schedule_dataclasses.py
+++ b/LDAR_Sim/src/scheduling/schedule_dataclasses.py
@@ -27,7 +27,7 @@ from constants.output_file_constants import EMIS_DATA_COL_ACCESSORS as eca
 class EmissionDetectionReport:
     site: str
     equipment_group: str
-    equipment: str
+    component: str
     measured_rate: float
     true_rate: float
     current_date: date = None
@@ -36,7 +36,7 @@ class EmissionDetectionReport:
 
     def to_report_summary(self):
         return {
-            eca.COMP: self.equipment,
+            eca.COMP: self.component,
             eca.M_RATE: self.measured_rate,
         }
 

--- a/LDAR_Sim/src/sensors/METEC_NoWind_sensor.py
+++ b/LDAR_Sim/src/sensors/METEC_NoWind_sensor.py
@@ -21,7 +21,7 @@ along with this program.  If not, see <https://opensource.org/licenses/MIT>.
 
 import numpy as np
 from sensors.default_sensor import DefaultSensor
-from sensors.default_equipment_level_sensor import DefaultEquipmentLevelSensor
+from sensors.default_component_level_sensor import DefaultComponentLevelSensor
 from sensors.default_equipment_group_level_sensor import DefaultEquipmentGroupLevelSensor
 
 
@@ -48,7 +48,7 @@ class METECNWEquipmentGroup(DefaultEquipmentGroupLevelSensor):
         return np.random.binomial(1, prob_detect) and self.check_min_threshold(emis_rate)
 
 
-class METECNWEquipment(DefaultEquipmentLevelSensor):
+class METECNWComponent(DefaultComponentLevelSensor):
     def __init__(self, mdl: float, quantification_error: float) -> None:
         super().__init__(mdl, quantification_error)
 

--- a/LDAR_Sim/src/sensors/OGI_camera_rk.py
+++ b/LDAR_Sim/src/sensors/OGI_camera_rk.py
@@ -21,11 +21,11 @@ along with this program.  If not, see <https://opensource.org/licenses/MIT>.
 
 import math
 import numpy as np
-from sensors.default_equipment_level_sensor import DefaultEquipmentLevelSensor
+from sensors.default_component_level_sensor import DefaultComponentLevelSensor
 from constants.general_const import Conversion_Constants as CC
 
 
-class OGICameraRKSensor(DefaultEquipmentLevelSensor):
+class OGICameraRKSensor(DefaultComponentLevelSensor):
     MDL_CONST1 = 0.01275
     MDL_CONST2 = 0.00000278
 

--- a/LDAR_Sim/src/sensors/OGI_camera_zim.py
+++ b/LDAR_Sim/src/sensors/OGI_camera_zim.py
@@ -23,14 +23,14 @@ along with this program.  If not, see <https://opensource.org/licenses/MIT>.
 """
 
 import numpy as np
-from sensors.default_equipment_level_sensor import DefaultEquipmentLevelSensor
+from sensors.default_component_level_sensor import DefaultComponentLevelSensor
 
 MDL_CONST1 = 0.24
 MDL_CONST2 = 0.39
 GS_TO_SCFH = 187
 
 
-class OGICameraZimSensor(DefaultEquipmentLevelSensor):
+class OGICameraZimSensor(DefaultComponentLevelSensor):
     def __init__(self, mdl: float, quantification_error: float) -> None:
         super().__init__(mdl, quantification_error)
         self._mdl = mdl

--- a/LDAR_Sim/src/sensors/default_component_level_sensor.py
+++ b/LDAR_Sim/src/sensors/default_component_level_sensor.py
@@ -1,8 +1,8 @@
 """
 ------------------------------------------------------------------------------
 Program:     The LDAR Simulator (LDAR-Sim)
-File:        default_equipment_level_sensor
-Purpose: The provides default behaviors for equipment level sensors
+File:        default_component_level_sensor.py
+Purpose: The provides default behaviors for component level sensors
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the MIT License as published
@@ -30,7 +30,7 @@ from virtual_world.sites import Site
 from constants.param_default_const import Levels
 
 
-class DefaultEquipmentLevelSensor(DefaultSensor):
+class DefaultComponentLevelSensor(DefaultSensor):
     SURVEY_LEVEL = Levels.COMPONENT_LEVEL
 
     def __init__(self, mdl: Union[list[float], float], quantification_error: float) -> None:
@@ -50,7 +50,7 @@ class DefaultEquipmentLevelSensor(DefaultSensor):
             eqg_level_measured_rate: float = 0.0
             emissions_detection_reports: list[EmissionDetectionReport] = []
 
-            for equip, emis_list in eq_emis_list.items():
+            for comp, emis_list in eq_emis_list.items():
                 equip_rate: float = sum([emission.get_rate() for emission in emis_list])
 
                 equip_emission_detected: bool = self._rate_detected(equip_rate)
@@ -62,7 +62,7 @@ class DefaultEquipmentLevelSensor(DefaultSensor):
 
                 emissions_detection_reports.append(
                     self._gen_emissions_detection_report(
-                        site.get_id(), eqg, equip, equip_measured_rate, equip_rate
+                        site.get_id(), eqg, comp, equip_measured_rate, equip_rate
                     )
                 )
 
@@ -118,12 +118,12 @@ class DefaultEquipmentLevelSensor(DefaultSensor):
         return eqg_survey_report
 
     def _gen_emissions_detection_report(
-        self, site_id: str, eqg_id: str, equip_id: str, measured_rate: float, true_rate: float
+        self, site_id: str, eqg_id: str, comp_id: str, measured_rate: float, true_rate: float
     ) -> EmissionDetectionReport:
         emis_detect_report = EmissionDetectionReport(
             site=site_id,
             equipment_group=eqg_id,
-            equipment=equip_id,
+            component=comp_id,
             measured_rate=measured_rate,
             true_rate=true_rate,
         )

--- a/LDAR_Sim/src/virtual_world/component.py
+++ b/LDAR_Sim/src/virtual_world/component.py
@@ -1,8 +1,8 @@
 """
 ------------------------------------------------------------------------------
 Program:     The LDAR Simulator (LDAR-Sim)
-File:        equipment
-Purpose: The equipment module.
+File:        component.py
+Purpose: The component module.
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the MIT License as published
@@ -41,12 +41,12 @@ from constants.error_messages import Initialization_Messages as im
 from virtual_world.sources import Source
 
 
-class Equipment:
+class Component:
     def __init__(self, equip_type, equip_id, infrastructure_inputs, prop_params) -> None:
         STR_FILTER = r"_equipment"
         pattern: re.Pattern[str] = re.compile(re.escape(STR_FILTER), re.IGNORECASE)
         self._equip_type: str = re.sub(pattern, "", equip_type)
-        self._equipment_ID: str = self._equip_type + "_" + str(equip_id)
+        self._component_ID: str = self._equip_type + "_" + str(equip_id)
         self._sources: list[Source] = []
         self._create_sources(infrastructure_inputs=infrastructure_inputs, prop_params=prop_params)
         self._active_emissions: list[Emission] = []
@@ -56,7 +56,7 @@ class Equipment:
     def __reduce__(self):
         args = (
             self._equip_type,
-            self._equipment_ID,
+            self._component_ID,
             self._sources,
             self._active_emissions,
             self._inactive_emissions,
@@ -68,7 +68,7 @@ class Equipment:
     def _reconstruct(
         cls,
         equip_type,
-        equipment_ID,
+        component_ID,
         sources,
         active_emissions,
         inactive_emissions,
@@ -76,7 +76,7 @@ class Equipment:
     ):
         instance = cls.__new__(cls)
         instance._equip_type = equip_type
-        instance._equipment_ID = equipment_ID
+        instance._component_ID = component_ID
         instance._sources = sources
         instance._active_emissions = active_emissions
         instance._inactive_emissions = inactive_emissions
@@ -166,11 +166,11 @@ class Equipment:
                 )
             )
 
-        return {self._equipment_ID: equip_emissions}
+        return {self._component_ID: equip_emissions}
 
     def activate_emissions(self, date: date, sim_number: int) -> int:
         """Activate any emissions that are due to begin on the current date for the given simulation
-        and add them to the active emissions list for the equipment at which they occur.
+        and add them to the active emissions list for the component at which they occur.
 
         Args:
             date (date): The current date in simulation.
@@ -243,7 +243,7 @@ class Equipment:
             src.set_pregen_emissions(equipment_emissions[src.get_id()], sim_number)
 
     def get_id(self) -> str:
-        return self._equipment_ID
+        return self._component_ID
 
     def gen_emis_data(
         self, emis_df: pd.DataFrame, site_id: str, eqg_id: str, row_index: int, end_date: date
@@ -252,7 +252,7 @@ class Equipment:
         for emission in self._active_emissions:
             summary_dict: dict[str, Any] = emission.get_summary_dict(end_date)
             summary_dict.update(
-                {eca.SITE_ID: site_id, eca.EQG: eqg_id, eca.COMP: self._equipment_ID}
+                {eca.SITE_ID: site_id, eca.EQG: eqg_id, eca.COMP: self._component_ID}
             )
             emis_df.loc[upd_row_index] = summary_dict
             upd_row_index += 1
@@ -260,7 +260,7 @@ class Equipment:
         for emission in self._inactive_emissions:
             summary_dict: dict[str, Any] = emission.get_summary_dict(end_date)
             summary_dict.update(
-                {eca.SITE_ID: site_id, eca.EQG: eqg_id, eca.COMP: self._equipment_ID}
+                {eca.SITE_ID: site_id, eca.EQG: eqg_id, eca.COMP: self._component_ID}
             )
             emis_df.loc[upd_row_index] = summary_dict
             upd_row_index += 1

--- a/LDAR_Sim/src/virtual_world/equipment_groups.py
+++ b/LDAR_Sim/src/virtual_world/equipment_groups.py
@@ -1,7 +1,7 @@
 """
 ------------------------------------------------------------------------------
 Program:     The LDAR Simulator (LDAR-Sim)
-File:        equipment_groups
+File:        equipment_groups.py
 Purpose: The equipment group module.
 
 This program is free software: you can redistribute it and/or modify
@@ -31,7 +31,7 @@ from file_processing.input_processing.emissions_source_processing import (
 from scheduling.schedule_dataclasses import TaggingInfo
 from virtual_world.emissions import Emission
 from constants.infrastructure_const import Infrastructure_Constants as IC
-from virtual_world.equipment import Equipment
+from virtual_world.component import Component
 from constants.param_default_const import Common_Params as cp
 
 
@@ -40,7 +40,7 @@ class Equipment_Group:
         self._id: str = id
         self._meth_survey_times = None
         self._meth_survey_costs = None
-        self._equipment: list[Equipment] = []
+        self._component: list[Component] = []
         self._update_prop_params(info, prop_params)
         self._set_method_specific_params(prop_params)
         self._create_equipment(
@@ -54,17 +54,17 @@ class Equipment_Group:
             self._id,
             self._meth_survey_times,
             self._meth_survey_costs,
-            self._equipment,
+            self._component,
         )
         return (self.__class__._reconstruct, args)
 
     @classmethod
-    def _reconstruct(cls, id, meth_survey_times, meth_survey_costs, equipment):
+    def _reconstruct(cls, id, meth_survey_times, meth_survey_costs, component):
         instance = cls.__new__(cls)
         instance._id = id
         instance._meth_survey_times = meth_survey_times
         instance._meth_survey_costs = meth_survey_costs
-        instance._equipment = equipment
+        instance._component = component
         return instance
 
     def _update_prop_params(self, info: dict, prop_params: dict) -> None:
@@ -93,7 +93,7 @@ class Equipment_Group:
             prop_params[IC.Equipment_Group_File_Constants.REP_EMIS_EPR] = rep_epr / tot_equip
         for col, val in info.items():
             for count in range(0, val):
-                self._equipment.append(Equipment(col, count, infrastructure_inputs, prop_params))
+                self._component.append(Component(col, count, infrastructure_inputs, prop_params))
 
     def _set_method_specific_params(self, prop_params):
         self._meth_survey_times = prop_params[cp.METH_SPECIFIC].pop(
@@ -112,7 +112,7 @@ class Equipment_Group:
         repair_delay_dataframe: pd.DataFrame,
     ) -> dict:
         eqg_emissions = {}
-        for eqmt in self._equipment:
+        for eqmt in self._component:
             eqg_emissions.update(
                 eqmt.generate_emissions(
                     sim_start_date,
@@ -135,33 +135,33 @@ class Equipment_Group:
             Used to interact with the correct set of emissions.
         """
         new_emissions: int = 0
-        for equipment in self._equipment:
-            new_emissions += equipment.activate_emissions(date, sim_number)
+        for component in self._component:
+            new_emissions += component.activate_emissions(date, sim_number)
         return new_emissions
 
     def update_emissions_state(self, emis_rep_info: EmisInfo) -> TsEmisData:
         emis_data = TsEmisData()
-        for equip in self._equipment:
-            emis_data += equip.update_emissions_state(emis_rep_info)
+        for comp in self._component:
+            emis_data += comp.update_emissions_state(emis_rep_info)
         return emis_data
 
-    def tag_emissions_at_equipment(self, equipment: str, tagging_info: TaggingInfo) -> None:
-        target_equip: Equipment | None = next(
-            (equip for equip in self._equipment if equip.get_id() == equipment),
+    def tag_emissions_at_component(self, component: str, tagging_info: TaggingInfo) -> None:
+        target_comp: Component | None = next(
+            (comp for comp in self._component if comp.get_id() == component),
             None,
         )
-        target_equip.tag_emissions(tagging_info)
+        target_comp.tag_emissions(tagging_info)
 
     def get_detectable_emissions(self, method_name: str) -> dict[str, list[Emission]]:
         detectable_emissions: dict[str, Emission] = {}
-        for equip in self._equipment:
+        for equip in self._component:
             detectable_emissions[equip.get_id()] = equip.get_detectable_emissions(method_name)
 
         return detectable_emissions
 
     def set_pregen_emissions(self, eqg_emissions, sim_number) -> None:
-        for equipment in self._equipment:
-            equipment.set_pregen_emissions(eqg_emissions[equipment.get_id()], sim_number)
+        for component in self._component:
+            component.set_pregen_emissions(eqg_emissions[component.get_id()], sim_number)
 
     def get_survey_time(self, method_name) -> float:
         survey_time: float = self._meth_survey_times[method_name]
@@ -176,7 +176,7 @@ class Equipment_Group:
 
     def gen_emis_data(self, emis_df: pd.DataFrame, site_id: str, row_index: int, end_date: date):
         upd_row_index = row_index
-        for equip in self._equipment:
+        for equip in self._component:
             upd_row_index = equip.gen_emis_data(emis_df, site_id, self._id, upd_row_index, end_date)
         return upd_row_index
 
@@ -184,5 +184,5 @@ class Equipment_Group:
         return self._meth_survey_costs[method_name]
 
     def setup(self, methods: list[str]):
-        for equipment in self._equipment:
-            equipment.set_emis_sum_dtypes(methods)
+        for component in self._component:
+            component.set_emis_sum_dtypes(methods)

--- a/LDAR_Sim/src/virtual_world/infrastructure.py
+++ b/LDAR_Sim/src/virtual_world/infrastructure.py
@@ -152,7 +152,7 @@ class Infrastructure:
 
     def activate_emissions(self, date: date, sim_number: int) -> int:
         """Activate any emissions that are due to begin on the current date for the given simulation
-        and add them to the active emissions list for the equipment at which they occur.
+        and add them to the active emissions list for the component at which they occur.
 
         Args:
             date (date): The current date in simulation.

--- a/LDAR_Sim/src/virtual_world/sites.py
+++ b/LDAR_Sim/src/virtual_world/sites.py
@@ -277,7 +277,7 @@ class Site:
 
     def activate_emissions(self, date: date, sim_number: int) -> int:
         """Activate any emissions that are due to begin on the current date for the given simulation
-        and add them to the active emissions list for the equipment at which they occur.
+        and add them to the active emissions list for the component at which they occur.
 
         Args:
             date (date): The current date in simulation.
@@ -359,8 +359,8 @@ class Site:
         for eqg in self._equipment_groups:
             eqg.set_pregen_emissions(site_emissions[eqg.get_id()], sim_number)
 
-    def tag_emissions_at_equipment(
-        self, equipment_group: str, equipment: str, tagging_info: TaggingInfo
+    def tag_emissions_at_component(
+        self, equipment_group: str, component: str, tagging_info: TaggingInfo
     ) -> None:
         target_equip_group: Equipment_Group | None = next(
             (
@@ -370,7 +370,7 @@ class Site:
             ),
             None,
         )
-        target_equip_group.tag_emissions_at_equipment(equipment, tagging_info)
+        target_equip_group.tag_emissions_at_component(component, tagging_info)
 
     def update_emissions_state(self, emis_rep_info: EmisInfo) -> TsEmisData:
         emis_data = TsEmisData()

--- a/LDAR_Sim/testing/unit_testing/test_sensors/test_equipment_level_sensors/test_detect_emissions.py
+++ b/LDAR_Sim/testing/unit_testing/test_sensors/test_equipment_level_sensors/test_detect_emissions.py
@@ -1,6 +1,6 @@
 from pytest import approx
 from src.scheduling.schedule_dataclasses import SiteSurveyReport, EmissionDetectionReport
-from src.sensors.default_equipment_level_sensor import DefaultEquipmentLevelSensor
+from sensors.default_component_level_sensor import DefaultComponentLevelSensor
 from src.virtual_world.sites import Site
 from testing.unit_testing.test_sensors.test_equipment_level_sensors.equipment_level_sensors_testing_fixtures import (  # noqa
     mock_site_emis_for_equip_level_detect_emissions_testing_fix,
@@ -36,7 +36,7 @@ def test_000_default_equip_level_sensor_detect_emissions_detects_emissions_at_si
     mock_site: Site = Site()
     mdl: float = sensor_info_for_default_equipment_level_sensor_construction_testing["mdl"]
     qe: float = sensor_info_for_default_equipment_level_sensor_construction_testing["QE"]
-    sensor = DefaultEquipmentLevelSensor(mdl, qe)
+    sensor = DefaultComponentLevelSensor(mdl, qe)
     report: SiteSurveyReport = SiteSurveyReport(1)
     emis_detected: bool = sensor.detect_emissions(mock_site, "test", report)
     expected_emis = mock_site_for_equip_level_detect_emissions_testing[1]
@@ -56,7 +56,7 @@ def test_000_default_equip_level_sensor_detect_emissions_does_not_detect_emissio
     mock_site: Site = Site()
     mdl: float = sensor_info_high_mdl_for_default_equipment_level_sensor_testing["mdl"]
     qe: float = sensor_info_high_mdl_for_default_equipment_level_sensor_testing["QE"]
-    sensor = DefaultEquipmentLevelSensor(mdl, qe)
+    sensor = DefaultComponentLevelSensor(mdl, qe)
     report: SiteSurveyReport = SiteSurveyReport(1)
     emis_detected: bool = sensor.detect_emissions(mock_site, "test", report)
     expected_true_emis = mock_site_for_equip_level_detect_emissions_testing_lower_emissions[1]
@@ -77,7 +77,7 @@ def test_000_default_eqg_level_sensor_detect_emissions_correctly_detects_only_em
     mock_site: Site = Site()
     mdl: float = sensor_info_high_mdl_for_default_equipment_level_sensor_testing["mdl"]
     qe: float = sensor_info_high_mdl_for_default_equipment_level_sensor_testing["QE"]
-    sensor = DefaultEquipmentLevelSensor(mdl, qe)
+    sensor = DefaultComponentLevelSensor(mdl, qe)
     report: SiteSurveyReport = SiteSurveyReport(1)
     emis_detected: bool = sensor.detect_emissions(mock_site, "test", report)
     expected_true_emis = mock_site_for_equip_level_detect_emissions_testing_mixed_detect[1]

--- a/LDAR_Sim/testing/unit_testing/test_sensors/test_equipment_level_sensors/test_fill_detection_report.py
+++ b/LDAR_Sim/testing/unit_testing/test_sensors/test_equipment_level_sensors/test_fill_detection_report.py
@@ -1,13 +1,13 @@
 from typing import Any, Tuple
 from hypothesis import given, strategies as st
 from src.scheduling.schedule_dataclasses import SiteSurveyReport, EquipmentGroupSurveyReport
-from src.sensors.default_equipment_level_sensor import DefaultEquipmentLevelSensor
+from sensors.default_component_level_sensor import DefaultComponentLevelSensor
 
 
-def get_sensor_for_default_equipment_level_sensor_testing() -> DefaultEquipmentLevelSensor:
+def get_sensor_for_default_equipment_level_sensor_testing() -> DefaultComponentLevelSensor:
     mdl: float = 1.0
     QE: float = 0.0
-    return DefaultEquipmentLevelSensor(mdl=mdl, quantification_error=QE)
+    return DefaultComponentLevelSensor(mdl=mdl, quantification_error=QE)
 
 
 @st.composite
@@ -29,7 +29,7 @@ def gen_measured_and_true_rates(draw) -> Tuple[Any | float, Any | int]:
 def test_000_default_equipment_level_sensor_fill_detection_report_with_successful_detection_correctly_fills_values(  # noqa
     gen_data,
 ) -> None:
-    sensor: DefaultEquipmentLevelSensor = get_sensor_for_default_equipment_level_sensor_testing()
+    sensor: DefaultComponentLevelSensor = get_sensor_for_default_equipment_level_sensor_testing()
     report: SiteSurveyReport = SiteSurveyReport(1)
     site_true_rate: float = gen_data[0]
     site_measured_rate: float = gen_data[1]

--- a/LDAR_Sim/testing/unit_testing/test_sensors/test_equipment_level_sensors/test_gen_eqg_survey_report.py
+++ b/LDAR_Sim/testing/unit_testing/test_sensors/test_equipment_level_sensors/test_gen_eqg_survey_report.py
@@ -1,19 +1,19 @@
 from hypothesis import given, strategies as st
 from src.scheduling.schedule_dataclasses import EmissionDetectionReport, EquipmentGroupSurveyReport
-from src.sensors.default_equipment_level_sensor import DefaultEquipmentLevelSensor
+from sensors.default_component_level_sensor import DefaultComponentLevelSensor
 
 
-def get_sensor_for_default_equipment_level_sensor_testing() -> DefaultEquipmentLevelSensor:
+def get_sensor_for_default_equipment_level_sensor_testing() -> DefaultComponentLevelSensor:
     mdl: float = [1.0]
     QE: float = 0.0
-    return DefaultEquipmentLevelSensor(mdl=mdl, quantification_error=QE)
+    return DefaultComponentLevelSensor(mdl=mdl, quantification_error=QE)
 
 
 generate_emission_detection_reports_strategy: st.SearchStrategy = st.builds(
     EmissionDetectionReport,
     site=st.text(min_size=1),
     equipment_group=st.text(min_size=1),
-    equipment=st.text(min_size=1),
+    component=st.text(min_size=1),
     true_rate=st.floats(min_value=0),
     measured_rate=st.floats(min_value=0),
 )
@@ -36,7 +36,7 @@ gen_test_data = st.tuples(
 
 @given(test_data=gen_test_data)
 def test_000_gen_equipment_survey_report_return_expected_report(test_data):
-    sensor: DefaultEquipmentLevelSensor = get_sensor_for_default_equipment_level_sensor_testing()
+    sensor: DefaultComponentLevelSensor = get_sensor_for_default_equipment_level_sensor_testing()
     site_id: str = test_data[0]
     eqg_id: str = test_data[1]
     meas_rate: float = test_data[3]

--- a/LDAR_Sim/testing/unit_testing/test_sensors/test_equipment_level_sensors/test_rate_detected.py
+++ b/LDAR_Sim/testing/unit_testing/test_sensors/test_equipment_level_sensors/test_rate_detected.py
@@ -1,4 +1,4 @@
-from src.sensors.default_equipment_level_sensor import DefaultEquipmentLevelSensor
+from sensors.default_component_level_sensor import DefaultComponentLevelSensor
 from hypothesis import given, strategies as st
 
 
@@ -30,13 +30,13 @@ def gen_sens_mdl_and_undetectable_rates(draw):
 
 @given(gen_test_vals=gen_sens_mdl_and_detectable_rates())
 def test_000_default_equipment_level_sensor_returns_true_above_mdl(gen_test_vals):
-    sens: DefaultEquipmentLevelSensor = DefaultEquipmentLevelSensor([gen_test_vals[0]], 0.0)
+    sens: DefaultComponentLevelSensor = DefaultComponentLevelSensor([gen_test_vals[0]], 0.0)
     rate = gen_test_vals[1]
     assert sens._rate_detected(rate) is True
 
 
 @given(gen_test_vals=gen_sens_mdl_and_undetectable_rates())
 def test_000_default_equipment_level_sensor_returns_false_below_mdl(gen_test_vals):
-    sens: DefaultEquipmentLevelSensor = DefaultEquipmentLevelSensor([gen_test_vals[0]], 0.0)
+    sens: DefaultComponentLevelSensor = DefaultComponentLevelSensor([gen_test_vals[0]], 0.0)
     rate = gen_test_vals[1]
     assert sens._rate_detected(rate) is False

--- a/LDAR_Sim/testing/unit_testing/test_sensors/test_equipment_level_sensors/test_sensor_constructor.py
+++ b/LDAR_Sim/testing/unit_testing/test_sensors/test_equipment_level_sensors/test_sensor_constructor.py
@@ -1,4 +1,4 @@
-from src.sensors.default_equipment_level_sensor import DefaultEquipmentLevelSensor
+from sensors.default_component_level_sensor import DefaultComponentLevelSensor
 from testing.unit_testing.test_sensors.test_equipment_level_sensors.equipment_level_sensors_testing_fixtures import (  # noqa
     sensor_info_for_default_equipment_level_sensor_construction_testing_fix,
 )
@@ -7,8 +7,8 @@ from testing.unit_testing.test_sensors.test_equipment_level_sensors.equipment_le
 def test_000_simple_default_equipment_level_constructor_properly_initializes_as_default_equipment_level_sensor(  # noqa
     sensor_info_for_default_equipment_level_sensor_construction_testing: dict[str, int],
 ) -> None:
-    sl_sensor = DefaultEquipmentLevelSensor(
+    sl_sensor = DefaultComponentLevelSensor(
         sensor_info_for_default_equipment_level_sensor_construction_testing["mdl"],
         sensor_info_for_default_equipment_level_sensor_construction_testing["QE"],
     )
-    assert isinstance(sl_sensor, DefaultEquipmentLevelSensor)
+    assert isinstance(sl_sensor, DefaultComponentLevelSensor)

--- a/LDAR_Sim/testing/unit_testing/test_virtual_world/test_equipment/test_tag_emissions.py
+++ b/LDAR_Sim/testing/unit_testing/test_virtual_world/test_equipment/test_tag_emissions.py
@@ -19,8 +19,8 @@ along with this program.  If not, see <https://opensource.org/licenses/MIT>.
 """
 
 from datetime import date
-from src.virtual_world.equipment import (
-    Equipment,
+from virtual_world.component import (
+    Component,
     TaggingInfo,
     FugitiveEmission,
     NonRepairableEmission,
@@ -64,16 +64,16 @@ def mock_equipment_init(self, *args, **kwargs):
 def setup_mock_equipment(mocker):
     mocker.patch.object(FugitiveEmission, "__init__", mock_fugitive_emission_init)
     mocker.patch.object(NonRepairableEmission, "__init__", mock_non_rep_emission_init)
-    mocker.patch.object(Equipment, "__init__", mock_equipment_init)
+    mocker.patch.object(Component, "__init__", mock_equipment_init)
 
 
 def test_tag_emissions_with_multiple_emissions(mocker):
     setup_mock_equipment(mocker)
     emissions = mock_active_emissions()
-    mock_equipment = Equipment(emissions=emissions)
+    mock_component = Component(emissions=emissions)
     tagging_info = mock_tagging_info()
     expected_rates = tagging_info.measured_rate / len(emissions)
-    mock_equipment.tag_emissions(tagging_info=tagging_info)
+    mock_component.tag_emissions(tagging_info=tagging_info)
 
     for emission in emissions:
         if isinstance(emission, FugitiveEmission):

--- a/LDAR_Sim/testing/unit_testing/test_virtual_world/test_sites/test_activate_emissions.py
+++ b/LDAR_Sim/testing/unit_testing/test_virtual_world/test_sites/test_activate_emissions.py
@@ -17,8 +17,8 @@ def test_000_simple_site_correctly_activates_emissions(
     # Don't know which equipment component the emission will be added to.
     # But with LPR of 1, there should be at least 1 emission active
     for eqg in test_site._equipment_groups:
-        for equip in eqg._equipment:
-            if len(equip._active_emissions) > 0:
+        for comp in eqg._component:
+            if len(comp._active_emissions) > 0:
                 active_emission = True
 
     assert active_emission


### PR DESCRIPTION
# Pull Request Key Information

## Reason for change

The hierarchical structure of equipment groups and equipment led to confusion when discussing varying levels of granularity.
All references to "equipment" or "equipment group" in the code now consistently represent the same level of equipment grouping, with "components" denoting the more granular infrastructure level nested under the equipment groups.

## What was changed

Update all instances of equipment to use component

## Intended Purpose

Reduce confusion and keep terminology consistent. 

## Testing Completed

All unit tests passed.
[results.txt](https://github.com/LDAR-Sim/LDAR_Sim/files/15169631/results.txt)

Ran the simple test case scenario. 
