### PR TITLE
V4 - Mitigation summary outputs

### DIFF
--- a/LDAR_Sim/src/constants/output_file_constants.py
+++ b/LDAR_Sim/src/constants/output_file_constants.py
@@ -203,6 +203,7 @@ class EMIS_DATA_COL_ACCESSORS:
     EST_DAYS_ACT = "Estimated Days Active"
     T_VOL_EMIT = '"True" Volume Emitted (Kg Methane)'
     EST_VOL_EMIT = '"Estimated" Volume Emitted (Kg Methane)'
+    MITIGATED = "Mitigated Emissions (Kg Methane)"
     T_RATE = '"True" Rate (g/s)'
     M_RATE = '"Measured" Rate (g/s)'
     DATE_BEG = "Date Began"
@@ -274,6 +275,7 @@ EMIS_DATA_FINAL_COL_ORDER = [
     EMIS_DATA_COL_ACCESSORS.EST_DAYS_ACT,
     EMIS_DATA_COL_ACCESSORS.DATE_BEG,
     EMIS_DATA_COL_ACCESSORS.DATE_REP_EXP,
+    EMIS_DATA_COL_ACCESSORS.MITIGATED,
     EMIS_DATA_COL_ACCESSORS.T_VOL_EMIT,
     EMIS_DATA_COL_ACCESSORS.EST_VOL_EMIT,
     EMIS_DATA_COL_ACCESSORS.T_RATE,

--- a/LDAR_Sim/src/constants/output_file_constants.py
+++ b/LDAR_Sim/src/constants/output_file_constants.py
@@ -144,8 +144,10 @@ class TS_SUMMARY_COLUMNS_ACCESSORS:
 class EMIS_SUMMARY_COLUMNS_ACCESSORS:
     PROG_NAME = "Program Name"
     SIM = "Simulation"
+    T_ANN_MIT = 'Year {} "True" Mitigated Emissions (Kg Methane)'
     T_ANN_EMIS = 'Year {} "True" Emissions (Kg Methane)'
     EST_ANN_EMIS = 'Year {} "Estimated" Emissions (Kg Methane)'
+    REGX_T_ANN_MIT = r'Year \d+ "True" Mitigated Emissions \(Kg Methane\)'
     REGX_T_ANN_EMIS = r'Year \d+ "True" Emissions \(Kg Methane\)'
     REGX_EST_ANN_EMIS = r'Year \d+ "Estimated" Emissions \(Kg Methane\)'
     REGX_EST_FUG_ANN_EMIS = r'Year \d+ "Estimated" Fugitive Emissions \(Kg Methane\)'
@@ -210,6 +212,7 @@ class EMIS_DATA_COL_ACCESSORS:
     M_RATE = '"Measured" Rate (g/s)'
     DATE_BEG = "Date Began"
     DATE_REP_EXP = "Date Repaired or Expired"
+    THEORY_DATE = "Theoretical End Date"
     INIT_DETECT_BY = "Initially Detected By"
     INIT_DETECT_DATE = "Initially Detected Date"
     TAGGED = "Tagged"
@@ -277,6 +280,7 @@ EMIS_DATA_FINAL_COL_ORDER = [
     EMIS_DATA_COL_ACCESSORS.EST_DAYS_ACT,
     EMIS_DATA_COL_ACCESSORS.DATE_BEG,
     EMIS_DATA_COL_ACCESSORS.DATE_REP_EXP,
+    EMIS_DATA_COL_ACCESSORS.THEORY_DATE,
     EMIS_DATA_COL_ACCESSORS.MITIGATED,
     EMIS_DATA_COL_ACCESSORS.T_VOL_EMIT,
     EMIS_DATA_COL_ACCESSORS.EST_VOL_EMIT,

--- a/LDAR_Sim/src/constants/output_file_constants.py
+++ b/LDAR_Sim/src/constants/output_file_constants.py
@@ -149,6 +149,7 @@ class EMIS_SUMMARY_COLUMNS_ACCESSORS:
     REGX_T_ANN_EMIS = r'Year \d+ "True" Emissions \(Kg Methane\)'
     REGX_EST_ANN_EMIS = r'Year \d+ "Estimated" Emissions \(Kg Methane\)'
     REGX_EST_FUG_ANN_EMIS = r'Year \d+ "Estimated" Fugitive Emissions \(Kg Methane\)'
+    T_TOT_MIT = 'Total "True" Mitigated Emissions (Kg Methane)'
     T_TOTAL_EMIS = 'Total "True" Emissions (Kg Methane)'
     EST_TOTAL_EMIS = 'Total "Estimated" Emissions (Kg Methane)'
     T_TOTAL_MIT_EMIS = 'Total "True" Mitigable Emissions (Kg Methane)'
@@ -181,6 +182,7 @@ TS_SUMMARY_COLUMNS = [
 EMIS_SUMMARY_COLUMNS = [
     EMIS_SUMMARY_COLUMNS_ACCESSORS.PROG_NAME,
     EMIS_SUMMARY_COLUMNS_ACCESSORS.SIM,
+    EMIS_SUMMARY_COLUMNS_ACCESSORS.T_TOT_MIT,
     EMIS_SUMMARY_COLUMNS_ACCESSORS.T_TOTAL_EMIS,
     EMIS_SUMMARY_COLUMNS_ACCESSORS.EST_TOTAL_EMIS,
     EMIS_SUMMARY_COLUMNS_ACCESSORS.T_TOTAL_MIT_EMIS,

--- a/LDAR_Sim/src/constants/param_default_const.py
+++ b/LDAR_Sim/src/constants/param_default_const.py
@@ -184,6 +184,7 @@ class Output_Params:
     AVERAGE_DAILY_COST = "Average Daily Cost ($)"
     PERCENTILE_95_DAILY_COST = "95th Percentile Daily Cost ($)"
     PERCENTILE_5_DAILY_COST = "5th Percentile Daily Cost ($)"
+    EMISSIONS_SUMMARY_TOT_MITIGATION = 'Total "True" Mitigated Emissions (Kg Methane)'
     EMISSIONS_SUMMARY_TOTAL_TRUE = 'Total "True" Emissions (Kg Methane)'
     EMISSIONS_SUMMARY_TOTAL_ESTIMATED = 'Total "Estimated" Emissions (Kg Methane)'
     EMISSIONS_SUMMARY_TOTAL_MITIGABLE = 'Total "True" Mitigable Emissions (Kg Methane)'

--- a/LDAR_Sim/src/default_parameters/outputs_default.yml
+++ b/LDAR_Sim/src/default_parameters/outputs_default.yml
@@ -22,6 +22,7 @@ Summary Outputs:
       95th Percentile Daily Cost ($): true
       5th Percentile Daily Cost ($): true
     Emissions Summary:
+      Total "True" Mitigated Emissions (Kg Methane): true
       Total "True" Emissions (Kg Methane): true
       Total "Estimated" Emissions (Kg Methane): true
       Total "True" Mitigable Emissions (Kg Methane): true

--- a/LDAR_Sim/src/file_processing/output_processing/program_output_helpers.py
+++ b/LDAR_Sim/src/file_processing/output_processing/program_output_helpers.py
@@ -32,7 +32,15 @@ def closest_future_date(date: pd.Timestamp, date_list: list[pd.Timestamp]) -> pd
 def find_df_row_value_w_match(
     value_to_match: Any, value_col: str, return_col: str, df: pd.DataFrame
 ):
-    return df.loc[df.loc[:, value_col] == value_to_match, return_col].values[0]
+    if not df.empty:
+        matching_rows = df.loc[df.loc[:, value_col] == value_to_match, return_col].values
+        if len(matching_rows) > 0:
+            return matching_rows[0]
+        else:
+            # Handle case where no matching rows were found
+            return False
+    else:
+        return False
 
 
 # Function to calculate start_date based on conditions

--- a/LDAR_Sim/src/file_processing/output_processing/summary_output_mapper.py
+++ b/LDAR_Sim/src/file_processing/output_processing/summary_output_mapper.py
@@ -106,6 +106,11 @@ class SummaryOutputMapper:
             ),
         },
         file_name_constants.Output_Files.SummaryFileNames.EMIS_SUMMARY: {
+            output_file_constants.EMIS_SUMMARY_COLUMNS_ACCESSORS.T_TOT_MIT: lambda df: (
+                summary_output_helpers.get_sum(
+                    df, output_file_constants.EMIS_DATA_COL_ACCESSORS.MITIGATED
+                )
+            ),
             output_file_constants.EMIS_SUMMARY_COLUMNS_ACCESSORS.T_TOTAL_EMIS: lambda df: (
                 summary_output_helpers.get_sum(
                     df, output_file_constants.EMIS_DATA_COL_ACCESSORS.T_VOL_EMIT

--- a/LDAR_Sim/src/file_processing/output_processing/summary_output_mapper.py
+++ b/LDAR_Sim/src/file_processing/output_processing/summary_output_mapper.py
@@ -178,6 +178,17 @@ class SummaryOutputMapper:
 
     YEARLY_MAPPINGS = {
         file_name_constants.Output_Files.SummaryFileNames.EMIS_SUMMARY: {
+            output_file_constants.EMIS_SUMMARY_COLUMNS_ACCESSORS.T_ANN_MIT: lambda year: (
+                lambda df: (
+                    summary_output_helpers.get_yearly_value_for_multi_day_stat(
+                        df,
+                        output_file_constants.EMIS_DATA_COL_ACCESSORS.MITIGATED,
+                        year,
+                        output_file_constants.EMIS_DATA_COL_ACCESSORS.DATE_REP_EXP,
+                        output_file_constants.EMIS_DATA_COL_ACCESSORS.THEORY_DATE,
+                    )
+                )
+            ),
             output_file_constants.EMIS_SUMMARY_COLUMNS_ACCESSORS.T_ANN_EMIS: lambda year: (
                 lambda df: (
                     summary_output_helpers.get_yearly_value_for_multi_day_stat(

--- a/LDAR_Sim/src/virtual_world/emissions.py
+++ b/LDAR_Sim/src/virtual_world/emissions.py
@@ -33,6 +33,7 @@ class Emission:
         eca.STATUS: "object",
         eca.DAYS_ACT: "int32",
         eca.T_VOL_EMIT: "float64",
+        eca.MITIGATED: "float64",
         eca.EST_VOL_EMIT: "float64",
         eca.T_RATE: "float64",
         eca.M_RATE: "float64",
@@ -42,6 +43,7 @@ class Emission:
         eca.TAGGED: "bool",
         eca.TAGGED_BY: "object",
         eca.DATE_REP_EXP: "datetime64",
+        eca.THEORY_DATE: "datetime64",
     }
 
     def __init__(

--- a/LDAR_Sim/src/virtual_world/emissions.py
+++ b/LDAR_Sim/src/virtual_world/emissions.py
@@ -134,6 +134,7 @@ class Emission:
         summary_dict.update({(eca.DAYS_ACT, self._active_days)})
         summary_dict.update({(eca.EST_DAYS_ACT, self._estimated_days_active)})
         summary_dict.update({(eca.T_VOL_EMIT, self.calc_true_emis_vol())})
+        summary_dict.update({(eca.MITIGATED, 0.0)})
         summary_dict.update({(eca.T_RATE, self._rate)})
         summary_dict.update({(eca.M_RATE, self._measured_rate)})
         summary_dict.update({(eca.DATE_BEG, self._start_date)})

--- a/LDAR_Sim/src/virtual_world/fugitive_emission.py
+++ b/LDAR_Sim/src/virtual_world/fugitive_emission.py
@@ -166,6 +166,9 @@ class FugitiveEmission(Emission):
             return mit_days * self._rate * cc.GRAMS_PER_SECOND_TO_KG_PER_DAY
         return 0.0
 
+    def calc_theory_date(self) -> date:
+        return self._start_date + timedelta(days=self._nrd)
+
     @override
     def update(self, emis_rep_info: EmisInfo) -> bool:
         is_active: bool = super().update(emis_rep_info)
@@ -186,6 +189,7 @@ class FugitiveEmission(Emission):
         summary_dict.update({(eca.TAGGED, self._tagged)})
         summary_dict.update({(eca.TAGGED_BY, self._tagged_by_company)})
         summary_dict.update({(eca.MITIGATED, self.calc_mitigated())})
+        summary_dict.update({(eca.THEORY_DATE, self.calc_theory_date())})
         return summary_dict
 
     @override

--- a/LDAR_Sim/src/virtual_world/fugitive_emission.py
+++ b/LDAR_Sim/src/virtual_world/fugitive_emission.py
@@ -24,7 +24,6 @@ from numpy import random
 from typing import Any
 from typing_extensions import override
 
-from constants.general_const import Conversion_Constants as conv_const
 from file_processing.output_processing.output_utils import EmisInfo
 from constants.output_file_constants import EMIS_DATA_COL_ACCESSORS as eca
 from constants.general_const import Emission_Constants as ec, Conversion_Constants as cc
@@ -161,6 +160,12 @@ class FugitiveEmission(Emission):
         self._tagging_rep_delay = tagging_rep_delay
         return True
 
+    def calc_mitigated(self) -> float:
+        mit_days = self._nrd - self._active_days
+        if self._tagged_by_company != ec.NATURAL and self._status == ec.REPAIRED and mit_days > 0:
+            return mit_days * self._rate * cc.GRAMS_PER_SECOND_TO_KG_PER_DAY
+        return 0.0
+
     @override
     def update(self, emis_rep_info: EmisInfo) -> bool:
         is_active: bool = super().update(emis_rep_info)
@@ -180,6 +185,7 @@ class FugitiveEmission(Emission):
         summary_dict.update({(eca.DATE_REP_EXP, self._repair_date)})
         summary_dict.update({(eca.TAGGED, self._tagged)})
         summary_dict.update({(eca.TAGGED_BY, self._tagged_by_company)})
+        summary_dict.update({(eca.MITIGATED, self.calc_mitigated())})
         return summary_dict
 
     @override

--- a/LDAR_Sim/src/virtual_world/nonfugitive_emissions.py
+++ b/LDAR_Sim/src/virtual_world/nonfugitive_emissions.py
@@ -147,6 +147,7 @@ class NonRepairableEmission(Emission):
         summary_dict.update({(eca.RECORDED, self._record)})
         summary_dict.update({(eca.RECORDED_BY, self._recorded_by_company)})
         summary_dict.update({(eca.DATE_REP_EXP, self._expiry_date)})
+        summary_dict.update({(eca.THEORY_DATE, self._expiry_date)})
         return summary_dict
 
     @override

--- a/LDAR_Sim/src/virtual_world/nonfugitive_emissions.py
+++ b/LDAR_Sim/src/virtual_world/nonfugitive_emissions.py
@@ -24,7 +24,6 @@ from typing import Any
 from typing_extensions import override
 
 from numpy import average
-from constants.general_const import Conversion_Constants as conv_const
 from virtual_world.emissions import Emission
 from file_processing.output_processing.output_utils import EmisInfo
 from constants.output_file_constants import EMIS_DATA_COL_ACCESSORS as eca

--- a/LDAR_Sim/testing/unit_testing/test_file_processing/test_output_processing/test_summary_output_mapper/test_add_yearly_mappings.py
+++ b/LDAR_Sim/testing/unit_testing/test_file_processing/test_output_processing/test_summary_output_mapper/test_add_yearly_mappings.py
@@ -11,6 +11,9 @@ def test_add_yearly_mappings_set_expected_mappings(mocker):
     summary_file = file_name_constants.Output_Files.SummaryFileNames.EMIS_SUMMARY
     simulation_years = [2017, 2018, 2019]
     expected_keys = [
+        output_file_constants.EMIS_SUMMARY_COLUMNS_ACCESSORS.T_ANN_MIT.format(2017),
+        output_file_constants.EMIS_SUMMARY_COLUMNS_ACCESSORS.T_ANN_MIT.format(2018),
+        output_file_constants.EMIS_SUMMARY_COLUMNS_ACCESSORS.T_ANN_MIT.format(2019),
         output_file_constants.EMIS_SUMMARY_COLUMNS_ACCESSORS.T_ANN_EMIS.format(2017),
         output_file_constants.EMIS_SUMMARY_COLUMNS_ACCESSORS.T_ANN_EMIS.format(2018),
         output_file_constants.EMIS_SUMMARY_COLUMNS_ACCESSORS.T_ANN_EMIS.format(2019),

--- a/LDAR_Sim/testing/unit_testing/test_file_processing/test_output_processing/test_summary_output_mapper/test_init.py
+++ b/LDAR_Sim/testing/unit_testing/test_file_processing/test_output_processing/test_summary_output_mapper/test_init.py
@@ -19,6 +19,7 @@ def get_mock_output_config_data():
             param_default_const.Output_Params.PERCENTILE_5_DAILY_COST: True,
         },
         param_default_const.Output_Params.EMISSIONS_SUMMARY: {
+            param_default_const.Output_Params.EMISSIONS_SUMMARY_TOT_MITIGATION: True,
             param_default_const.Output_Params.EMISSIONS_SUMMARY_TOTAL_TRUE: True,
             param_default_const.Output_Params.EMISSIONS_SUMMARY_TOTAL_ESTIMATED: True,
             param_default_const.Output_Params.EMISSIONS_SUMMARY_TOTAL_MITIGABLE: True,
@@ -39,6 +40,9 @@ def test_summary_output_mapper_init():
     mock_sim_years = [2020, 2021, 2022]
     output_mapper: SummaryOutputMapper = SummaryOutputMapper(mock_output_config, mock_sim_years)
     expected_yearly_mapping_keys = [
+        output_file_constants.EMIS_SUMMARY_COLUMNS_ACCESSORS.T_ANN_MIT.format(2020),
+        output_file_constants.EMIS_SUMMARY_COLUMNS_ACCESSORS.T_ANN_MIT.format(2021),
+        output_file_constants.EMIS_SUMMARY_COLUMNS_ACCESSORS.T_ANN_MIT.format(2022),
         output_file_constants.EMIS_SUMMARY_COLUMNS_ACCESSORS.T_ANN_EMIS.format(2020),
         output_file_constants.EMIS_SUMMARY_COLUMNS_ACCESSORS.T_ANN_EMIS.format(2021),
         output_file_constants.EMIS_SUMMARY_COLUMNS_ACCESSORS.T_ANN_EMIS.format(2022),

--- a/LDAR_Sim/testing/unit_testing/test_file_processing/test_output_processing/test_summary_output_mapper/test_set_summary_mapping.py
+++ b/LDAR_Sim/testing/unit_testing/test_file_processing/test_output_processing/test_summary_output_mapper/test_set_summary_mapping.py
@@ -24,6 +24,7 @@ def get_mock_output_config_data():
             param_default_const.Output_Params.PERCENTILE_5_DAILY_COST: True,
         },
         param_default_const.Output_Params.EMISSIONS_SUMMARY: {
+            param_default_const.Output_Params.EMISSIONS_SUMMARY_TOT_MITIGATION: True,
             param_default_const.Output_Params.EMISSIONS_SUMMARY_TOTAL_TRUE: True,
             param_default_const.Output_Params.EMISSIONS_SUMMARY_TOTAL_ESTIMATED: True,
             param_default_const.Output_Params.EMISSIONS_SUMMARY_TOTAL_MITIGABLE: True,

--- a/LDAR_Sim/testing/unit_testing/test_file_processing/test_output_processing/test_summary_outputs/test_summarize_program_outputs.py
+++ b/LDAR_Sim/testing/unit_testing/test_file_processing/test_output_processing/test_summary_outputs/test_summarize_program_outputs.py
@@ -55,6 +55,7 @@ def get_mock_summary_output_mapper():
                 param_default_const.Output_Params.PERCENTILE_5_DAILY_COST: True,
             },
             param_default_const.Output_Params.EMISSIONS_SUMMARY: {
+                param_default_const.Output_Params.EMISSIONS_SUMMARY_TOT_MITIGATION: True,
                 param_default_const.Output_Params.EMISSIONS_SUMMARY_TOTAL_TRUE: True,
                 param_default_const.Output_Params.EMISSIONS_SUMMARY_TOTAL_ESTIMATED: True,
                 param_default_const.Output_Params.EMISSIONS_SUMMARY_TOTAL_MITIGABLE: True,
@@ -102,33 +103,39 @@ mock_emis_csv_data = {
         {
             eca.T_VOL_EMIT: [1, 2, 3, 4],
             eca.EST_VOL_EMIT: [0, 1, 2, 3],
+            eca.MITIGATED: [0, 1, 1, 1],
             eca.T_RATE: [10, 9, 8, 7],
             eca.M_RATE: [9, 8, 7, 6],
             eca.REPAIRABLE: [True, True, True, False],
             eca.DATE_BEG: ["2024-01-01", "2024-01-01", "2025-01-01", "2025-01-01"],
             eca.DATE_REP_EXP: ["2024-01-01", "2024-01-01", "2025-01-01", "2025-01-01"],
+            eca.THEORY_DATE: ["2024-01-02", "2024-01-02", "2025-01-02", "2025-01-01"],
         }
     ),
     "test_1_emissions_summary.csv": pd.DataFrame(
         {
             eca.T_VOL_EMIT: [5, 6, 7, 8],
             eca.EST_VOL_EMIT: [4, 5, 6, 7],
+            eca.MITIGATED: [1, 1, 1, 0],
             eca.T_RATE: [6, 5, 4, 3],
             eca.M_RATE: [5, 4, 3, 2],
             eca.REPAIRABLE: [True, True, True, False],
             eca.DATE_BEG: ["2024-01-01", "2024-01-01", "2025-01-01", "2025-01-01"],
             eca.DATE_REP_EXP: ["2024-01-01", "2024-01-01", "2025-01-01", "2025-01-01"],
+            eca.THEORY_DATE: ["2024-01-02", "2024-01-02", "2025-01-02", "2025-01-01"],
         }
     ),
     "test_2_emissions_summary.csv": pd.DataFrame(
         {
             eca.T_VOL_EMIT: [9, 10, 11, 12],
             eca.EST_VOL_EMIT: [8, 9, 10, 11],
+            eca.MITIGATED: [1, 1, 1, 1],
             eca.T_RATE: [3, 2, 1, 0],
             eca.M_RATE: [2, 1, 0, 0],
             eca.REPAIRABLE: [True, True, True, False],
             eca.DATE_BEG: ["2024-01-01", "2024-01-01", "2025-01-01", "2025-01-01"],
             eca.DATE_REP_EXP: ["2024-01-01", "2024-01-01", "2025-01-01", "2025-01-01"],
+            eca.THEORY_DATE: ["2024-01-02", "2024-01-02", "2025-01-02", "2025-01-01"],
         }
     ),
 }
@@ -137,6 +144,7 @@ expected_emis_summary_csv = pd.DataFrame(
     {
         esca.PROG_NAME: ["test", "test", "test"],
         esca.SIM: ["0", "1", "2"],
+        esca.T_TOT_MIT: [3, 3, 4],
         esca.T_TOTAL_EMIS: [10, 26, 42],
         esca.EST_TOTAL_EMIS: [6, 22, 38],
         esca.T_TOTAL_MIT_EMIS: [6, 18, 30],
@@ -147,6 +155,8 @@ expected_emis_summary_csv = pd.DataFrame(
         esca.T_AVG_EMIS_AMOUNT: [2.5, 6.5, 10.5],
         esca.T_EMIS_AMOUNT_95: [4.0, 8.0, 12.0],
         esca.T_EMIS_AMOUNT_5: [1.0, 5.0, 9.0],
+        esca.T_ANN_MIT.format(2024): [1.0, 2.0, 2.0],
+        esca.T_ANN_MIT.format(2025): [2.0, 1.0, 2.0],
         esca.T_ANN_EMIS.format(2024): [3.0, 11.0, 19.0],
         esca.T_ANN_EMIS.format(2025): [7.0, 15.0, 23.0],
         esca.EST_ANN_EMIS.format(2024): [0, 0, 0],
@@ -157,6 +167,7 @@ expected_emis_summary_csv2 = pd.DataFrame(
     {
         esca.PROG_NAME: ["test", "test", "test"],
         esca.SIM: ["0", "1", "2"],
+        esca.T_TOT_MIT: [3, 3, 4],
         esca.T_TOTAL_EMIS: [10, 26, 42],
         esca.EST_TOTAL_EMIS: [6, 22, 38],
         esca.T_TOTAL_MIT_EMIS: [6, 18, 30],
@@ -167,6 +178,8 @@ expected_emis_summary_csv2 = pd.DataFrame(
         esca.T_AVG_EMIS_AMOUNT: [2.5, 6.5, 10.5],
         esca.T_EMIS_AMOUNT_95: [4.0, 8.0, 12.0],
         esca.T_EMIS_AMOUNT_5: [1.0, 5.0, 9.0],
+        esca.T_ANN_MIT.format(2024): [1.0, 2.0, 2.0],
+        esca.T_ANN_MIT.format(2025): [2.0, 1.0, 2.0],
         esca.T_ANN_EMIS.format(2024): [3.0, 11.0, 19.0],
         esca.T_ANN_EMIS.format(2025): [7.0, 15.0, 23.0],
         esca.EST_ANN_EMIS.format(2024): [0.0, 7.0, 13.0],

--- a/LDAR_Sim/testing/unit_testing/test_virtual_world/test_emissions/emissions_testing_fixtures.py
+++ b/LDAR_Sim/testing/unit_testing/test_virtual_world/test_emissions/emissions_testing_fixtures.py
@@ -1,3 +1,23 @@
+"""
+------------------------------------------------------------------------------
+Program:     The LDAR Simulator (LDAR-Sim)
+File:        emissions_testing_fixtures.py
+Purpose: Contains fixtures for testing emissions unit tests
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the MIT License as published
+by the Free Software Foundation, version 3.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+MIT License for more details.
+You should have received a copy of the MIT License
+along with this program.  If not, see <https://opensource.org/licenses/MIT>.
+
+------------------------------------------------------------------------------
+"""
+
 from datetime import date
 from typing import Tuple
 import pytest
@@ -58,6 +78,7 @@ def mock_simple_emission_for_get_summary_dict_fix() -> Tuple[Emission, dict[str,
             "Days Active": 0,
             "Estimated Days Active": 0,
             '"True" Volume Emitted (Kg Methane)': 0.0,
+            "Mitigated Emissions (Kg Methane)": 0.0,
             '"True" Rate (g/s)': 1,
             '"Measured" Rate (g/s)': None,
             "Date Began": date(2018, 1, 1),

--- a/LDAR_Sim/testing/unit_testing/test_virtual_world/test_fugitive_emission/fugitive_emission_testing_fixtures.py
+++ b/LDAR_Sim/testing/unit_testing/test_virtual_world/test_fugitive_emission/fugitive_emission_testing_fixtures.py
@@ -1,3 +1,23 @@
+"""
+------------------------------------------------------------------------------
+Program:     The LDAR Simulator (LDAR-Sim)
+File:        fugitive_emissions_testing_fixtures.py
+Purpose: Contains fixtures for fugitive emission testing unit tests
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the MIT License as published
+by the Free Software Foundation, version 3.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+MIT License for more details.
+You should have received a copy of the MIT License
+along with this program.  If not, see <https://opensource.org/licenses/MIT>.
+
+------------------------------------------------------------------------------
+"""
+
 from datetime import date
 from typing import Tuple
 import pytest
@@ -52,6 +72,7 @@ def mock_simple_emission_for_get_summary_dict_1_fix() -> Tuple[FugitiveEmission,
             "Days Active": 0,
             "Estimated Days Active": 0,
             '"True" Volume Emitted (Kg Methane)': 0.0,
+            "Mitigated Emissions (Kg Methane)": 0.0,
             '"True" Rate (g/s)': 1,
             '"Measured" Rate (g/s)': None,
             "Date Began": date(2018, 1, 1),

--- a/LDAR_Sim/testing/unit_testing/test_virtual_world/test_fugitive_emission/fugitive_emission_testing_fixtures.py
+++ b/LDAR_Sim/testing/unit_testing/test_virtual_world/test_fugitive_emission/fugitive_emission_testing_fixtures.py
@@ -84,6 +84,7 @@ def mock_simple_emission_for_get_summary_dict_1_fix() -> Tuple[FugitiveEmission,
             "Recorded By": "N/A",
             "Repairable": True,
             "Date Repaired or Expired": None,
+            "Theoretical End Date": date(2019, 1, 1),
         },
     )
 

--- a/LDAR_Sim/testing/unit_testing/test_virtual_world/test_fugitive_emission/test_calculate_mitigation.py
+++ b/LDAR_Sim/testing/unit_testing/test_virtual_world/test_fugitive_emission/test_calculate_mitigation.py
@@ -28,12 +28,26 @@ def mock_simple_fugitive_emission_for_mitigation1() -> FugitiveEmission:
     return FugitiveEmission(1, 1, date(*[2018, 1, 1]), date(*[2017, 1, 1]), False, {}, 14, 200, 365)
 
 
+def mock_simple_fugitive_emission_for_mitigation2() -> FugitiveEmission:
+    return FugitiveEmission(
+        1,
+        1,
+        date(*[2019, 12, 30]),
+        date(*[2017, 1, 1]),
+        False,
+        {},
+        14,
+        200,
+        365,
+    )
+
+
 def test_000_calc_mit_returns_expected_values_for_simple_case() -> None:
     fug_emis: FugitiveEmission = mock_simple_fugitive_emission_for_mitigation1()
 
     fug_emis._active_days = 100
     fug_emis._status = ec.REPAIRED
-    mitigated = fug_emis.calc_mitigated()
+    mitigated = fug_emis.calc_mitigated(date(*[2019, 1, 1]))
     expected = 22896
     assert expected == mitigated
 
@@ -42,7 +56,7 @@ def test_000_calc_mit_returns_expected_values_for_simple_active_emissions() -> N
     fug_emis: FugitiveEmission = mock_simple_fugitive_emission_for_mitigation1()
 
     fug_emis._active_days = 100
-    mitigated = fug_emis.calc_mitigated()
+    mitigated = fug_emis.calc_mitigated(date(*[2019, 1, 1]))
     expected = 0.0
     assert expected == mitigated
 
@@ -51,7 +65,7 @@ def test_000_calc_mit_returns_expected_values_for_not_active() -> None:
     fug_emis: FugitiveEmission = mock_simple_fugitive_emission_for_mitigation1()
 
     fug_emis._active_days = 0
-    mitigated = fug_emis.calc_mitigated()
+    mitigated = fug_emis.calc_mitigated(date(*[2019, 1, 1]))
     expected = 0.0
     assert expected == mitigated
 
@@ -60,7 +74,7 @@ def test_000_calc_mit_returns_expected_values_for_edge_case_nrd_less_than_active
     fug_emis: FugitiveEmission = mock_simple_fugitive_emission_for_mitigation1()
     fug_emis._status = ec.REPAIRED
     fug_emis._active_days = 370
-    mitigated = fug_emis.calc_mitigated()
+    mitigated = fug_emis.calc_mitigated(date(*[2019, 1, 1]))
     expected = 0.0
     assert expected == mitigated
 
@@ -70,6 +84,25 @@ def test_000_calc_mit_returns_expected_values_for_repaired_by_nrd_but_active_is_
     fug_emis._status = ec.REPAIRED
     fug_emis._active_days = 10
     fug_emis._tagged_by_company = ec.NATURAL
-    mitigated = fug_emis.calc_mitigated()
+    mitigated = fug_emis.calc_mitigated(date(*[2019, 1, 1]))
     expected = 0.0
+    assert expected == mitigated
+
+
+def test_000_calc_mit_emiss_start_before_sim() -> None:
+    fug_emis: FugitiveEmission = mock_simple_fugitive_emission_for_mitigation1()
+    fug_emis._status = ec.REPAIRED
+    fug_emis._active_days = 50
+    fug_emis._days_active_b4_sim = 50
+    mitigated = fug_emis.calc_mitigated(date(*[2019, 1, 1]))
+    expected = 22896
+    assert expected == mitigated
+
+
+def test_000_calc_mit_emiss_rep_emiss_end_date_before_theory_date() -> None:
+    fug_emis: FugitiveEmission = mock_simple_fugitive_emission_for_mitigation2()
+    fug_emis._status = ec.REPAIRED
+    fug_emis._active_days = 1
+    mitigated = fug_emis.calc_mitigated(date(*[2020, 1, 1]))
+    expected = 86.4
     assert expected == mitigated

--- a/LDAR_Sim/testing/unit_testing/test_virtual_world/test_fugitive_emission/test_calculate_mitigation.py
+++ b/LDAR_Sim/testing/unit_testing/test_virtual_world/test_fugitive_emission/test_calculate_mitigation.py
@@ -1,0 +1,75 @@
+"""
+------------------------------------------------------------------------------
+Program:     The LDAR Simulator (LDAR-Sim)
+File:        test_calculate_mitigation.py
+Purpose: Contains unit tests for testing the calculation of mitigation of 
+fugitive emissions
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the MIT License as published
+by the Free Software Foundation, version 3.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+MIT License for more details.
+You should have received a copy of the MIT License
+along with this program.  If not, see <https://opensource.org/licenses/MIT>.
+
+------------------------------------------------------------------------------
+"""
+
+from datetime import date
+from src.virtual_world.fugitive_emission import FugitiveEmission
+from src.constants.general_const import Emission_Constants as ec
+
+
+def mock_simple_fugitive_emission_for_mitigation1() -> FugitiveEmission:
+    return FugitiveEmission(1, 1, date(*[2018, 1, 1]), date(*[2017, 1, 1]), False, {}, 14, 200, 365)
+
+
+def test_000_calc_mit_returns_expected_values_for_simple_case() -> None:
+    fug_emis: FugitiveEmission = mock_simple_fugitive_emission_for_mitigation1()
+
+    fug_emis._active_days = 100
+    fug_emis._status = ec.REPAIRED
+    mitigated = fug_emis.calc_mitigated()
+    expected = 22896
+    assert expected == mitigated
+
+
+def test_000_calc_mit_returns_expected_values_for_simple_active_emissions() -> None:
+    fug_emis: FugitiveEmission = mock_simple_fugitive_emission_for_mitigation1()
+
+    fug_emis._active_days = 100
+    mitigated = fug_emis.calc_mitigated()
+    expected = 0.0
+    assert expected == mitigated
+
+
+def test_000_calc_mit_returns_expected_values_for_not_active() -> None:
+    fug_emis: FugitiveEmission = mock_simple_fugitive_emission_for_mitigation1()
+
+    fug_emis._active_days = 0
+    mitigated = fug_emis.calc_mitigated()
+    expected = 0.0
+    assert expected == mitigated
+
+
+def test_000_calc_mit_returns_expected_values_for_edge_case_nrd_less_than_active() -> None:
+    fug_emis: FugitiveEmission = mock_simple_fugitive_emission_for_mitigation1()
+    fug_emis._status = ec.REPAIRED
+    fug_emis._active_days = 370
+    mitigated = fug_emis.calc_mitigated()
+    expected = 0.0
+    assert expected == mitigated
+
+
+def test_000_calc_mit_returns_expected_values_for_repaired_by_nrd_but_active_is_less() -> None:
+    fug_emis: FugitiveEmission = mock_simple_fugitive_emission_for_mitigation1()
+    fug_emis._status = ec.REPAIRED
+    fug_emis._active_days = 10
+    fug_emis._tagged_by_company = ec.NATURAL
+    mitigated = fug_emis.calc_mitigated()
+    expected = 0.0
+    assert expected == mitigated

--- a/LDAR_Sim/testing/unit_testing/test_virtual_world/test_nonfugitive_emissions/nonfugitive_emission_testing_fixtures.py
+++ b/LDAR_Sim/testing/unit_testing/test_virtual_world/test_nonfugitive_emissions/nonfugitive_emission_testing_fixtures.py
@@ -1,3 +1,23 @@
+"""
+------------------------------------------------------------------------------
+Program:     The LDAR Simulator (LDAR-Sim)
+File:        non-fugitive_emission_testing_fixtures.py
+Purpose: Contains fixtures for nonfugitive emission testing unit tests
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the MIT License as published
+by the Free Software Foundation, version 3.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+MIT License for more details.
+You should have received a copy of the MIT License
+along with this program.  If not, see <https://opensource.org/licenses/MIT>.
+
+------------------------------------------------------------------------------
+"""
+
 from datetime import date
 from typing import Tuple
 import pytest
@@ -32,6 +52,7 @@ def mock_simple_emission_for_get_summary_dict_1_fix() -> (
             "Days Active": 0,
             "Estimated Days Active": 0,
             '"True" Volume Emitted (Kg Methane)': 0.0,
+            "Mitigated Emissions (Kg Methane)": 0.0,
             '"True" Rate (g/s)': 1,
             '"Measured" Rate (g/s)': None,
             "Date Began": date(2018, 1, 1),

--- a/LDAR_Sim/testing/unit_testing/test_virtual_world/test_nonfugitive_emissions/nonfugitive_emission_testing_fixtures.py
+++ b/LDAR_Sim/testing/unit_testing/test_virtual_world/test_nonfugitive_emissions/nonfugitive_emission_testing_fixtures.py
@@ -64,6 +64,7 @@ def mock_simple_emission_for_get_summary_dict_1_fix() -> (
             "Recorded By": None,
             "Repairable": False,
             "Date Repaired or Expired": None,
+            "Theoretical End Date": None,
         },
     )
 


### PR DESCRIPTION
# Pull Request Key Information

## Reason for change

Mitigation output statistics were missing. 

## What was changed

Added mitigation output summary stats
Updated existing unit tests to account for changes in structure/format

## Testing Completed

Added relevant unit tests for calculating the mitigation 
All unit tests pass. 
[results.txt](https://github.com/LDAR-Sim/LDAR_Sim/files/15253880/results.txt)

Manually ran simulations and checked numbers using emission values.

## Additional
Requires PR #186 