### PR TITLE
<FEAT>: Add upfront cost to outputs

### DIFF
--- a/LDAR_Sim/src/file_processing/output_processing/output_utils.py
+++ b/LDAR_Sim/src/file_processing/output_processing/output_utils.py
@@ -87,6 +87,7 @@ class TsEmisData:
 @dataclass
 class TsMethodData:
     method_name: str
+    upfront_cost: float = 0.0
     daily_deployment_cost: float = 0.0
     daily_tags: int = 0
     daily_flags: int = 0

--- a/LDAR_Sim/src/file_processing/output_processing/program_output_manager.py
+++ b/LDAR_Sim/src/file_processing/output_processing/program_output_manager.py
@@ -139,16 +139,25 @@ class ProgramOutputManager:
         new_row[tca.NAT_REP_LEAKS] = ts_emis_rep_info.leaks_nat_repaired
 
     def _update_ts_row_w_methods_info(
-        self, new_row: dict[str, Any], ts_methods_info: list[TsMethodData]
+        self,
+        new_row: dict[str, Any],
+        ts_methods_info: list[TsMethodData],
+        include_upfront_cost: bool = False,
     ) -> None:
         total_daily_cost: float = 0.0
         total_leaks_tagged: int = 0
         for method_info in ts_methods_info:
+            if include_upfront_cost:
+                total_daily_cost += method_info.upfront_cost
+                new_row[tca.METH_DAILY_DEPLOY_COST.format(method=method_info.method_name)] = (
+                    method_info.daily_deployment_cost + method_info.upfront_cost
+                )
+            else:
+                new_row[tca.METH_DAILY_DEPLOY_COST.format(method=method_info.method_name)] = (
+                    method_info.daily_deployment_cost
+                )
             total_daily_cost += method_info.daily_deployment_cost
             total_leaks_tagged += np.nan_to_num(method_info.daily_tags)
-            new_row[tca.METH_DAILY_DEPLOY_COST.format(method=method_info.method_name)] = (
-                method_info.daily_deployment_cost
-            )
             new_row[tca.METH_DAILY_TAGS.format(method=method_info.method_name)] = (
                 method_info.daily_tags
             )

--- a/LDAR_Sim/src/ldar_sim.py
+++ b/LDAR_Sim/src/ldar_sim.py
@@ -87,6 +87,7 @@ class LdarSim:
         ts_columns = self._output_manager._init_ts_columns()
         timeseries = pd.DataFrame(columns=ts_columns)
         total_emissions_count: int = 0
+        first_day: bool = True
         while not self._tc.at_simulation_end():
             if self._preseed:
                 np.random.seed(self._preseed_ts[self._tc.current_date])
@@ -101,9 +102,15 @@ class LdarSim:
             self._output_manager._update_ts_row_w_emis_info(
                 new_row=new_row, ts_emis_info=ts_emis_info, ts_emis_rep_info=ts_emis_rep_info
             )
-            self._output_manager._update_ts_row_w_methods_info(
-                new_row=new_row, ts_methods_info=ts_methods_info
-            )
+            if first_day:
+                first_day = False
+                self._output_manager._update_ts_row_w_methods_info(
+                    new_row=new_row, ts_methods_info=ts_methods_info, include_upfront_cost=True
+                )
+            else:
+                self._output_manager._update_ts_row_w_methods_info(
+                    new_row=new_row, ts_methods_info=ts_methods_info
+                )
             timeseries.loc[len(timeseries)] = new_row
             self._program.update_date()
             self._tc.next_day()

--- a/LDAR_Sim/src/ldar_sim.py
+++ b/LDAR_Sim/src/ldar_sim.py
@@ -102,15 +102,11 @@ class LdarSim:
             self._output_manager._update_ts_row_w_emis_info(
                 new_row=new_row, ts_emis_info=ts_emis_info, ts_emis_rep_info=ts_emis_rep_info
             )
-            if first_day:
-                first_day = False
-                self._output_manager._update_ts_row_w_methods_info(
-                    new_row=new_row, ts_methods_info=ts_methods_info, include_upfront_cost=True
-                )
-            else:
-                self._output_manager._update_ts_row_w_methods_info(
-                    new_row=new_row, ts_methods_info=ts_methods_info
-                )
+            self._output_manager._update_ts_row_w_methods_info(
+                new_row=new_row, ts_methods_info=ts_methods_info, include_upfront_cost=first_day
+            )
+            first_day = False
+
             timeseries.loc[len(timeseries)] = new_row
             self._program.update_date()
             self._tc.next_day()

--- a/LDAR_Sim/src/programs/method.py
+++ b/LDAR_Sim/src/programs/method.py
@@ -94,7 +94,7 @@ class Method:
         return
 
     def initialize_cost_tracking(self, cost_properties: dict[str, float]):
-        self.upfront_cost = cost_properties[pdc.Method_Params.UPFRONT]
+        self.upfront_cost = cost_properties[pdc.Method_Params.UPFRONT] * self._crews
         if cost_properties[pdc.Method_Params.PER_SITE] > 0:
             self.cost_type = self.PER_SITE_COST
             self.cost = cost_properties[pdc.Method_Params.PER_SITE]
@@ -180,6 +180,9 @@ class Method:
         survey_time: float = self._avg_s_time
 
         return math.ceil(daily_work_time / survey_time)
+
+    def get_upfront_cost(self) -> float:
+        return self.upfront_cost
 
     def get_crew_count(self) -> int:
         return self._crews

--- a/LDAR_Sim/src/programs/program.py
+++ b/LDAR_Sim/src/programs/program.py
@@ -202,6 +202,7 @@ class Program:
             timeseries_methods_data.append(
                 TsMethodData(
                     method_name=method.get_name(),
+                    upfront_cost=method.get_upfront_cost(),
                     daily_deployment_cost=deployment_stats.deployment_cost,
                     daily_flags=tags_flags.sites_flagged,
                     daily_tags=tags_flags.leaks_tagged,

--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -1242,7 +1242,7 @@ and `c` represents the optional minimum threshold that the rate must exceed to b
 
 **Default input:** 0
 
-**Description:** The initial up-front cost of each crew. This cost is only charged once.
+**Description:** The initial up-front cost of each crew. This cost is only charged once. The total upfront cost will be upfront times the number of crews.
 
 **Notes on acquisition:** Consult service provider.
 


### PR DESCRIPTION
# Pull Request Key Information

## Reason for change

Upfront costs were not included in the overall outputs.

## What was changed

TsMethodData now keeps track of upfront_cost
The upfront cost amount is added to the daily cost of the first day of the simulation.

## Intended Purpose

Add in upfront costs to the output code.


## Testing Completed

All unit tests pass.
[results.txt](https://github.com/user-attachments/files/15775658/results.txt)

Manually tested that the time-series deployment cost and daily cost values include upfront cost.


