### PR TITLE
V4 Expiry & Repair date fix

### DIFF
--- a/LDAR_Sim/src/virtual_world/fugitive_emission.py
+++ b/LDAR_Sim/src/virtual_world/fugitive_emission.py
@@ -113,7 +113,9 @@ class FugitiveEmission(Emission):
         self._status = ec.REPAIRED
         emis_rep_info.leaks_nat_repaired += 1
         emis_rep_info.nat_repair_cost += self.get_repair_cost()
-        self._repair_date = self._start_date + timedelta(days=(self._active_days))
+        self._repair_date = self._start_date + timedelta(
+            days=(self._active_days + self._days_active_b4_sim)
+        )
 
     # TODO potentially move this into company later
     def estimate_start_date(self, cur_date: date, t_since_ldar: int) -> None:

--- a/LDAR_Sim/src/virtual_world/nonfugitive_emissions.py
+++ b/LDAR_Sim/src/virtual_world/nonfugitive_emissions.py
@@ -82,7 +82,9 @@ class NonRepairableEmission(Emission):
         self._recorded_by_company = ec.EXPIRE
         self._status = ec.EXPIRE
         emis_info.emis_expired += 1
-        self._expiry_date = self._start_date + timedelta(days=(self._active_days))
+        self._expiry_date = self._start_date + timedelta(
+            days=(self._active_days + self._days_active_b4_sim)
+        )
 
     def estimate_start_date(self, cur_date: date, t_since_ldar: int) -> None:
         """Estimates the start date and days activate of the fugitive emission based on

--- a/LDAR_Sim/testing/unit_testing/test_virtual_world/test_fugitive_emission/fugitive_emission_testing_fixtures.py
+++ b/LDAR_Sim/testing/unit_testing/test_virtual_world/test_fugitive_emission/fugitive_emission_testing_fixtures.py
@@ -79,6 +79,18 @@ def mock_simple_fugitive_emission_for_natural_repair_testing_1_fix() -> (
     return to_ret, date(*[2018, 3, 2])
 
 
+@pytest.fixture(name="mock_simple_fugitive_emission_for_natural_repair_testing_2")
+def mock_simple_fugitive_emission_for_natural_repair_testing_2_fix() -> (
+    Tuple[FugitiveEmission, date]
+):
+    to_ret = FugitiveEmission(
+        1, 1, date(*[2016, 12, 31]), date(*[2017, 1, 1]), True, {}, 14, 200, 10
+    )
+    to_ret._days_since_tagged = 0
+    to_ret._active_days = 9
+    return to_ret, date(*[2017, 1, 10])
+
+
 @pytest.fixture(name="mock_simple_fugitive_emission_for_tag_leak_testing_1")
 def mock_simple_fugitive_emission_for_tag_leak_testing_1_fix() -> Tuple[
     FugitiveEmission,

--- a/LDAR_Sim/testing/unit_testing/test_virtual_world/test_fugitive_emission/test_natural_repair.py
+++ b/LDAR_Sim/testing/unit_testing/test_virtual_world/test_fugitive_emission/test_natural_repair.py
@@ -2,6 +2,7 @@ from datetime import date
 from typing import Tuple
 from testing.unit_testing.test_virtual_world.test_fugitive_emission.fugitive_emission_testing_fixtures import (  # noqa
     mock_simple_fugitive_emission_for_natural_repair_testing_1_fix,
+    mock_simple_fugitive_emission_for_natural_repair_testing_2_fix,
 )
 from src.virtual_world.fugitive_emission import FugitiveEmission
 from src.file_processing.output_processing.output_utils import EmisInfo
@@ -21,4 +22,21 @@ def test_000_natural_repair_applies_correctly_to_simple_case(
     assert (
         mock_simple_fugitive_emission_for_natural_repair_testing_1[0]._repair_date
         == mock_simple_fugitive_emission_for_natural_repair_testing_1[1]
+    )
+
+
+def test_000_natural_repair_applies_correctly_to_pregen_emission_simple(
+    mock_simple_fugitive_emission_for_natural_repair_testing_2: Tuple[FugitiveEmission, date],
+):
+    emis_info = EmisInfo(0, 0, 0, 0, 0)
+    mock_simple_fugitive_emission_for_natural_repair_testing_2[0].natural_repair(emis_info)
+    assert mock_simple_fugitive_emission_for_natural_repair_testing_2[0]._tagged is True
+    assert (
+        mock_simple_fugitive_emission_for_natural_repair_testing_2[0]._tagged_by_company
+        == "natural"
+    )
+    assert mock_simple_fugitive_emission_for_natural_repair_testing_2[0]._status == "repaired"
+    assert (
+        mock_simple_fugitive_emission_for_natural_repair_testing_2[0]._repair_date
+        == mock_simple_fugitive_emission_for_natural_repair_testing_2[1]
     )

--- a/LDAR_Sim/testing/unit_testing/test_virtual_world/test_nonfugitive_emissions/nonfugitive_emission_testing_fixtures.py
+++ b/LDAR_Sim/testing/unit_testing/test_virtual_world/test_nonfugitive_emissions/nonfugitive_emission_testing_fixtures.py
@@ -57,6 +57,16 @@ def mock_simple_nonfugitive_emission_for_expire_testing_1_fix() -> (
     return to_ret, date(*[2018, 3, 2])
 
 
+@pytest.fixture(name="mock_simple_nonfugitive_emission_for_expire_testing_2")
+def mock_simple_nonfugitive_emission_for_expire_testing_2_fix() -> (
+    Tuple[NonRepairableEmission, date]
+):
+    to_ret = NonRepairableEmission(1, 1, date(*[2016, 12, 31]), date(*[2017, 1, 1]), True, {}, 10)
+    to_ret._days_since_tagged = 30
+    to_ret._active_days = 9
+    return to_ret, date(*[2017, 1, 10])
+
+
 @pytest.fixture(name="mock_nonfugitive_emission_for_update_no_status_change")
 def mock_nonfugitive_emission_for_update_no_status_change_fix() -> NonRepairableEmission:
     to_ret = NonRepairableEmission(1, 1, date(*[2018, 1, 1]), date(*[2017, 1, 1]), True, {}, 365)

--- a/LDAR_Sim/testing/unit_testing/test_virtual_world/test_nonfugitive_emissions/test_expire.py
+++ b/LDAR_Sim/testing/unit_testing/test_virtual_world/test_nonfugitive_emissions/test_expire.py
@@ -2,6 +2,7 @@ from datetime import date
 from typing import Tuple
 from testing.unit_testing.test_virtual_world.test_nonfugitive_emissions.nonfugitive_emission_testing_fixtures import (  # noqa
     mock_simple_nonfugitive_emission_for_expire_testing_1_fix,
+    mock_simple_nonfugitive_emission_for_expire_testing_2_fix,
 )
 from src.constants.general_const import Emission_Constants as ec
 from src.virtual_world.nonfugitive_emissions import NonRepairableEmission
@@ -21,4 +22,20 @@ def test_000_expire_applies_correctly_to_simple_case(
     assert (
         mock_simple_nonfugitive_emission_for_expire_testing_1[0]._expiry_date
         == mock_simple_nonfugitive_emission_for_expire_testing_1[1]
+    )
+
+
+def test_000_expire_applies_to_pre_sim_emissions_case(
+    mock_simple_nonfugitive_emission_for_expire_testing_2: Tuple[NonRepairableEmission, date],
+):
+    emis: EmisInfo = EmisInfo()
+    mock_simple_nonfugitive_emission_for_expire_testing_2[0].expire(emis)
+    assert mock_simple_nonfugitive_emission_for_expire_testing_2[0]._record is False
+    assert (
+        mock_simple_nonfugitive_emission_for_expire_testing_2[0]._recorded_by_company == ec.EXPIRE
+    )
+    assert mock_simple_nonfugitive_emission_for_expire_testing_2[0]._status == ec.EXPIRE
+    assert (
+        mock_simple_nonfugitive_emission_for_expire_testing_2[0]._expiry_date
+        == mock_simple_nonfugitive_emission_for_expire_testing_2[1]
     )


### PR DESCRIPTION
# Pull Request Key Information

## Reason for change

Expiry/Repair dates for emissions that have started before simulation start date are not properly set as the pre-simulation start days active are not accounted for.

## What was changed

-Emissions output will now have correct expiry and repair dates

## Intended Purpose

Account for pre-simulation start days active when setting the exp/rep dates

## Testing Completed
[result.txt](https://github.com/LDAR-Sim/LDAR_Sim/files/15242258/result.txt)
Added unit tests, all existing unit tests pass. 
Double checked by running a simple sim and checking the dates on the emissions that starts before the simulation. 
Attached image is of a sim which has a start date of 2024-1-1. 
![image](https://github.com/LDAR-Sim/LDAR_Sim/assets/43421303/a9d705ad-a579-4c89-9442-cf56503ab9a1)
