### PR TITLE
<FEAT> V4 stationary method rework

### DIFF
--- a/LDAR_Sim/src/constants/param_default_const.py
+++ b/LDAR_Sim/src/constants/param_default_const.py
@@ -149,6 +149,11 @@ class Method_Params:
     SORT_BY_RATE = "sort_by_rate"
     THRESHOLD = "threshold"
     DEPLOY_SITE = "site_deployment"
+    ROLLING_AVRG = "rolling_average"
+    SMALL_WINDOW = "small_window"
+    LARGE_WINDOW = "large_window"
+    SMALL_WINDOW_THRESHOLD = "small_window_threshold"
+    LARGE_WINDOW_THRESHOLD = "large_window_threshold"
 
 
 @dataclass

--- a/LDAR_Sim/src/default_parameters/m_default.yml
+++ b/LDAR_Sim/src/default_parameters/m_default.yml
@@ -44,4 +44,4 @@ rolling_average:
   small_window: 7 # days
   large_window: 30 # days
   small_window_threshold: 0.0 # g/s
-  large_window_threshold: 0.0 # g/s
+  large_window_threshold: "_placeholder_float_" # g/s

--- a/LDAR_Sim/src/default_parameters/m_default.yml
+++ b/LDAR_Sim/src/default_parameters/m_default.yml
@@ -2,7 +2,7 @@ parameter_level: "methods"
 version: "4.0"
 method_name: "_placeholder_str_"
 measurement_scale: "_placeholder_str_" # site/equipment/component
-deployment_type: "_placeholder_str_" # mobile/stationary/orbit
+deployment_type: "_placeholder_str_" # mobile/stationary
 sensor:
   type: default # default/OGI_camera_zim(see User manual for MDL values)/OGI_camera_rk
   quantification_error: 0.0
@@ -12,17 +12,17 @@ coverage:
   temporal: 1.0 # 0.0 to 1.0
 cost:
   per_day: 0
-  per_site: 0
+  per_site: 0 # MOBILE ONLY
   upfront: 0
-crew_count: 0 # whole numbers
+crew_count: 0 # whole numbers - MOBILE ONLY
 consider_daylight: False
-surveys_per_year: "_placeholder_int_"
-survey_time: "_placeholder_int_" # minutes
-max_workday: 8 # 1 to 23
+surveys_per_year: "_placeholder_int_" # days - MOBILE ONLY
+survey_time: "_placeholder_int_" # minutes - MOBILE ONLY
+max_workday: 8 # 1 to 23 - MOBILE ONLY
 reporting_delay: 2 # days
 time_between_sites:
-  file: "_placeholder_str_"
-  values: [30.0] # minutes
+  file: "_placeholder_str_" # MOBILE ONLY
+  values: [30.0] # minutes - MOBILE ONLY
 scheduling:
   deployment_months: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
   deployment_years: ["_placeholder_int_"]
@@ -37,11 +37,11 @@ follow_up:
   instant_threshold: "_placeholder_float_" # g/s
   interaction_priority: "threshold" # threshold/proportion
   proportion: 1.0 # 0 to 1.0
-  redundancy_filter: "recent" # recent/max/average
+  redundancy_filter: "recent" # recent/max/average - MOBILE ONLY
   sort_by_rate: True # True/False
-  threshold: 0.0 # g/s
+  threshold: 0.0 # g/s - MOBILE ONLY
 rolling_average:
-  small_window: 7 # days
-  large_window: 30 # days
-  small_window_threshold: 0.0 # g/s
-  large_window_threshold: "_placeholder_float_" # g/s
+  small_window: 7 # days - STATIONARY ONLY
+  large_window: 30 # days - STATIONARY ONLY
+  small_window_threshold: 0.0 # g/s - STATIONARY ONLY
+  large_window_threshold: "_placeholder_float_" # g/s - STATIONARY ONLY

--- a/LDAR_Sim/src/default_parameters/m_default.yml
+++ b/LDAR_Sim/src/default_parameters/m_default.yml
@@ -40,3 +40,8 @@ follow_up:
   redundancy_filter: "recent" # recent/max/average
   sort_by_rate: True # True/False
   threshold: 0.0 # g/s
+rolling_average:
+  small_window: 7 # days
+  large_window: 30 # days
+  small_window_threshold: 0.0 # g/s
+  large_window_threshold: 0.0 # g/s

--- a/LDAR_Sim/src/programs/component_level_method.py
+++ b/LDAR_Sim/src/programs/component_level_method.py
@@ -61,7 +61,7 @@ class ComponentLevelMethod(Method):
         weather,
         curr_date: date,
     ) -> Tuple[SiteSurveyReport, float]:
-        survey_report, site_travel_time, last_site_survey = super().survey_site(
+        survey_report, site_travel_time, last_site_survey, site_visit = super().survey_site(
             crew=crew,
             survey_report=survey_report,
             site_to_survey=site_to_survey,
@@ -89,7 +89,7 @@ class ComponentLevelMethod(Method):
                             tagging_info=tagging_info,
                         )
                         self._emissions_tagged_daily += 1
-        return survey_report, site_travel_time, last_site_survey
+        return survey_report, site_travel_time, last_site_survey, site_visit
 
     def _initialize_sensor(self, sensor_info: dict) -> None:
         """Will initialize a sensor of the correct type based
@@ -152,7 +152,7 @@ class ComponentLevelMethod(Method):
                 assigned_crew: CrewDailyReport
 
                 # Send the crew to attempt to survey the site
-                survey_report, travel_time, last_site_survey = self.survey_site(
+                survey_report, travel_time, last_site_survey, n_site_visited = self.survey_site(
                     crew=assigned_crew,
                     survey_report=survey_report,
                     site_to_survey=site_to_survey,
@@ -163,7 +163,7 @@ class ComponentLevelMethod(Method):
                 travel_time: float
                 last_site_survey: bool
                 # Tracking Deployment statistics
-                deploy_stats.sites_visited += 1
+                deploy_stats.sites_visited += n_site_visited
                 deploy_stats.travel_time += travel_time
                 deploy_stats.survey_time += survey_report.time_surveyed
 

--- a/LDAR_Sim/src/programs/component_level_method.py
+++ b/LDAR_Sim/src/programs/component_level_method.py
@@ -152,7 +152,7 @@ class ComponentLevelMethod(Method):
                 assigned_crew: CrewDailyReport
 
                 # Send the crew to attempt to survey the site
-                survey_report, travel_time, last_site_survey, n_site_visited = self.survey_site(
+                survey_report, travel_time, last_site_survey, site_visited = self.survey_site(
                     crew=assigned_crew,
                     survey_report=survey_report,
                     site_to_survey=site_to_survey,
@@ -163,7 +163,8 @@ class ComponentLevelMethod(Method):
                 travel_time: float
                 last_site_survey: bool
                 # Tracking Deployment statistics
-                deploy_stats.sites_visited += n_site_visited
+                if site_visited:
+                    deploy_stats.sites_visited += 1
                 deploy_stats.travel_time += travel_time
                 deploy_stats.survey_time += survey_report.time_surveyed
 

--- a/LDAR_Sim/src/programs/component_level_method.py
+++ b/LDAR_Sim/src/programs/component_level_method.py
@@ -61,7 +61,7 @@ class ComponentLevelMethod(Method):
         weather,
         curr_date: date,
     ) -> Tuple[SiteSurveyReport, float]:
-        survey_report, site_travel_time, last_site_survey, site_visit = super().survey_site(
+        survey_report, site_travel_time, last_site_survey, site_visited = super().survey_site(
             crew=crew,
             survey_report=survey_report,
             site_to_survey=site_to_survey,
@@ -89,7 +89,7 @@ class ComponentLevelMethod(Method):
                             tagging_info=tagging_info,
                         )
                         self._emissions_tagged_daily += 1
-        return survey_report, site_travel_time, last_site_survey, site_visit
+        return survey_report, site_travel_time, last_site_survey, site_visited
 
     def _initialize_sensor(self, sensor_info: dict) -> None:
         """Will initialize a sensor of the correct type based

--- a/LDAR_Sim/src/programs/method.py
+++ b/LDAR_Sim/src/programs/method.py
@@ -234,7 +234,7 @@ class Method:
                 assigned_crew: CrewDailyReport
 
                 # Send the crew to attempt to survey the site
-                survey_report, travel_time, last_site_survey = self.survey_site(
+                survey_report, travel_time, last_site_survey, n_site_visited = self.survey_site(
                     crew=assigned_crew,
                     survey_report=survey_report,
                     site_to_survey=site_to_survey,
@@ -245,7 +245,7 @@ class Method:
                 travel_time: float
                 last_site_survey: bool
                 # Tracking Deployment statistics
-                deploy_stats.sites_visited += 1
+                deploy_stats.sites_visited += n_site_visited
                 deploy_stats.travel_time += travel_time
                 deploy_stats.survey_time += survey_report.time_surveyed
 
@@ -316,11 +316,13 @@ class Method:
         workable: bool = True
         last_site_survey: bool = False
         site_travel_time: float = 0
+        site_visit: int = 0
         if self._weather:
             # if weather is considered
             workable: bool = self.check_weather(weather, curr_date, site_to_survey)
 
         if workable:
+            site_visit = 1
             if self._deployment_type == pdc.Deployment_Types.STATIONARY:
                 site_survey_time: float = 0
                 site_travel_time: float = 0
@@ -377,8 +379,7 @@ class Method:
             else:
                 site_travel_time = 0
                 last_site_survey = True
-
-        return survey_report, site_travel_time, last_site_survey
+        return survey_report, site_travel_time, last_site_survey, site_visit
 
     def _determine_if_site_survey_can_be_completed(
         self,

--- a/LDAR_Sim/src/programs/method.py
+++ b/LDAR_Sim/src/programs/method.py
@@ -238,7 +238,7 @@ class Method:
                 assigned_crew: CrewDailyReport
 
                 # Send the crew to attempt to survey the site
-                survey_report, travel_time, last_site_survey, n_site_visited = self.survey_site(
+                survey_report, travel_time, last_site_survey, site_visited = self.survey_site(
                     crew=assigned_crew,
                     survey_report=survey_report,
                     site_to_survey=site_to_survey,
@@ -249,7 +249,8 @@ class Method:
                 travel_time: float
                 last_site_survey: bool
                 # Tracking Deployment statistics
-                deploy_stats.sites_visited += n_site_visited
+                if site_visited:
+                    deploy_stats.sites_visited += 1
                 deploy_stats.travel_time += travel_time
                 deploy_stats.survey_time += survey_report.time_surveyed
 
@@ -320,13 +321,13 @@ class Method:
         workable: bool = True
         last_site_survey: bool = False
         site_travel_time: float = 0
-        site_visit: int = 0
+        site_visit: bool = False
         if self._weather:
             # if weather is considered
             workable: bool = self.check_weather(weather, curr_date, site_to_survey)
 
         if workable:
-            site_visit = 1
+            site_visit = True
             if self._deployment_type == pdc.Deployment_Types.STATIONARY:
                 site_survey_time: float = 0
                 site_travel_time: float = 0

--- a/LDAR_Sim/src/programs/method.py
+++ b/LDAR_Sim/src/programs/method.py
@@ -221,7 +221,11 @@ class Method:
         # If the cost type for the method is per day, calculate the deployment cost for day
         # based off the number of crews being deployed
         if self.cost_type == self.PER_DAY_COST:
-            deploy_stats.deployment_cost = self.cost * len(self._crew_reports)
+            if self._deployment_type == pdc.Deployment_Types.STATIONARY:
+                deploy_stats.deployment_cost = self.cost * len(workplan.site_survey_planners)
+            else:
+                deploy_stats.deployment_cost = self.cost * len(self._crew_reports)
+
         # pop the site with the longest remaining hours to assign the next crew
         # while there are crews that can work
         for survey_plan in workplan.site_survey_planners.values():

--- a/LDAR_Sim/src/programs/site_level_method.py
+++ b/LDAR_Sim/src/programs/site_level_method.py
@@ -134,9 +134,9 @@ class SiteLevelMethod(Method):
                     if existing_plan.rate_at_site >= self._inst_threshold:
                         self._follow_up_schedule.add_previous_queued_to_survey_queue(existing_plan)
                     elif self._deployment_type == pdc.Deployment_Types.STATIONARY:
-                        if (
-                            existing_plan.rate_at_site >= self._small_window_threshold
-                            or existing_plan.rate_at_site_long >= self._large_window_threshold
+                        if existing_plan.rate_at_site >= self._small_window_threshold or (
+                            self._large_window_threshold is not None
+                            and existing_plan.rate_at_site_long >= self._large_window_threshold
                         ):
                             self._candidates_for_flags.add(existing_plan)
                     elif existing_plan.rate_at_site >= self._threshold:
@@ -159,9 +159,9 @@ class SiteLevelMethod(Method):
                     if existing_plan.rate_at_site >= self._inst_threshold:
                         self._follow_up_schedule.add_previous_queued_to_survey_queue(existing_plan)
                     elif self._deployment_type == pdc.Deployment_Types.STATIONARY:
-                        if (
-                            existing_plan.rate_at_site >= self._small_window_threshold
-                            or existing_plan.rate_at_site_long >= self._large_window_threshold
+                        if existing_plan.rate_at_site >= self._small_window_threshold or (
+                            self._large_window_threshold is not None
+                            and existing_plan.rate_at_site_long >= self._large_window_threshold
                         ):
                             self._follow_up_schedule.add_to_survey_queue(existing_plan)
                     elif existing_plan.rate_at_site >= self._threshold:
@@ -177,8 +177,11 @@ class SiteLevelMethod(Method):
                     # if the detected rate is non-zero, and above the threshold add to queue
                     elif self._deployment_type == pdc.Deployment_Types.STATIONARY:
                         if detection_record.rate_detected != 0 and (
-                            detection_record.rate_detected >= self._small_window_threshold
-                            or detection_record.rate_detected >= self._large_window_threshold
+                            existing_plan.rate_at_site >= self._small_window_threshold
+                            or (
+                                self._large_window_threshold is not None
+                                and existing_plan.rate_at_site_long >= self._large_window_threshold
+                            )
                         ):
                             self._candidates_for_flags.add(
                                 FollowUpSurveyPlanner(detection_record, date_to_check)

--- a/LDAR_Sim/src/programs/site_level_method.py
+++ b/LDAR_Sim/src/programs/site_level_method.py
@@ -26,7 +26,10 @@ from constants.error_messages import Input_Processing_Messages as ipm
 from file_processing.output_processing.output_utils import TaggingFlaggingStats
 from programs.method import Method
 from scheduling.follow_up_mobile_schedule import FollowUpMobileSchedule
-from scheduling.follow_up_survey_planner import FollowUpSurveyPlanner
+from scheduling.follow_up_survey_planner import (
+    FollowUpSurveyPlanner,
+    StationaryFollowUpSurveyPlanner,
+)
 from scheduling.surveying_dataclasses import DetectionRecord
 from sensors.default_site_level_sensor import DefaultSiteLevelSensor
 from sensors.METEC_NoWind_sensor import METECNWSite
@@ -85,10 +88,10 @@ class SiteLevelMethod(Method):
             self._inst_threshold = float("inf")
         self._follow_up_schedule: FollowUpMobileSchedule = follow_up_schedule
         self._detection_count = 0
-        self._small_window: int = properties[pdc.Method_Params.ROLLING_AVRG][
+        self._small_window = properties[pdc.Method_Params.ROLLING_AVRG][
             pdc.Method_Params.SMALL_WINDOW
         ]
-        self._large_window: int = properties[pdc.Method_Params.ROLLING_AVRG][
+        self._large_window = properties[pdc.Method_Params.ROLLING_AVRG][
             pdc.Method_Params.LARGE_WINDOW
         ]
         if self._deployment_type == pdc.Deployment_Types.STATIONARY:
@@ -184,7 +187,7 @@ class SiteLevelMethod(Method):
                             )
                         ):
                             self._candidates_for_flags.add(
-                                FollowUpSurveyPlanner(detection_record, date_to_check)
+                                StationaryFollowUpSurveyPlanner(detection_record, date_to_check)
                             )
                         # count that there was a detection, but it wasn't above the thresholds
                         elif detection_record.rate_detected > 0:

--- a/LDAR_Sim/src/programs/site_level_method.py
+++ b/LDAR_Sim/src/programs/site_level_method.py
@@ -78,19 +78,34 @@ class SiteLevelMethod(Method):
         self._proportion: float = properties[pdc.Method_Params.FOLLOW_UP][
             pdc.Method_Params.PROPORTION
         ]
-        self._threshold: float = properties[pdc.Method_Params.FOLLOW_UP][
-            pdc.Method_Params.THRESHOLD
-        ]
         self._inst_threshold: float = properties[pdc.Method_Params.FOLLOW_UP][
             pdc.Method_Params.INSTANT_THRESHOLD
         ]
         if self._inst_threshold is None:
             self._inst_threshold = float("inf")
-        self._redund_filter: str = properties[pdc.Method_Params.FOLLOW_UP][
-            pdc.Method_Params.REDUNDANCY_FILTER
-        ]
         self._follow_up_schedule: FollowUpMobileSchedule = follow_up_schedule
         self._detection_count = 0
+        self._small_window: int = properties[pdc.Method_Params.ROLLING_AVRG][
+            pdc.Method_Params.SMALL_WINDOW
+        ]
+        self._large_window: int = properties[pdc.Method_Params.ROLLING_AVRG][
+            pdc.Method_Params.LARGE_WINDOW
+        ]
+        if self._deployment_type == pdc.Deployment_Types.STATIONARY:
+            self._small_window_threshold: float = properties[pdc.Method_Params.ROLLING_AVRG][
+                pdc.Method_Params.SMALL_WINDOW_THRESHOLD
+            ]
+            self._large_window_threshold: float = properties[pdc.Method_Params.ROLLING_AVRG][
+                pdc.Method_Params.LARGE_WINDOW_THRESHOLD
+            ]
+            self._redund_filter: str = pdc.Method_Params.ROLLING_AVRG
+        else:
+            self._redund_filter: str = properties[pdc.Method_Params.FOLLOW_UP][
+                pdc.Method_Params.REDUNDANCY_FILTER
+            ]
+            self._threshold: float = properties[pdc.Method_Params.FOLLOW_UP][
+                pdc.Method_Params.THRESHOLD
+            ]
 
     def update(self, current_date: date) -> TaggingFlaggingStats:
         # TODO add user configurable follow_up parameter to allow
@@ -109,12 +124,24 @@ class SiteLevelMethod(Method):
                         detection_record.site_id
                     )
                     existing_plan.update_with_latest_survey(
-                        detection_record, self._redund_filter, self._name, date_to_check
+                        detection_record,
+                        self._redund_filter,
+                        self._name,
+                        date_to_check,
+                        self._small_window,
+                        self._large_window,
                     )
                     if existing_plan.rate_at_site >= self._inst_threshold:
                         self._follow_up_schedule.add_previous_queued_to_survey_queue(existing_plan)
+                    elif self._deployment_type == pdc.Deployment_Types.STATIONARY:
+                        if (
+                            existing_plan.rate_at_site >= self._small_window_threshold
+                            or existing_plan.rate_at_site_long >= self._large_window_threshold
+                        ):
+                            self._candidates_for_flags.add(existing_plan)
                     elif existing_plan.rate_at_site >= self._threshold:
                         self._candidates_for_flags.add(existing_plan)
+
                 # If the site is already queued to get a follow-up,
                 # update the queue priority based on new results
                 elif self._site_IDs_in_follow_up_queue[detection_record.site_id]:
@@ -122,10 +149,21 @@ class SiteLevelMethod(Method):
                         self._follow_up_schedule.get_plan_from_queue(detection_record.site_id)
                     )
                     existing_plan.update_with_latest_survey(
-                        detection_record, self._redund_filter, self._name, date_to_check
+                        detection_record,
+                        self._redund_filter,
+                        self._name,
+                        date_to_check,
+                        self._small_window,
+                        self._large_window,
                     )
                     if existing_plan.rate_at_site >= self._inst_threshold:
                         self._follow_up_schedule.add_previous_queued_to_survey_queue(existing_plan)
+                    elif self._deployment_type == pdc.Deployment_Types.STATIONARY:
+                        if (
+                            existing_plan.rate_at_site >= self._small_window_threshold
+                            or existing_plan.rate_at_site_long >= self._large_window_threshold
+                        ):
+                            self._follow_up_schedule.add_to_survey_queue(existing_plan)
                     elif existing_plan.rate_at_site >= self._threshold:
                         self._follow_up_schedule.add_to_survey_queue(existing_plan)
                 # Otherwise, the site is not already in processing for a follow-up,
@@ -137,6 +175,17 @@ class SiteLevelMethod(Method):
                             FollowUpSurveyPlanner(detection_record, date_to_check)
                         )
                     # if the detected rate is non-zero, and above the threshold add to queue
+                    elif self._deployment_type == pdc.Deployment_Types.STATIONARY:
+                        if detection_record.rate_detected != 0 and (
+                            detection_record.rate_detected >= self._small_window_threshold
+                            or detection_record.rate_detected >= self._large_window_threshold
+                        ):
+                            self._candidates_for_flags.add(
+                                FollowUpSurveyPlanner(detection_record, date_to_check)
+                            )
+                        # count that there was a detection, but it wasn't above the thresholds
+                        elif detection_record.rate_detected > 0:
+                            self._detection_count += 1
                     elif (
                         detection_record.rate_detected != 0
                         and detection_record.rate_detected >= self._threshold

--- a/LDAR_Sim/src/programs/site_level_method.py
+++ b/LDAR_Sim/src/programs/site_level_method.py
@@ -177,10 +177,10 @@ class SiteLevelMethod(Method):
                     # if the detected rate is non-zero, and above the threshold add to queue
                     elif self._deployment_type == pdc.Deployment_Types.STATIONARY:
                         if detection_record.rate_detected != 0 and (
-                            existing_plan.rate_at_site >= self._small_window_threshold
+                            detection_record.rate_detected >= self._small_window_threshold
                             or (
                                 self._large_window_threshold is not None
-                                and existing_plan.rate_at_site_long >= self._large_window_threshold
+                                and detection_record.rate_detected >= self._large_window_threshold
                             )
                         ):
                             self._candidates_for_flags.add(

--- a/LDAR_Sim/src/scheduling/follow_up_survey_planner.py
+++ b/LDAR_Sim/src/scheduling/follow_up_survey_planner.py
@@ -47,8 +47,6 @@ class FollowUpSurveyPlanner(SurveyPlanner):
         redund_filter: str,
         method_name: str,
         detect_date: date,
-        small_window: int = 7,
-        long_window: int = 30,
     ) -> None:
         if redund_filter == self.REDUND_FILTER_RECENT:
             self.rate_at_site = new_detection.rate_detected
@@ -68,8 +66,16 @@ class FollowUpSurveyPlanner(SurveyPlanner):
 
 
 class StationaryFollowUpSurveyPlanner(FollowUpSurveyPlanner):
-    def __init__(self, detection_record: DetectionRecord, detect_date: date) -> None:
+    def __init__(
+        self,
+        detection_record: DetectionRecord,
+        detect_date: date,
+        small_window: int,
+        long_window: int,
+    ) -> None:
         super().__init__(detection_record, detect_date)
+        self._small_window: int = small_window
+        self._long_window: int = long_window
 
     def update_with_latest_survey(
         self,
@@ -77,17 +83,17 @@ class StationaryFollowUpSurveyPlanner(FollowUpSurveyPlanner):
         redund_filter: str,
         method_name: str,
         detect_date: date,
-        small_window: int = 7,
-        long_window: int = 30,
     ) -> None:
         if redund_filter == pdc.Method_Params.ROLLING_AVRG:
             self._detected_rates.append(new_detection.rate_detected)
             series_detect_rates = pd.Series(self._detected_rates)
             self.rate_at_site = (
-                series_detect_rates.rolling(window=small_window, min_periods=1).mean().iloc[-1]
+                series_detect_rates.rolling(window=self._small_window, min_periods=1)
+                .mean()
+                .iloc[-1]
             )
             self.rate_at_site_long = (
-                series_detect_rates.rolling(window=long_window, min_periods=1).mean().iloc[-1]
+                series_detect_rates.rolling(window=self._long_window, min_periods=1).mean().iloc[-1]
             )
             self._latest_detection_date = detect_date
         else:

--- a/LDAR_Sim/src/scheduling/follow_up_survey_planner.py
+++ b/LDAR_Sim/src/scheduling/follow_up_survey_planner.py
@@ -62,7 +62,25 @@ class FollowUpSurveyPlanner(SurveyPlanner):
             self._detected_rates.append(new_detection.rate_detected)
             self.rate_at_site = max(self._detected_rates)
             self._latest_detection_date = detect_date
-        elif redund_filter == pdc.Method_Params.ROLLING_AVRG:
+        else:
+            print(rem.INVALID_REDUND_FILTER_ERROR.format(filter=redund_filter, method=method_name))
+            sys.exit()
+
+
+class StationaryFollowUpSurveyPlanner(FollowUpSurveyPlanner):
+    def __init__(self, detection_record: DetectionRecord, detect_date: date) -> None:
+        super().__init__(detection_record, detect_date)
+
+    def update_with_latest_survey(
+        self,
+        new_detection: DetectionRecord,
+        redund_filter: str,
+        method_name: str,
+        detect_date: date,
+        small_window: int = 7,
+        long_window: int = 30,
+    ) -> None:
+        if redund_filter == pdc.Method_Params.ROLLING_AVRG:
             self._detected_rates.append(new_detection.rate_detected)
             series_detect_rates = pd.Series(self._detected_rates)
             self.rate_at_site = (

--- a/LDAR_Sim/src/scheduling/scheduled_survey_planner.py
+++ b/LDAR_Sim/src/scheduling/scheduled_survey_planner.py
@@ -293,17 +293,6 @@ class StationarySurveyPlanner(ScheduledSurveyPlanner):
             deployment_months=deployment_months,
         )
 
-    def _set_survey_per_year(self) -> dict[int, dataclass]:
-        """Creates the dictionary used to check for number of surveys done each year"""
-        _surveys_this_year: dict[int, Survey_Counter] = {}
-        for year in self._sim_years:
-            if year in self._deployment_years:
-                _surveys_this_year[year] = Survey_Counter(Required_surveys=365, Surveys_done=0)
-            else:
-                _surveys_this_year[year] = Survey_Counter(Required_surveys=0, Surveys_done=0)
-
-        return _surveys_this_year
-
     def _gen_survey_plan(
         self,
         site_annual_rs: int,
@@ -327,7 +316,10 @@ class StationarySurveyPlanner(ScheduledSurveyPlanner):
         if self._check_deployable_month() is False:
             return False
         # check if if the site has already been queued
-        elif self._queued is False:
+        elif (
+            self._queued is False
+            and self._surveys_this_year[self._current_date.year].Required_surveys > 0
+        ):
             self._queued = True
             return True
         # if site has already been queued, return false.

--- a/LDAR_Sim/src/scheduling/scheduled_survey_planner.py
+++ b/LDAR_Sim/src/scheduling/scheduled_survey_planner.py
@@ -293,6 +293,42 @@ class StationarySurveyPlanner(ScheduledSurveyPlanner):
             deployment_months=deployment_months,
         )
 
+    def _set_survey_per_year(self) -> dict[int, dataclass]:
+        """Creates the dictionary used to check for number of surveys done each year"""
+        _surveys_this_year: dict[int, Survey_Counter] = {}
+        for year in self._sim_years:
+            if year in self._deployment_years:
+                _surveys_this_year[year] = Survey_Counter(Required_surveys=365, Surveys_done=0)
+            else:
+                _surveys_this_year[year] = Survey_Counter(Required_surveys=0, Surveys_done=0)
+
+        return _surveys_this_year
+
+    def _gen_survey_plan(
+        self,
+        site_annual_rs: int,
+    ) -> None:
+        """Not needed for stationary, placeholder to reduce computation when not needed"""
+        return None
+
+    def queue_site_for_survey(self) -> bool:
+        """Method to determine if the site for which this survey plan was generated
+        should be queued to be surveyed. Will return True if the site should be
+        queued to be surveyed, False otherwise.
+
+        Returns:
+            bool: Boolean indicating if the site should be queued to be surveyed.
+            True if the site should be queued to be surveyed, False otherwise.
+        """
+        if self._check_deployable_year() is False:
+            return False
+        if self._check_deployable_month() is False:
+            return False
+        elif self._queued is False:
+            self._queued = True
+            return True
+        return False
+
 
 @dataclass
 class Survey_Counter:

--- a/LDAR_Sim/src/scheduling/scheduled_survey_planner.py
+++ b/LDAR_Sim/src/scheduling/scheduled_survey_planner.py
@@ -320,13 +320,17 @@ class StationarySurveyPlanner(ScheduledSurveyPlanner):
             bool: Boolean indicating if the site should be queued to be surveyed.
             True if the site should be queued to be surveyed, False otherwise.
         """
+        # check it's a valid year
         if self._check_deployable_year() is False:
             return False
+        # check if it's a valid deployment month
         if self._check_deployable_month() is False:
             return False
+        # check if if the site has already been queued
         elif self._queued is False:
             self._queued = True
             return True
+        # if site has already been queued, return false.
         return False
 
 

--- a/LDAR_Sim/src/scheduling/scheduling_utils.py
+++ b/LDAR_Sim/src/scheduling/scheduling_utils.py
@@ -69,7 +69,7 @@ def create_schedule(
                 sites,
                 sim_start_date,
                 sim_end_date,
-                est_meth_daily_surveys,
+                len(sites),
                 method_avail_crews,
             )
         else:

--- a/LDAR_Sim/src/scheduling/stationary_schedule.py
+++ b/LDAR_Sim/src/scheduling/stationary_schedule.py
@@ -57,7 +57,10 @@ class StationarySchedule(GenericSchedule):
     ) -> list[StationarySurveyPlanner]:
         survey_plans: list[StationarySurveyPlanner] = []
         for site in sites:
-            survey_freq = 365
+            survey_freq: int = 365
+            deploy_meth: bool = site.do_site_deployment(self._method)
+            if not deploy_meth:
+                survey_freq = 0
             deploy_year: int = site._deployment_years[self._method]
             deploy_month: int = site._deployment_months[self._method]
             survey_plans.append(

--- a/LDAR_Sim/src/scheduling/stationary_schedule.py
+++ b/LDAR_Sim/src/scheduling/stationary_schedule.py
@@ -78,15 +78,3 @@ class StationarySchedule(GenericSchedule):
             prio, _, survey_plan = self._survey_queue.get()
             daily_plan.append(survey_plan)
         return daily_plan
-
-    def get_workplan(self, current_date) -> Workplan:
-        """
-        Updates the survey plans,
-        Adds necessary sites to the queue
-        Returns:
-            The list sites that the method should do on the given day
-        """
-        for survey_plan in self._survey_plans:
-            survey_plan.update_date(current_date)
-            if survey_plan.queue_site_for_survey():
-                self.add_to_survey_queue(survey_plan)

--- a/LDAR_Sim/testing/unit_testing/test_programs/test_method/method_testing_fixtures.py
+++ b/LDAR_Sim/testing/unit_testing/test_programs/test_method/method_testing_fixtures.py
@@ -169,6 +169,7 @@ def simple_method_values_fix(mocker):
     properties: dict = {
         pdc.Method_Params.N_CREWS: 5,
         pdc.Method_Params.SENSOR: "default",
+        pdc.Method_Params.DEPLOYMENT_TYPE: "mobile",
         pdc.Method_Params.MAX_WORKDAY: 8,
         pdc.Method_Params.CONSIDER_DAYLIGHT: False,
         pdc.Method_Params.T_BW_SITES: {pdc.Common_Params.VAL: [1]},
@@ -228,6 +229,7 @@ def simple_method_values2_fix(mocker):
     properties: dict = {
         pdc.Method_Params.N_CREWS: 5,
         pdc.Method_Params.SENSOR: "default",
+        pdc.Method_Params.DEPLOYMENT_TYPE: "mobile",
         pdc.Method_Params.MAX_WORKDAY: 1,
         pdc.Method_Params.T_BW_SITES: {pdc.Common_Params.VAL: [1]},
         pdc.Method_Params.IS_FOLLOW_UP: False,
@@ -287,6 +289,7 @@ def simple_method_values3_fix(mocker):
     properties: dict = {
         pdc.Method_Params.N_CREWS: 5,
         pdc.Method_Params.SENSOR: "default",
+        pdc.Method_Params.DEPLOYMENT_TYPE: "mobile",
         pdc.Method_Params.MAX_WORKDAY: 1,
         pdc.Method_Params.T_BW_SITES: {pdc.Common_Params.VAL: [1]},
         pdc.Method_Params.IS_FOLLOW_UP: True,
@@ -342,6 +345,7 @@ def simple_method_values4_fix(mocker):
     properties: dict = {
         pdc.Method_Params.N_CREWS: 5,
         pdc.Method_Params.SENSOR: "default",
+        pdc.Method_Params.DEPLOYMENT_TYPE: "mobile",
         pdc.Method_Params.MAX_WORKDAY: 8,
         pdc.Method_Params.CONSIDER_DAYLIGHT: False,
         pdc.Method_Params.T_BW_SITES: {pdc.Common_Params.VAL: [1]},
@@ -405,6 +409,7 @@ def simple_method_values5_fix(mocker):
             pdc.Method_Params.MDL: 1,
             pdc.Method_Params.QE: 0,
         },
+        pdc.Method_Params.DEPLOYMENT_TYPE: "mobile",
         pdc.Method_Params.MAX_WORKDAY: 8,
         pdc.Method_Params.CONSIDER_DAYLIGHT: False,
         pdc.Method_Params.T_BW_SITES: {pdc.Common_Params.VAL: [1]},
@@ -472,6 +477,7 @@ def deploy_crews_testing_fix(mocker):
             pdc.Method_Params.MDL: 1,
             pdc.Method_Params.QE: 0,
         },
+        pdc.Method_Params.DEPLOYMENT_TYPE: "mobile",
         pdc.Method_Params.MAX_WORKDAY: 8,
         pdc.Method_Params.CONSIDER_DAYLIGHT: False,
         pdc.Method_Params.T_BW_SITES: {pdc.Common_Params.VAL: [1]},
@@ -549,6 +555,7 @@ def deploy_crews_testing2_fix(mocker):
             pdc.Method_Params.MDL: 1,
             pdc.Method_Params.QE: 0,
         },
+        pdc.Method_Params.DEPLOYMENT_TYPE: "mobile",
         pdc.Method_Params.MAX_WORKDAY: 8,
         pdc.Method_Params.CONSIDER_DAYLIGHT: False,
         pdc.Method_Params.T_BW_SITES: {pdc.Common_Params.VAL: [1]},

--- a/LDAR_Sim/testing/unit_testing/test_programs/test_method/method_testing_fixtures.py
+++ b/LDAR_Sim/testing/unit_testing/test_programs/test_method/method_testing_fixtures.py
@@ -98,7 +98,7 @@ def mock_determine_if_site_survey_can_be_completed(
 
 
 def mock_false_survey_site(self, crew, survey_report, site_to_survey, weather, curr_date):
-    return SiteSurveyReport(1), 0, False
+    return SiteSurveyReport(1), 0, False, 0
 
 
 def mock_survey_site(self, crew, survey_report, site_to_survey, weather, curr_date):
@@ -120,6 +120,7 @@ def mock_survey_site(self, crew, survey_report, site_to_survey, weather, curr_da
         ),
         1,
         True,
+        1,
     )
 
 

--- a/LDAR_Sim/testing/unit_testing/test_programs/test_method/test_survey_site.py
+++ b/LDAR_Sim/testing/unit_testing/test_programs/test_method/test_survey_site.py
@@ -40,13 +40,14 @@ def test_000_simple_weather_fail_to_survey_site(simple_method_values4):
     sites = [mocker.Mock(spec=Site) for i in range(5)]
     method = Method("test_method", properties, True, sites)
     daily_report = CrewDailyReport(1, 400)
-    surveyed_report, travel_time, last_survey = method.survey_site(
+    surveyed_report, travel_time, last_survey, site_visited = method.survey_site(
         daily_report, survey_report, sites[0], state, current_date
     )
     expected = survey_report
     assert surveyed_report == expected
     assert not last_survey
     assert travel_time == 0
+    assert site_visited == 0
 
 
 def test_000_simple_weather_fail_to_finish_site(simple_method_values5):
@@ -61,7 +62,7 @@ def test_000_simple_weather_fail_to_finish_site(simple_method_values5):
     sites = [mocker.Mock(spec=Site) for i in range(5)]
     method = Method("test_method", properties, True, sites)
     daily_report = CrewDailyReport(1, 10)
-    surveyed_report, travel_time, last_survey = method.survey_site(
+    surveyed_report, travel_time, last_survey, site_visited = method.survey_site(
         daily_report, survey_report, site_mock, state, current_date
     )
     expected = SiteSurveyReport(
@@ -74,6 +75,7 @@ def test_000_simple_weather_fail_to_finish_site(simple_method_values5):
     assert surveyed_report == expected
     assert last_survey
     assert travel_time == 1
+    assert site_visited == 1
 
 
 def test_000_simple_weather_finish_site(simple_method_values5):
@@ -88,7 +90,7 @@ def test_000_simple_weather_finish_site(simple_method_values5):
     sites = [mocker.Mock(spec=Site) for i in range(5)]
     method = Method("test_method", properties, True, sites)
     daily_report = CrewDailyReport(1, 200)
-    surveyed_report, travel_time, last_survey = method.survey_site(
+    surveyed_report, travel_time, last_survey, site_visited = method.survey_site(
         daily_report, survey_report, site_mock, state, current_date
     )
 
@@ -108,3 +110,4 @@ def test_000_simple_weather_finish_site(simple_method_values5):
     assert surveyed_report == expected
     assert not last_survey
     assert travel_time == 1
+    assert site_visited == 1

--- a/LDAR_Sim/testing/unit_testing/test_programs/test_site_level_method/test_site_level_method_constructor.py
+++ b/LDAR_Sim/testing/unit_testing/test_programs/test_site_level_method/test_site_level_method_constructor.py
@@ -25,6 +25,10 @@ def test_site_level_method_creation(mock_follow_up_schedule):
             pdc.Method_Params.INSTANT_THRESHOLD: 1.0,
             pdc.Method_Params.REDUNDANCY_FILTER: "some_filter",
         },
+        pdc.Method_Params.ROLLING_AVRG: {
+            pdc.Method_Params.SMALL_WINDOW: 7,
+            pdc.Method_Params.LARGE_WINDOW: 30,
+        },
         pdc.Method_Params.DEPLOYMENT_TYPE: "mobile",
         pdc.Method_Params.SENSOR: {
             pdc.Method_Params.TYPE: "default",

--- a/LDAR_Sim/testing/unit_testing/test_programs/test_site_level_method/test_site_level_method_constructor.py
+++ b/LDAR_Sim/testing/unit_testing/test_programs/test_site_level_method/test_site_level_method_constructor.py
@@ -25,6 +25,7 @@ def test_site_level_method_creation(mock_follow_up_schedule):
             pdc.Method_Params.INSTANT_THRESHOLD: 1.0,
             pdc.Method_Params.REDUNDANCY_FILTER: "some_filter",
         },
+        pdc.Method_Params.DEPLOYMENT_TYPE: "mobile",
         pdc.Method_Params.SENSOR: {
             pdc.Method_Params.TYPE: "default",
             pdc.Method_Params.MDL: 1.0,

--- a/LDAR_Sim/testing/unit_testing/test_scheduling/test_survey_planner/test_queue_site_for_survey.py
+++ b/LDAR_Sim/testing/unit_testing/test_scheduling/test_survey_planner/test_queue_site_for_survey.py
@@ -17,6 +17,7 @@ along with this program.  If not, see <https://opensource.org/licenses/MIT>.
 
 ------------------------------------------------------------------------------
 """
+
 from datetime import date
 from src.virtual_world.sites import Site
 from scheduling.scheduled_survey_planner import ScheduledSurveyPlanner
@@ -56,7 +57,7 @@ def test_000_queue_site_for_survey_returns_false_when_site_it_has_yet_to_reach_s
         deploy_months,
     )
     result = planner.queue_site_for_survey()
-    assert result == False
+    assert result is False
 
 
 def test_000_queue_site_for_survey_returns_false_when_site_is_not_due_to_be_queued_for_survey(

--- a/LDAR_Sim/testing/unit_testing/test_scheduling/test_survey_planner/test_update_with_latest_survey.py
+++ b/LDAR_Sim/testing/unit_testing/test_scheduling/test_survey_planner/test_update_with_latest_survey.py
@@ -20,7 +20,10 @@ along with this program.  If not, see <https://opensource.org/licenses/MIT>.
 
 from datetime import date
 from src.virtual_world.sites import Site
-from scheduling.follow_up_survey_planner import FollowUpSurveyPlanner
+from scheduling.follow_up_survey_planner import (
+    FollowUpSurveyPlanner,
+    StationaryFollowUpSurveyPlanner,
+)
 from scheduling.surveying_dataclasses import DetectionRecord
 
 
@@ -64,16 +67,61 @@ def test_update_with_latest_survey(mocker):
         detection_record, redund_filter, method_name, detect_date
     )
 
+    new_detection = DetectionRecord(site_id=1, site=mocker, rate_detected=0.1)
+    detect_date = date(2021, 1, 7)
+    follow_up_survey_planner.update_with_latest_survey(
+        new_detection, redund_filter, method_name, detect_date
+    )
+    assert follow_up_survey_planner.rate_at_site == 0.1
+    assert follow_up_survey_planner._detected_rates == [0.1, 0.1, 0.1, 0.1, 0.1, 0.5, 0.1]
+    assert follow_up_survey_planner._latest_detection_date == date(2021, 1, 7)
+
+
+def test_update_with_avrg_survey(mocker):
+    """
+    Function to test the update_with_latest_survey function in FollowUpSurveyPlanner
+    """
+    mocker.patch.object(Site, "__init__", lambda self, *args, **kwargs: setattr(self, "id", 1))
+    detection_record = DetectionRecord(site_id=1, site=mocker, rate_detected=0.1)
+    detect_date = date(2021, 1, 1)
+    follow_up_survey_planner = FollowUpSurveyPlanner(detection_record, detect_date)
+    method_name = "test_method"
+    redund_filter = FollowUpSurveyPlanner.REDUND_FILTER_AVERAGE
+    detection_record = DetectionRecord(site_id=1, site=mocker, rate_detected=0.1)
+    detect_date = date(2021, 1, 2)
+    follow_up_survey_planner.update_with_latest_survey(
+        detection_record, redund_filter, method_name, detect_date
+    )
+
+    detection_record = DetectionRecord(site_id=1, site=mocker, rate_detected=0.1)
+    detect_date = date(2021, 1, 3)
+    follow_up_survey_planner.update_with_latest_survey(
+        detection_record, redund_filter, method_name, detect_date
+    )
+
+    detection_record = DetectionRecord(site_id=1, site=mocker, rate_detected=0.1)
+    detect_date = date(2021, 1, 4)
+    follow_up_survey_planner.update_with_latest_survey(
+        detection_record, redund_filter, method_name, detect_date
+    )
+
+    detection_record = DetectionRecord(site_id=1, site=mocker, rate_detected=0.1)
+    detect_date = date(2021, 1, 5)
+    follow_up_survey_planner.update_with_latest_survey(
+        detection_record, redund_filter, method_name, detect_date
+    )
+
+    detection_record = DetectionRecord(site_id=1, site=mocker, rate_detected=0.5)
+    detect_date = date(2021, 1, 6)
+    follow_up_survey_planner.update_with_latest_survey(
+        detection_record, redund_filter, method_name, detect_date
+    )
+
     new_detection = DetectionRecord(site_id=1, site=mocker, rate_detected=0.6)
     detect_date = date(2021, 1, 7)
     follow_up_survey_planner.update_with_latest_survey(
         new_detection, redund_filter, method_name, detect_date
     )
-    assert follow_up_survey_planner.rate_at_site == 0.6
-    assert follow_up_survey_planner._detected_rates == [0.1, 0.1, 0.1, 0.1, 0.1, 0.5, 0.6]
-    assert follow_up_survey_planner._latest_detection_date == date(2021, 1, 7)
-
-    redund_filter = FollowUpSurveyPlanner.REDUND_FILTER_AVERAGE
     follow_up_survey_planner.update_with_latest_survey(
         new_detection, redund_filter, method_name, detect_date
     )
@@ -81,21 +129,114 @@ def test_update_with_latest_survey(mocker):
     assert follow_up_survey_planner._detected_rates == [0.1, 0.1, 0.1, 0.1, 0.1, 0.5, 0.6, 0.6]
     assert follow_up_survey_planner._latest_detection_date == date(2021, 1, 7)
 
+
+def test_update_with_max_survey(mocker):
+    """
+    Function to test the update_with_latest_survey function in FollowUpSurveyPlanner
+    """
+    mocker.patch.object(Site, "__init__", lambda self, *args, **kwargs: setattr(self, "id", 1))
+    detection_record = DetectionRecord(site_id=1, site=mocker, rate_detected=0.1)
+    detect_date = date(2021, 1, 1)
+    follow_up_survey_planner = FollowUpSurveyPlanner(detection_record, detect_date)
+    method_name = "test_method"
     redund_filter = FollowUpSurveyPlanner.REDUND_FILTER_MAX
+    detection_record = DetectionRecord(site_id=1, site=mocker, rate_detected=0.1)
+    detect_date = date(2021, 1, 2)
+    follow_up_survey_planner.update_with_latest_survey(
+        detection_record, redund_filter, method_name, detect_date
+    )
+
+    detection_record = DetectionRecord(site_id=1, site=mocker, rate_detected=0.1)
+    detect_date = date(2021, 1, 3)
+    follow_up_survey_planner.update_with_latest_survey(
+        detection_record, redund_filter, method_name, detect_date
+    )
+
+    detection_record = DetectionRecord(site_id=1, site=mocker, rate_detected=0.1)
+    detect_date = date(2021, 1, 4)
+    follow_up_survey_planner.update_with_latest_survey(
+        detection_record, redund_filter, method_name, detect_date
+    )
+
+    detection_record = DetectionRecord(site_id=1, site=mocker, rate_detected=0.1)
+    detect_date = date(2021, 1, 5)
+    follow_up_survey_planner.update_with_latest_survey(
+        detection_record, redund_filter, method_name, detect_date
+    )
+
+    detection_record = DetectionRecord(site_id=1, site=mocker, rate_detected=0.5)
+    detect_date = date(2021, 1, 6)
+    follow_up_survey_planner.update_with_latest_survey(
+        detection_record, redund_filter, method_name, detect_date
+    )
+
+    new_detection = DetectionRecord(site_id=1, site=mocker, rate_detected=0.1)
+    detect_date = date(2021, 1, 7)
     follow_up_survey_planner.update_with_latest_survey(
         new_detection, redund_filter, method_name, detect_date
     )
-    assert follow_up_survey_planner.rate_at_site == 0.6
-    assert follow_up_survey_planner._detected_rates == [0.1, 0.1, 0.1, 0.1, 0.1, 0.5, 0.6, 0.6, 0.6]
+    assert follow_up_survey_planner.rate_at_site == 0.5
+    assert follow_up_survey_planner._detected_rates == [0.1, 0.1, 0.1, 0.1, 0.1, 0.5, 0.1]
     assert follow_up_survey_planner._latest_detection_date == date(2021, 1, 7)
 
+
+def test_update_with_rolling_survey(mocker):
+    """
+    Function to test the update_with_latest_survey function in FollowUpSurveyPlanner
+    """
+    mocker.patch.object(Site, "__init__", lambda self, *args, **kwargs: setattr(self, "id", 1))
+    detection_record = DetectionRecord(site_id=1, site=mocker, rate_detected=0.1)
+    detect_date = date(2021, 1, 1)
+    stationary_survey_planner = StationaryFollowUpSurveyPlanner(detection_record, detect_date)
+    method_name = "test_method"
     redund_filter = "rolling_average"
-    follow_up_survey_planner.update_with_latest_survey(
+    detection_record = DetectionRecord(site_id=1, site=mocker, rate_detected=0.1)
+    detect_date = date(2021, 1, 2)
+    stationary_survey_planner.update_with_latest_survey(
+        detection_record, redund_filter, method_name, detect_date
+    )
+
+    detection_record = DetectionRecord(site_id=1, site=mocker, rate_detected=0.1)
+    detect_date = date(2021, 1, 3)
+    stationary_survey_planner.update_with_latest_survey(
+        detection_record, redund_filter, method_name, detect_date
+    )
+
+    detection_record = DetectionRecord(site_id=1, site=mocker, rate_detected=0.1)
+    detect_date = date(2021, 1, 4)
+    stationary_survey_planner.update_with_latest_survey(
+        detection_record, redund_filter, method_name, detect_date
+    )
+
+    detection_record = DetectionRecord(site_id=1, site=mocker, rate_detected=0.1)
+    detect_date = date(2021, 1, 5)
+    stationary_survey_planner.update_with_latest_survey(
+        detection_record, redund_filter, method_name, detect_date
+    )
+
+    detection_record = DetectionRecord(site_id=1, site=mocker, rate_detected=0.5)
+    detect_date = date(2021, 1, 6)
+    stationary_survey_planner.update_with_latest_survey(
+        detection_record, redund_filter, method_name, detect_date
+    )
+
+    new_detection = DetectionRecord(site_id=1, site=mocker, rate_detected=0.6)
+    detect_date = date(2021, 1, 7)
+    stationary_survey_planner.update_with_latest_survey(
         new_detection, redund_filter, method_name, detect_date
     )
-    assert round(follow_up_survey_planner.rate_at_site, 6) == 0.442857
-    assert round(follow_up_survey_planner.rate_at_site_long, 5) == 0.34000
-    assert follow_up_survey_planner._detected_rates == [
+
+    stationary_survey_planner.update_with_latest_survey(
+        new_detection, redund_filter, method_name, detect_date
+    )
+
+    stationary_survey_planner.update_with_latest_survey(
+        new_detection, redund_filter, method_name, detect_date
+    )
+    stationary_survey_planner.update_with_latest_survey(
+        new_detection, redund_filter, method_name, detect_date
+    )
+    assert stationary_survey_planner._detected_rates == [
         0.1,
         0.1,
         0.1,
@@ -107,4 +248,6 @@ def test_update_with_latest_survey(mocker):
         0.6,
         0.6,
     ]
-    assert follow_up_survey_planner._latest_detection_date == date(2021, 1, 7)
+    assert stationary_survey_planner._latest_detection_date == date(2021, 1, 7)
+    assert round(stationary_survey_planner.rate_at_site, 6) == 0.442857
+    assert round(stationary_survey_planner.rate_at_site_long, 5) == 0.34000

--- a/LDAR_Sim/testing/unit_testing/test_scheduling/test_survey_planner/test_update_with_latest_survey.py
+++ b/LDAR_Sim/testing/unit_testing/test_scheduling/test_survey_planner/test_update_with_latest_survey.py
@@ -187,7 +187,9 @@ def test_update_with_rolling_survey(mocker):
     mocker.patch.object(Site, "__init__", lambda self, *args, **kwargs: setattr(self, "id", 1))
     detection_record = DetectionRecord(site_id=1, site=mocker, rate_detected=0.1)
     detect_date = date(2021, 1, 1)
-    stationary_survey_planner = StationaryFollowUpSurveyPlanner(detection_record, detect_date)
+    stationary_survey_planner = StationaryFollowUpSurveyPlanner(
+        detection_record, detect_date, 7, 30
+    )
     method_name = "test_method"
     redund_filter = "rolling_average"
     detection_record = DetectionRecord(site_id=1, site=mocker, rate_detected=0.1)

--- a/LDAR_Sim/testing/unit_testing/test_scheduling/test_survey_planner/test_update_with_latest_survey.py
+++ b/LDAR_Sim/testing/unit_testing/test_scheduling/test_survey_planner/test_update_with_latest_survey.py
@@ -1,0 +1,110 @@
+"""
+------------------------------------------------------------------------------
+Program:     The LDAR Simulator (LDAR-Sim)
+File:        test_update_with_latest_survey.py
+Purpose: Module for testing test_update_with_latest_survey for FollowUpSurveyPlanner
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the MIT License as published
+by the Free Software Foundation, version 3.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+MIT License for more details.
+You should have received a copy of the MIT License
+along with this program.  If not, see <https://opensource.org/licenses/MIT>.
+
+------------------------------------------------------------------------------
+"""
+
+from datetime import date
+from src.virtual_world.sites import Site
+from scheduling.follow_up_survey_planner import FollowUpSurveyPlanner
+from scheduling.surveying_dataclasses import DetectionRecord
+
+
+def test_update_with_latest_survey(mocker):
+    """
+    Function to test the update_with_latest_survey function in FollowUpSurveyPlanner
+    """
+    mocker.patch.object(Site, "__init__", lambda self, *args, **kwargs: setattr(self, "id", 1))
+    detection_record = DetectionRecord(site_id=1, site=mocker, rate_detected=0.1)
+    detect_date = date(2021, 1, 1)
+    follow_up_survey_planner = FollowUpSurveyPlanner(detection_record, detect_date)
+    method_name = "test_method"
+    redund_filter = FollowUpSurveyPlanner.REDUND_FILTER_RECENT
+    detection_record = DetectionRecord(site_id=1, site=mocker, rate_detected=0.1)
+    detect_date = date(2021, 1, 2)
+    follow_up_survey_planner.update_with_latest_survey(
+        detection_record, redund_filter, method_name, detect_date
+    )
+
+    detection_record = DetectionRecord(site_id=1, site=mocker, rate_detected=0.1)
+    detect_date = date(2021, 1, 3)
+    follow_up_survey_planner.update_with_latest_survey(
+        detection_record, redund_filter, method_name, detect_date
+    )
+
+    detection_record = DetectionRecord(site_id=1, site=mocker, rate_detected=0.1)
+    detect_date = date(2021, 1, 4)
+    follow_up_survey_planner.update_with_latest_survey(
+        detection_record, redund_filter, method_name, detect_date
+    )
+
+    detection_record = DetectionRecord(site_id=1, site=mocker, rate_detected=0.1)
+    detect_date = date(2021, 1, 5)
+    follow_up_survey_planner.update_with_latest_survey(
+        detection_record, redund_filter, method_name, detect_date
+    )
+
+    detection_record = DetectionRecord(site_id=1, site=mocker, rate_detected=0.5)
+    detect_date = date(2021, 1, 6)
+    follow_up_survey_planner.update_with_latest_survey(
+        detection_record, redund_filter, method_name, detect_date
+    )
+
+    new_detection = DetectionRecord(site_id=1, site=mocker, rate_detected=0.6)
+    detect_date = date(2021, 1, 7)
+    follow_up_survey_planner.update_with_latest_survey(
+        new_detection, redund_filter, method_name, detect_date
+    )
+    assert follow_up_survey_planner.rate_at_site == 0.6
+    assert follow_up_survey_planner._detected_rates == [0.1, 0.1, 0.1, 0.1, 0.1, 0.5, 0.6]
+    assert follow_up_survey_planner._latest_detection_date == date(2021, 1, 7)
+
+    redund_filter = FollowUpSurveyPlanner.REDUND_FILTER_AVERAGE
+    follow_up_survey_planner.update_with_latest_survey(
+        new_detection, redund_filter, method_name, detect_date
+    )
+    assert round(follow_up_survey_planner.rate_at_site, 3) == 0.275
+    assert follow_up_survey_planner._detected_rates == [0.1, 0.1, 0.1, 0.1, 0.1, 0.5, 0.6, 0.6]
+    assert follow_up_survey_planner._latest_detection_date == date(2021, 1, 7)
+
+    redund_filter = FollowUpSurveyPlanner.REDUND_FILTER_MAX
+    follow_up_survey_planner.update_with_latest_survey(
+        new_detection, redund_filter, method_name, detect_date
+    )
+    assert follow_up_survey_planner.rate_at_site == 0.6
+    assert follow_up_survey_planner._detected_rates == [0.1, 0.1, 0.1, 0.1, 0.1, 0.5, 0.6, 0.6, 0.6]
+    assert follow_up_survey_planner._latest_detection_date == date(2021, 1, 7)
+
+    redund_filter = "rolling_average"
+    follow_up_survey_planner.update_with_latest_survey(
+        new_detection, redund_filter, method_name, detect_date
+    )
+    assert round(follow_up_survey_planner.rate_at_site, 6) == 0.442857
+    assert round(follow_up_survey_planner.rate_at_site_long, 5) == 0.34000
+    assert follow_up_survey_planner._detected_rates == [
+        0.1,
+        0.1,
+        0.1,
+        0.1,
+        0.1,
+        0.5,
+        0.6,
+        0.6,
+        0.6,
+        0.6,
+    ]
+    assert follow_up_survey_planner._latest_detection_date == date(2021, 1, 7)

--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -1413,7 +1413,10 @@ _TODO_ Doesn't exist
 
 **Default input:** 0
 
-**Description:** The initial up-front cost of each crew. This cost is only charged once. The total upfront cost will be upfront times the number of crews.
+**Description:** The initial up-front cost of each crew. This cost is only charged once.
+
+- For `mobile deployment` the total upfront cost will be upfront **times** the number of crews used.
+- For `stationary deployment` the total upfront cost will be equal to the user input value. There is **no** scaling.
 
 See the following files for examples on setting this value at a more granular level:
 

--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -124,6 +124,11 @@ Email: <sally@highwoodemissions.com>
       - [\<redundancy\_filter\>](#redundancy_filter)
       - [\<sort\_by\_rate\>](#sort_by_rate)
       - [\<threshold\>](#threshold)
+    - [rolling\_average](#rolling_average)
+      - [small\_window](#small_window)
+      - [large\_window](#large_window)
+      - [small\_window\_threshold](#small_window_threshold)
+      - [large\_window\_threshold](#large_window_threshold)
   - [10. Virtual World Defining Files](#10-virtual-world-defining-files)
     - [Sites File](#sites-file)
       - [site\_ID](#site_id)
@@ -1729,6 +1734,58 @@ The follow-up [delay](#delay-follow_up) parameter can be set to require multiple
 **Notes on acquisition:** No data acquisition required.
 
 **Notes of caution:** Follow-up thresholds are explored in detail in Fox et al. 2021\. Choosing follow-up rules is complex and work practices should be developed following extensive analysis of different scenarios. It is important to understand how follow-up thresholds and follow-up ratios interact, especially if both are to be used in the same program. Note that follow-up thresholds are similar to minimum detection limits but that the former is checked against to the measured emission rate (which is a function of quantification error) while the latter is checked against the true emission rate.
+
+### rolling_average
+
+**Description:** This parameter provides the overarching heading for the nested parameters related to rolling averages. The following parameters are only relevant when [deployment type](#deployment_type) is set to `stationary`.
+
+#### small_window
+
+**Data Type:** Numeric(Integer)
+
+**Default input:** 7
+
+**Description:** The number of days to consider when taking the rolling average for the [small threshold](#small_window_threshold).
+
+**Notes of acquisition:** N/A
+
+**Notes of caution:** N/A
+
+#### large_window
+
+**Data Type:** Numeric(Integer)
+
+**Default input:** 30
+
+**Description:** The number of days to consider when taking the rolling average for the [large threshold](#large_window_threshold).
+
+**Notes of acquisition:** N/A
+
+**Notes of caution:** N/A
+
+#### small_window_threshold
+
+**Data Type:** Numeric(Float)
+
+**Default input:** 0.0
+
+**Description:** The threshold in grams per second to consider when triggering follow-up work practices, based on the smaller window rolling average.
+
+**Notes of acquisition:** N/A
+
+**Notes of caution:** N/A
+
+#### large_window_threshold
+
+**Data Type:** Numeric(Float)
+
+**Default input:** 0.0
+
+**Description:** The threshold in grams per second to consider when triggering follow-up work practices, based on the larger window rolling average.
+
+**Notes of acquisition:** N/A
+
+**Notes of caution:** N/A
 
 --------------------------------------------------------------------------------
 

--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -1773,19 +1773,19 @@ The follow-up [delay](#delay-follow_up) parameter can be set to require multiple
 
 **Notes of acquisition:** N/A
 
-**Notes of caution:** N/A
+**Notes of caution:** When using the [stationary deployment type](#deployment_type),only the `small_window_threshold` is used by default. To enable two different rolling average considerations for the method, users will need to set the [large_window_threshold](#large_window_threshold).
 
 #### large_window_threshold
 
 **Data Type:** Numeric(Float)
 
-**Default input:** 0.0
+**Default input:** _placeholder_float_
 
-**Description:** The threshold in grams per second to consider when triggering follow-up work practices, based on the larger window rolling average.
+**Description:** The threshold in grams per second to consider when triggering follow-up work practices, based on the larger window rolling average. This is an optional second threshold value; if not set, the method will only consider the [small_window_threshold](#small_window_threshold) for triggering follow-up work practices.
 
 **Notes of acquisition:** N/A
 
-**Notes of caution:** N/A
+**Notes of caution:** When using the [stationary deployment type](#deployment_type),only the [small_window_threshold](#small_window_threshold) is used by default. To enable two different rolling average considerations for the method, users will need to set the `large_window_threshold`.
 
 --------------------------------------------------------------------------------
 

--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -96,17 +96,17 @@ Email: <sally@highwoodemissions.com>
       - [\<temporal\>](#temporal)
     - [\<cost\>](#cost)
       - [\<per\_day\>](#per_day)
-      - [\<per\_site\>  _(propagating parameter)_](#per_site--propagating-parameter)
+      - [\<per\_site\>  _(propagating parameter)_ _(mobile parameter)_](#per_site--propagating-parameter-mobile-parameter)
       - [\<upfront\>  _(propagating parameter)_](#upfront--propagating-parameter)
-    - [\<crew\_count\>](#crew_count)
+    - [\<crew\_count\> _(mobile parameter)_](#crew_count-mobile-parameter)
     - [\<consider\_daylight\>](#consider_daylight)
-    - [\<surveys\_per\_year\> _(propagating parameter)_](#surveys_per_year-propagating-parameter)
-    - [\<survey\_time\> _(propagating parameter)_](#survey_time-propagating-parameter)
-    - [\<max\_workday\>](#max_workday)
+    - [\<surveys\_per\_year\> _(propagating parameter)_ _(mobile parameter)_](#surveys_per_year-propagating-parameter-mobile-parameter)
+    - [\<survey\_time\> _(propagating parameter)_ _(mobile parameter)_](#survey_time-propagating-parameter-mobile-parameter)
+    - [\<max\_workday\> _(mobile parameter)_](#max_workday-mobile-parameter)
     - [\<reporting\_delay\>](#reporting_delay)
     - [\<time\_between\_sites\>](#time_between_sites)
-      - [file (time\_between\_sites)](#file-time_between_sites)
-      - [values (time\_between\_sites)](#values-time_between_sites)
+      - [file (time\_between\_sites) _(mobile parameter)_](#file-time_between_sites-mobile-parameter)
+      - [values (time\_between\_sites) _(mobile parameter)_](#values-time_between_sites-mobile-parameter)
     - [\<scheduling\>](#scheduling)
       - [\<deployment\_months\>  _(propagating parameter)_](#deployment_months--propagating-parameter)
       - [\<deployment\_years\>  _(propagating parameter)_](#deployment_years--propagating-parameter)
@@ -121,14 +121,14 @@ Email: <sally@highwoodemissions.com>
       - [\<instant\_threshold\>](#instant_threshold)
       - [\<interaction\_priority\>](#interaction_priority)
       - [\<proportion\>](#proportion)
-      - [\<redundancy\_filter\>](#redundancy_filter)
+      - [\<redundancy\_filter\> _(mobile parameter)_](#redundancy_filter-mobile-parameter)
       - [\<sort\_by\_rate\>](#sort_by_rate)
-      - [\<threshold\>](#threshold)
+      - [\<threshold\> _(mobile parameter)_](#threshold-mobile-parameter)
     - [rolling\_average](#rolling_average)
-      - [small\_window](#small_window)
-      - [large\_window](#large_window)
-      - [small\_window\_threshold](#small_window_threshold)
-      - [large\_window\_threshold](#large_window_threshold)
+      - [small\_window _(stationary parameter)_](#small_window-stationary-parameter)
+      - [large\_window _(stationary parameter)_](#large_window-stationary-parameter)
+      - [small\_window\_threshold _(stationary parameter)_](#small_window_threshold-stationary-parameter)
+      - [large\_window\_threshold _(stationary parameter)_](#large_window_threshold-stationary-parameter)
   - [10. Virtual World Defining Files](#10-virtual-world-defining-files)
     - [Sites File](#sites-file)
       - [site\_ID](#site_id)
@@ -1229,7 +1229,7 @@ Valid deployment types:
 
 **Notes on acquisition:** No data acquisition required.
 
-**Notes of caution:** N/A
+**Notes of caution:** Certain parameters are mobile/stationary deployment specific, which will be labeled with the following _(mobile parameter)_ or _(stationary parameter)_.
 
 ### &lt;sensor&gt;
 
@@ -1386,9 +1386,9 @@ See the following files for examples on setting this value at a more granular le
 
 **Notes on acquisition:** No data acquisition required.
 
-**Notes of caution:** N/A
+**Notes of caution:** `Stationary` deployment methods only use the `per_day` and `upfront` cost values.
 
-#### &lt;per_site&gt;  _(propagating parameter)_
+#### &lt;per_site&gt;  _(propagating parameter)_ _(mobile parameter)_
 
 **Data type:** Numeric
 
@@ -1403,7 +1403,7 @@ See the following files for examples on setting this value at a more granular le
 
 **Notes on acquisition:** No data acquisition required.
 
-**Notes of caution:** N/A
+**Notes of caution:** `Stationary` deployment methods only use the `per_day` and `upfront` cost values.
 
 #### &lt;upfront&gt;  _(propagating parameter)_
 
@@ -1424,7 +1424,9 @@ See the following files for examples on setting this value at a more granular le
 
 **Notes of caution:** Does not account for maintenance activities or the cost of replacing devices at the end of their lifetime.
 
-### &lt;crew_count&gt;
+`Stationary` deployment methods only use the `per_day` and `upfront` cost values.
+
+### &lt;crew_count&gt; _(mobile parameter)_
 
 **Data type:**  Numeric (Integer)
 
@@ -1442,13 +1444,13 @@ See the following files for examples on setting this value at a more granular le
 
 **Default input:** False
 
-**Description:** A binary True/False to indicate whether crews should only work during daylight hours. If False, crews work the number of hours specified by the [max_workday](#max_workday) input variable used for each method. If True, crews work the shorter of either [max_workday](#max_workday) or the number of daylight hours calculated using the PyEphem package in python using latitude, longitude of each site, for each day of the year.
+**Description:** A binary True/False to indicate whether crews should only work during daylight hours. If False, crews work the number of hours specified by the [max_workday](#max_workday-mobile-parameter) input variable used for each method. If True, crews work the shorter of either [max_workday](#max_workday-mobile-parameter) or the number of daylight hours calculated using the PyEphem package in python using latitude, longitude of each site, for each day of the year.
 
 **Notes on acquisition:** Acquisition is automated using required latitude and longitude coordinates for each facility (see infrastructure_file input) at each time step.
 
 **Notes of caution:** In most cases, True and False will yield similar results. Use of daylight constraints should be considered for companies that do not wish to deploy crews in the dark for safety reasons, especially for locations at high latitudes during winter months (e.g., Northern Alberta). However, this functionality should not be used to determine whether sunlight is available for passive remote sensing methods or other technologies that require sunlight operate, as the sun has already set when civil twilight occurs (see obs.horizon). Solar flux will vary with topography and cloud cover (use ERA5 data).
 
-### &lt;surveys_per_year&gt; _(propagating parameter)_
+### &lt;surveys_per_year&gt; _(propagating parameter)_ _(mobile parameter)_
 
 **Data type:**  Numeric (Integer)
 
@@ -1467,7 +1469,7 @@ See the following files for examples on setting this value at a more granular le
 
 **Note:** this parameter may also be set more granularly using the infrastructure files.
 
-### &lt;survey_time&gt; _(propagating parameter)_
+### &lt;survey_time&gt; _(propagating parameter)_ _(mobile parameter)_
 
 **Data type:**  Numeric (Integer)
 
@@ -1486,7 +1488,7 @@ See the following files for examples on setting this value at a more granular le
 
 **Note:** this parameter may also be set more granularly using the infrastructure files.
 
-### &lt;max_workday&gt;
+### &lt;max_workday&gt; _(mobile parameter)_
 
 **Data type:**  Numeric (Integer)
 
@@ -1514,7 +1516,7 @@ See the following files for examples on setting this value at a more granular le
 
 **Description:** The following parameters specify the time required between surveys for planning, travel, setup, and takedown. This includes all the time not spent on the actual site survey, but the time needed between each site survey by a crew.
 
-#### file (time_between_sites)
+#### file (time_between_sites) _(mobile parameter)_
 
 **Data type:** String
 
@@ -1526,7 +1528,7 @@ See the following files for examples on setting this value at a more granular le
 
 **Notes of caution:** These data may be difficult to acquire and may lack representativeness.
 
-#### values (time_between_sites)
+#### values (time_between_sites) _(mobile parameter)_
 
 **Data type:** List of Integers
 
@@ -1646,7 +1648,11 @@ Moreover, this feature can model work practices involving multiple screenings to
 
 **Default input:** 0
 
-**Description:** The number of days required to have passed since the first site added to the site candidate flagged pool before a site can be flagged. The company will hold all measurements in a site candidate flagged pool. The emissions rate used to triage flagging based on follow-up threshold and proportion are specified with [redundancy filter](#redundancy_filter).
+**Description:** The number of days required to have passed since the first site added to the site candidate flagged pool before a site can be flagged. The company will hold all measurements in a site candidate flagged pool.
+
+The emissions rate for flagging mobile deployment methods is determined by the follow-up  [threshold](#threshold-mobile-parameter) and the specified [proportion](#proportion), as outlined  by the [redundancy filter](#redundancy_filter-mobile-parameter).
+
+For `Stationary` deployment methods, flagging is based on the [rolling-average](#rolling_average) parameters and specified [proportion](#proportion).
 
 **Notes on acquisition:** N/A
 
@@ -1662,7 +1668,7 @@ Moreover, this feature can model work practices involving multiple screenings to
 
 **Notes on acquisition:** No data acquisition required.
 
-**Notes of caution:** The instant threshold should be set above the [follow-up threshold](#threshold), as this is the minimum emission rate that a site must reach to be flagged.
+**Notes of caution:** The instant threshold should be set above the [follow-up threshold](#threshold-mobile-parameter), as this is the minimum emission rate that a site must reach to be flagged.
 
 Follow-up thresholds are explored in detail in Fox et al. 2021\. Choosing follow-up rules is complex and work practices should be developed following extensive analysis of different scenarios. It is important to understand how follow-up thresholds and follow-up ratios interact, especially if both are to be used in the same program. Note that follow-up thresholds are similar to minimum detection limits but that the former is checked against the measured emission rate (which is a function of quantification error) while the latter is checked against the true emission rate.
 
@@ -1693,7 +1699,7 @@ Follow-up thresholds are explored in detail in Fox et al. 2021\. Choosing follow
 
 **Notes of caution:** Specifies which measured emission rates to use when identifying flagged candidate sites for follow-up. This is relevant for individual sites that have had multiple independent measurements during the given period, resulting in the sites being added to a candidate pool of potentially flagged sites. The following are the three options available for this parameter:
 
-#### &lt;redundancy_filter&gt;
+#### &lt;redundancy_filter&gt; _(mobile parameter)_
 
 **Data type:** String
 
@@ -1721,7 +1727,7 @@ Follow-up thresholds are explored in detail in Fox et al. 2021\. Choosing follow
 
 **Notes of caution:** For the intended follow-up `interaction_priority:proportion` use case, it's advisable to enable sorting by setting `sort_by_rate: True`. This ensures that the original purpose of using `interaction_priority:proportion` is maintained.
 
-#### &lt;threshold&gt;
+#### &lt;threshold&gt; _(mobile parameter)_
 
 **Data type:** Float
 
@@ -1739,31 +1745,31 @@ The follow-up [delay](#delay-follow_up) parameter can be set to require multiple
 
 **Description:** This parameter provides the overarching heading for the nested parameters related to rolling averages. The following parameters are only relevant when [deployment type](#deployment_type) is set to `stationary`.
 
-#### small_window
+#### small_window _(stationary parameter)_
 
 **Data Type:** Numeric(Integer)
 
 **Default input:** 7
 
-**Description:** The number of days to consider when taking the rolling average for the [small threshold](#small_window_threshold).
+**Description:** The number of days to consider when taking the rolling average for the [small threshold](#small_window_threshold-stationary-parameter).
 
 **Notes of acquisition:** N/A
 
 **Notes of caution:** N/A
 
-#### large_window
+#### large_window _(stationary parameter)_
 
 **Data Type:** Numeric(Integer)
 
 **Default input:** 30
 
-**Description:** The number of days to consider when taking the rolling average for the [large threshold](#large_window_threshold).
+**Description:** The number of days to consider when taking the rolling average for the [large threshold](#large_window_threshold-stationary-parameter).
 
 **Notes of acquisition:** N/A
 
 **Notes of caution:** N/A
 
-#### small_window_threshold
+#### small_window_threshold _(stationary parameter)_
 
 **Data Type:** Numeric(Float)
 
@@ -1773,19 +1779,19 @@ The follow-up [delay](#delay-follow_up) parameter can be set to require multiple
 
 **Notes of acquisition:** N/A
 
-**Notes of caution:** When using the [stationary deployment type](#deployment_type),only the `small_window_threshold` is used by default. To enable two different rolling average considerations for the method, users will need to set the [large_window_threshold](#large_window_threshold).
+**Notes of caution:** When using the [stationary deployment type](#deployment_type),only the `small_window_threshold` is used by default. To enable two different rolling average considerations for the method, users will need to set the [large_window_threshold](#large_window_threshold-stationary-parameter).
 
-#### large_window_threshold
+#### large_window_threshold _(stationary parameter)_
 
 **Data Type:** Numeric(Float)
 
 **Default input:** _placeholder_float_
 
-**Description:** The threshold in grams per second to consider when triggering follow-up work practices, based on the larger window rolling average. This is an optional second threshold value; if not set, the method will only consider the [small_window_threshold](#small_window_threshold) for triggering follow-up work practices.
+**Description:** The threshold in grams per second to consider when triggering follow-up work practices, based on the larger window rolling average. This is an optional second threshold value; if not set, the method will only consider the [small_window_threshold](#small_window_threshold-stationary-parameter) for triggering follow-up work practices.
 
 **Notes of acquisition:** N/A
 
-**Notes of caution:** When using the [stationary deployment type](#deployment_type),only the [small_window_threshold](#small_window_threshold) is used by default. To enable two different rolling average considerations for the method, users will need to set the `large_window_threshold`.
+**Notes of caution:** When using the [stationary deployment type](#deployment_type),only the [small_window_threshold](#small_window_threshold-stationary-parameter) is used by default. To enable two different rolling average considerations for the method, users will need to set the `large_window_threshold`.
 
 --------------------------------------------------------------------------------
 

--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -1415,8 +1415,8 @@ _TODO_ Doesn't exist
 
 **Description:** The initial up-front cost of each crew. This cost is only charged once.
 
-- For `mobile deployment` the total upfront cost will be upfront **times** the number of crews used.
-- For `stationary deployment` the total upfront cost will be equal to the user input value. There is **no** scaling.
+- For `mobile` deployment the total upfront cost will be upfront **times** the number of crews used.
+- For `stationary` deployment the total upfront cost will be equal to the user input value. There is **no** scaling.
 
 See the following files for examples on setting this value at a more granular level:
 


### PR DESCRIPTION
# Pull Request Key Information

## Reason for change

Stationary deployment methods were not re-implemented with the original code rework, only a skeleton existed.

## What was changed

Stationary deployment methods have been re-introduced
Stationary methods now use rolling averages based on a short or a long window

## Intended Purpose

To reimplement the stationary deployment method and improve upon it by adding a feature to use the rolling averages as thresholds.

## Testing Completed

All unit tests pass - added in new unit test to ensure rolling averages function works as intended.
[results.txt](https://github.com/user-attachments/files/15592917/results.txt)

Manual end to end tests checked the following:
- Manually ran a mobile method parameterized to act like a stationary method and compared it to a stationary deployed method; the results matched.
- Verified that the daily deployment cost is as expected, despite a known bug with upfront costs.
- Deployment cost is added to the total even if measurements didn't happen due to weather.
- Deployment cost is not considered only if the deployment month/year was invalid.
- Confirmed that the deployment year/month functionality with stationary works.
- Checked that deployment numbers, when accounting for weather, made sense. Previously, the count increased even if deployment didn't happen due to weather.
- Checked that the survey time/time between sites was not a factor for stationary deployment
