### PR TITLE
<FEAT>: Add debug flag

### DIFF
--- a/LDAR_Sim/src/constants/output_messages.py
+++ b/LDAR_Sim/src/constants/output_messages.py
@@ -24,7 +24,11 @@ SUMMARY_PLOT_GENERATION_MESSAGE = "Generating cross-program summary plots"
 
 
 class RuntimeMessages:
-
+    DEBUG_MODE_ON = """
+        !!! Warning !!!
+            Debug mode is on.
+            This mode disables multiprocessing!!!
+    """
     OPENING_MSG = """
         You are running LDAR-Sim version 4.0.0 an open sourced software (MIT) license.
         Provide any issues, comments, questions, or recommendations by
@@ -79,4 +83,9 @@ class InputHelpText:
     OUTPUT_DIR_HELP_TEXT = (
         "Output Directory, folder containing output files, will save all output files \n"
         "ie. python ldar_sim_main.py --out_dir ./folder_for_save_outputs"
+    )
+    DEBUG_HELP_TEXT = (
+        "Debug mode, will print out additional information for debugging purposes"
+        "Will set to True if present"
+        "ie. python ldar_sim_run.py --debug"
     )

--- a/LDAR_Sim/src/initialization/args.py
+++ b/LDAR_Sim/src/initialization/args.py
@@ -77,9 +77,11 @@ def files_from_args(ref_path):
         "--out_dir",
         help=iht.OUTPUT_DIR_HELP_TEXT,
     )
+    parser.add_argument(
+        "-D", "--debug", action="store_true", help=iht.DEBUG_HELP_TEXT, default=False
+    )
 
     args = parser.parse_args()
-
     if args.in_dir is not None:
         # if an input directory is specified, get all files within that are in the directory
         # Get all yaml or json files in specified folder
@@ -102,7 +104,7 @@ def files_from_args(ref_path):
         out_dir = get_abs_path(args.out_dir, ref_path)
         return {"parameter_files": parameter_files, "out_dir": str(out_dir)}
 
-    return parameter_files
+    return parameter_files, args.debug
 
 
 def files_from_path(in_path):

--- a/LDAR_Sim/src/ldar_sim_run.py
+++ b/LDAR_Sim/src/ldar_sim_run.py
@@ -310,11 +310,6 @@ if __name__ == "__main__":
     src_dir: Path = root_dir / "src"
     sys.path.insert(1, str(src_dir))
 
-    # Add the external sensors directory
-    # TODO update external sensors
-    # ext_sens_dir: Path = root_dir / "external_sensors"
-    # sys.path.append(str(ext_sens_dir))
-
     # -- Retrieve input parameters from commandline argument and parse --
     parameter_filenames, _DEBUG = files_from_args(root_dir)
 

--- a/LDAR_Sim/src/ldar_sim_run.py
+++ b/LDAR_Sim/src/ldar_sim_run.py
@@ -13,15 +13,17 @@
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # MIT License for more details.
 
-import copy
-import gc
-from math import floor
 
 # You should have received a copy of the MIT License
 # along with this program.  If not, see <https://opensource.org/licenses/MIT>.
 #
 # ------------------------------------------------------------------------------
 import os
+
+import copy
+import gc
+from math import floor
+import cProfile
 import multiprocessing as mp
 import sys
 import shutil
@@ -68,7 +70,10 @@ def simulate(
     preseed_timeseries,
     lock,
 ):
-    with lock:
+    if lock is not None:
+        with lock:
+            infra = copy.deepcopy(infrastructure)
+    else:
         infra = copy.deepcopy(infrastructure)
     gc.collect()
     program: Program = Program(
@@ -100,22 +105,7 @@ def simulate(
     return
 
 
-def run_ldar_sim():
-    print(rm.OPENING_MSG)
-
-    root_dir: Path = Path(__file__).resolve().parent.parent
-    os.chdir(root_dir)
-
-    src_dir: Path = root_dir / "src"
-    sys.path.insert(1, str(src_dir))
-
-    # Add the external sensors directory
-    # TODO update external sensors
-    # ext_sens_dir: Path = root_dir / "external_sensors"
-    # sys.path.append(str(ext_sens_dir))
-
-    # -- Retrieve input parameters from commandline argument and parse --
-    parameter_filenames = files_from_args(root_dir)
+def run_ldar_sim(parameter_filenames, DEBUG=False):
 
     input_manager = InputManager()
 
@@ -230,11 +220,7 @@ def run_ldar_sim():
             sim_counts.append(remainder)
     else:
         sim_counts = [simulation_count]
-    n_process = sim_params[pdc.Sim_Setting_Params.PROCESS]
-    if len(programs) < sim_params[pdc.Sim_Setting_Params.PROCESS]:
-        n_process = len(programs)
-    with mp.Manager() as manager:
-        lock = manager.Lock()
+    if _DEBUG:
         for batch_count, sim_count in enumerate(sim_counts):
             for simulation in range(sim_count):
                 simulation_number: int = batch_count * 5 + simulation
@@ -242,42 +228,102 @@ def run_ldar_sim():
                 # read in pregen emissions
                 infra = read_in_emissions(infrastructure, generator_dir, simulation_number)
                 # -- Run simulations --
-                prog_data = []
                 for program in programs:
                     meth_params = {}
                     for meth in programs[program][pdc.Program_Params.METHODS]:
                         meth_params[meth] = methods[meth]
-                    prog_data.append(
-                        (
-                            daylight,
-                            weather,
-                            simulation_number,
-                            program,
-                            meth_params,
-                            programs[program],
-                            sim_params,
-                            virtual_world,
-                            infra,
-                            in_dir,
-                            out_dir,
-                            seed_timeseries,
-                            lock,
-                        )
+                    simulate(
+                        daylight,
+                        weather,
+                        simulation_number,
+                        program,
+                        meth_params,
+                        programs[program],
+                        sim_params,
+                        virtual_world,
+                        infra,
+                        in_dir,
+                        out_dir,
+                        seed_timeseries,
+                        None,
                     )
-
-                with mp.Pool(processes=n_process) as p:
-                    sim_outputs = p.starmap(
-                        simulate,
-                        prog_data,
-                    )
-                gc.collect()
                 print(rm.FIN_SIM_SET.format(simulation_number=simulation_number))
-
             # -- Batch Report --
             print(rm.BATCH_CLEAN.format(batch_count=batch_count))
             summary_stats_manager.gen_summary_outputs(batch_count != 0)
+    else:
+        n_process = sim_params[pdc.Sim_Setting_Params.PROCESS]
+        if len(programs) < sim_params[pdc.Sim_Setting_Params.PROCESS]:
+            n_process = len(programs)
+        with mp.Manager() as manager:
+            lock = manager.Lock()
+            for batch_count, sim_count in enumerate(sim_counts):
+                for simulation in range(sim_count):
+                    simulation_number: int = batch_count * 5 + simulation
+                    print(rm.SIM_SET.format(simulation_number=simulation_number))
+                    # read in pregen emissions
+                    infra = read_in_emissions(infrastructure, generator_dir, simulation_number)
+                    # -- Run simulations --
+                    prog_data = []
+                    for program in programs:
+                        meth_params = {}
+                        for meth in programs[program][pdc.Program_Params.METHODS]:
+                            meth_params[meth] = methods[meth]
+                        prog_data.append(
+                            (
+                                daylight,
+                                weather,
+                                simulation_number,
+                                program,
+                                meth_params,
+                                programs[program],
+                                sim_params,
+                                virtual_world,
+                                infra,
+                                in_dir,
+                                out_dir,
+                                seed_timeseries,
+                                lock,
+                            )
+                        )
+
+                    with mp.Pool(processes=n_process) as p:
+                        _ = p.starmap(
+                            simulate,
+                            prog_data,
+                        )
+                    gc.collect()
+                    print(rm.FIN_SIM_SET.format(simulation_number=simulation_number))
+
+                # -- Batch Report --
+                print(rm.BATCH_CLEAN.format(batch_count=batch_count))
+                summary_stats_manager.gen_summary_outputs(batch_count != 0)
     summary_visualization_manager.gen_visualizations()
 
 
 if __name__ == "__main__":
-    run_ldar_sim()
+    print(rm.OPENING_MSG)
+
+    root_dir: Path = Path(__file__).resolve().parent.parent
+    os.chdir(root_dir)
+
+    src_dir: Path = root_dir / "src"
+    sys.path.insert(1, str(src_dir))
+
+    # Add the external sensors directory
+    # TODO update external sensors
+    # ext_sens_dir: Path = root_dir / "external_sensors"
+    # sys.path.append(str(ext_sens_dir))
+
+    # -- Retrieve input parameters from commandline argument and parse --
+    parameter_filenames, _DEBUG = files_from_args(root_dir)
+
+    if _DEBUG:
+        print(rm.DEBUG_MODE_ON)
+        cProfile.run(
+            "run_ldar_sim(parameter_filenames, _DEBUG)",
+            "../Benchmarking/benchmark1_results",
+            "cumulative",
+        )
+    else:
+        run_ldar_sim(parameter_filenames)


### PR DESCRIPTION
# Pull Request Key Information

## Reason for change

For debugging purposes, it is useful to have a debug flag that can be set to True to do alternative things in the code.

## What was changed

- Debugging flag can be set to True to remove multiprocessing
- Debugging flag can be set to turn on profiling by default

## Intended Purpose

Add a debugging flag for future use.

## Testing Completed
[result.txt](https://github.com/LDAR-Sim/LDAR_Sim/files/15394542/result.txt)
All unit tests pass. 
Manually ran simulation with the debug flag on and off. 

