### PR TITLE
<Fix>: Rework program_output

### DIFF
--- a/LDAR_Sim/src/file_processing/output_processing/program_output.py
+++ b/LDAR_Sim/src/file_processing/output_processing/program_output.py
@@ -108,12 +108,11 @@ def gen_estimated_fugitive_emissions_to_remove(
 
 
 def gen_estimated_emissions_report(
-    pm,
     site_survey_reports_summary: pd.DataFrame,
     fugutive_emissions_rates_and_repair_dates: pd.DataFrame,
     start_date: date,
     end_date: date,
-) -> None:
+) -> tuple[pd.DataFrame, pd.DataFrame]:
     """Generate a report of yearly estimated emissions based on site survey reports
     Args:
         site_survey_reports (pd.DataFrame): The site survey reports
@@ -189,21 +188,15 @@ def gen_estimated_emissions_report(
 
     # Select only the predefined columns
     selected_sorted_by_site_summary = sorted_by_site_summary[EMIS_ESTIMATION_OUTPUT_COLUMNS]
-
-    rep_filename: str = pm.generate_file_names(Output_Files.EST_REP_EMISSIONS_FILE)
-    filename: str = pm.generate_file_names(Output_Files.EST_EMISSIONS_FILE)
-
-    selected_sorted_by_site_summary.to_csv(pm._output_dir / filename, index=False)
-    fugitive_emissions_to_remove.to_csv(pm._output_dir / rep_filename, index=False)
+    return (selected_sorted_by_site_summary, fugitive_emissions_to_remove)
 
 
 def gen_estimated_comp_emissions_report(
-    pm,
     site_survey_reports_summary: pd.DataFrame,
     fugutive_emissions_rates_and_repair_dates: pd.DataFrame,
     start_date: date,
     end_date: date,
-) -> None:
+) -> tuple[pd.DataFrame, pd.DataFrame]:
     """Generate a report of yearly estimated emissions based on only component level surveys
     Args:
         site_survey_reports (pd.DataFrame): The site survey reports
@@ -325,9 +318,5 @@ def gen_estimated_comp_emissions_report(
 
     # Filter out only the predefined columns
     select_sorted_by_site_summary = sorted_by_site_summary[EMIS_COMP_ESTIMATION_OUTPUT_COLUMNS]
-    # Save files
-    rep_filename: str = pm.generate_file_names(Output_Files.EST_REP_EMISSIONS_FILE)
-    filename: str = pm.generate_file_names(Output_Files.EST_EMISSIONS_FILE)
 
-    select_sorted_by_site_summary.to_csv(pm._output_dir / filename, index=False)
-    fugitive_emissions_to_remove.to_csv(pm._output_dir / rep_filename, index=False)
+    return (select_sorted_by_site_summary, fugitive_emissions_to_remove)

--- a/LDAR_Sim/src/file_processing/output_processing/program_output_manager.py
+++ b/LDAR_Sim/src/file_processing/output_processing/program_output_manager.py
@@ -78,13 +78,21 @@ class ProgramOutputManager:
         ]
         function_to_call = self.PROGRAM_FUNCTIONS_MAPPING.get(program.duration_method)
         if function_to_call:
-            function_to_call(
-                self,
+            result = function_to_call(
                 program.aggregate_method_survey_reports(),
                 emis_info_for_duration_estimation,
                 start_date,
                 end_date,
             )
+            if result:
+                emis_estimation: pd.DataFrame
+                fug_to_remove: pd.DataFrame
+                emis_estimation, fug_to_remove = result
+                emis_file_name = self.generate_file_names(Output_Files.EST_EMISSIONS_FILE)
+                fug_file_name = self.generate_file_names(Output_Files.EST_REP_EMISSIONS_FILE)
+
+                emis_estimation.to_csv(self._output_dir / emis_file_name, index=False)
+                fug_to_remove.to_csv(self._output_dir / fug_file_name, index=False)
         else:
             raise KeyError(f"No function found for program: {program}")
 


### PR DESCRIPTION
# Pull Request Key Information

## Reason for change

Program output manager should not be passed into objects that it should own. Circular references could exist in the original code

## What was changed

Move the portion of code that required the program manager outside, and remove the need to pass in the program manager.

## Intended Purpose

Potential circular referencing is removed.

## Testing Completed
All unit tests pass
[result.txt](https://github.com/LDAR-Sim/LDAR_Sim/files/15357916/result.txt)
Manually ran simple test case
