### PR TITLE
<UPD>: Split Default Methods files

### DIFF
--- a/LDAR_Sim/src/constants/error_messages.py
+++ b/LDAR_Sim/src/constants/error_messages.py
@@ -98,6 +98,7 @@ class Input_Processing_Messages:
         "Error: Invalid {level} name provided: {name}. "
         "Refer to the User Manual for further details."
     )
+    MISSING_DEPLOYMENT_TYPE_ERROR = "Warning: Deployment type is missing for method: {method}"
 
 
 class Output_Processing_Messages:
@@ -193,10 +194,10 @@ class Initialization_Messages:
         "Invalid LDAR-Sim infrastructure inputs: Failure to read in sources infrastructure input"
     )
     PARAMETER_CREATION_ERROR_MESSAGE = (
-        "Key {key} present in test parameters, but not in default parameters"
+        "Key {key} present in user defined parameters for {name}, but not in default parameters"
     )
     PARAMETER_TYPE_MISMATCH_ERROR_MESSAGE = (
-        "Parameter type mismatch. \nDefault parameter: {default} is {def_type}"
+        "Parameter type mismatch for {name}. \nDefault parameter: {default} is {def_type}"
         "\nTest parameter: {test} is {test_type}"
     )
     AWS_KEY_SEC_ERROR = (

--- a/LDAR_Sim/src/constants/file_name_constants.py
+++ b/LDAR_Sim/src/constants/file_name_constants.py
@@ -26,7 +26,8 @@ class Default_Files:
     VIRTUAL_DEF_FILE = "virtual_world_default.yml"
     SIM_SETTING_DEF_FILE = "simulation_settings_default.yml"
     PROG_DEF_FILE = "p_default.yml"
-    METH_DEF_FILE = "m_default.yml"
+    METH_STATIONARY_DEF_FILE = "m_default_stationary.yml"
+    METH_MOBILE_DEF_FILE = "m_default_mobile.yml"
     OUTPUT_DEF_FILE = "outputs_default.yml"
 
 

--- a/LDAR_Sim/src/default_parameters/m_default_mobile.yml
+++ b/LDAR_Sim/src/default_parameters/m_default_mobile.yml
@@ -2,7 +2,7 @@ parameter_level: "methods"
 version: "4.0"
 method_name: "_placeholder_str_"
 measurement_scale: "_placeholder_str_" # site/equipment/component
-deployment_type: "_placeholder_str_" # mobile/stationary
+deployment_type: mobile # mobile
 sensor:
   type: default # default/OGI_camera_zim(see User manual for MDL values)/OGI_camera_rk
   quantification_error: 0.0
@@ -40,8 +40,3 @@ follow_up:
   redundancy_filter: "recent" # recent/max/average - MOBILE ONLY
   sort_by_rate: True # True/False
   threshold: 0.0 # g/s - MOBILE ONLY
-rolling_average:
-  small_window: 7 # days - STATIONARY ONLY
-  large_window: 30 # days - STATIONARY ONLY
-  small_window_threshold: 0.0 # g/s - STATIONARY ONLY
-  large_window_threshold: "_placeholder_float_" # g/s - STATIONARY ONLY

--- a/LDAR_Sim/src/default_parameters/m_default_stationary.yml
+++ b/LDAR_Sim/src/default_parameters/m_default_stationary.yml
@@ -1,0 +1,37 @@
+parameter_level: "methods"
+version: "4.0"
+method_name: "_placeholder_str_"
+measurement_scale: "_placeholder_str_" # site/equipment/component
+deployment_type: stationary #stationary
+sensor:
+  type: default # default/OGI_camera_zim(see User manual for MDL values)/OGI_camera_rk
+  quantification_error: 0.0
+  minimum_detection_limit: [0.01]
+coverage:
+  spatial: 1.0 # 0.0 to 1.0
+  temporal: 1.0 # 0.0 to 1.0
+cost:
+  per_day: 0
+  upfront: 0
+consider_daylight: False
+reporting_delay: 2 # days
+scheduling:
+  deployment_months: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
+  deployment_years: ["_placeholder_int_"]
+weather_envelopes:
+  precipitation: [0.0, 0.5]
+  temperature: [-40.0, 40.0]
+  wind: [0.0, 10.0]
+is_follow_up: False # True/False
+follow_up:
+  preferred_method: "_placeholder_str_"
+  delay: 0 # days
+  instant_threshold: "_placeholder_float_" # g/s
+  interaction_priority: "threshold" # threshold/proportion
+  proportion: 1.0 # 0 to 1.0
+  sort_by_rate: True # True/False
+rolling_average:
+  small_window: 7 # days - STATIONARY ONLY
+  large_window: 30 # days - STATIONARY ONLY
+  small_window_threshold: 0.0 # g/s - STATIONARY ONLY
+  large_window_threshold: "_placeholder_float_" # g/s - STATIONARY ONLY

--- a/LDAR_Sim/src/file_processing/input_processing/input_manager.py
+++ b/LDAR_Sim/src/file_processing/input_processing/input_manager.py
@@ -273,7 +273,10 @@ class InputManager:
             # methods pre-specified
             for midx, method in program[pc.Levels.METHOD].items():
                 if ParameterProcessingConst.DEFAULT_PARAM_STRING not in method:
-                    def_file = df.METH_DEF_FILE
+                    if method[pc.Method_Params.DEPLOYMENT_TYPE] == pc.Deployment_Types.MOBILE:
+                        def_file = df.METH_MOBILE_DEF_FILE
+                    else:
+                        def_file = df.METH_STATIONARY_DEF_FILE
                 else:
                     def_file = new_parameters[ParameterProcessingConst.DEFAULT_PARAM_STRING]
                 m_param_file = ParameterProcessingConst.DEFAULT_PARAM_PATHWAY.format(def_file)

--- a/LDAR_Sim/src/file_processing/input_processing/input_manager.py
+++ b/LDAR_Sim/src/file_processing/input_processing/input_manager.py
@@ -187,7 +187,10 @@ class InputManager:
                         programs = programs + new_parameters.pop(pc.Levels.PROGRAM)
 
                 check_types(
-                    self.simulation_parameters, new_parameters, omit_keys=[pc.Levels.PROGRAM]
+                    self.simulation_parameters,
+                    new_parameters,
+                    pc.Levels.SIMULATION,
+                    omit_keys=[pc.Levels.PROGRAM],
                 )
                 self.retain_update(self.simulation_parameters, new_parameters)
 
@@ -199,7 +202,7 @@ class InputManager:
                 v_world_param_file = ParameterProcessingConst.DEFAULT_PARAM_PATHWAY.format(def_file)
                 with open(v_world_param_file, "r") as f:
                     default_v_world_params = yaml.load(f.read(), Loader=yaml.SafeLoader)
-                check_types(default_v_world_params, new_parameters)
+                check_types(default_v_world_params, new_parameters, pc.Levels.VIRTUAL)
                 new_v_world = copy.deepcopy(default_v_world_params)
                 self.retain_update(new_v_world, new_parameters)
                 self.simulation_parameters[pc.Levels.VIRTUAL] = new_v_world
@@ -213,7 +216,10 @@ class InputManager:
                 with open(p_param_file, "r") as f:
                     default_program_parameters = yaml.load(f.read(), Loader=yaml.SafeLoader)
                 check_types(
-                    default_program_parameters, new_parameters, omit_keys=[pc.Levels.METHOD]
+                    default_program_parameters,
+                    new_parameters,
+                    new_parameters[pc.Program_Params.NAME],
+                    omit_keys=[pc.Levels.METHOD],
                 )
                 # Copy all default program parameters to build upon by calling update, then append
                 new_program = copy.deepcopy(default_program_parameters)
@@ -234,7 +240,7 @@ class InputManager:
                 output_param_file = ParameterProcessingConst.DEFAULT_PARAM_PATHWAY.format(def_file)
                 with open(output_param_file, "r") as f:
                     default_output_params = yaml.load(f.read(), Loader=yaml.SafeLoader)
-                check_types(default_output_params, new_parameters)
+                check_types(default_output_params, new_parameters, pc.Levels.OUTPUTS)
                 new_outputs = copy.deepcopy(default_output_params)
                 self.retain_update(new_outputs, new_parameters)
                 self.simulation_parameters[pc.Levels.OUTPUTS] = new_outputs
@@ -275,8 +281,10 @@ class InputManager:
                 if ParameterProcessingConst.DEFAULT_PARAM_STRING not in method:
                     if method[pc.Method_Params.DEPLOYMENT_TYPE] == pc.Deployment_Types.MOBILE:
                         def_file = df.METH_MOBILE_DEF_FILE
-                    else:
+                    elif method[pc.Method_Params.DEPLOYMENT_TYPE] == pc.Deployment_Types.STATIONARY:
                         def_file = df.METH_STATIONARY_DEF_FILE
+                    else:
+                        print(ipm.MISSING_DEPLOYMENT_TYPE_ERROR.format(method=method))
                 else:
                     def_file = new_parameters[ParameterProcessingConst.DEFAULT_PARAM_STRING]
                 m_param_file = ParameterProcessingConst.DEFAULT_PARAM_PATHWAY.format(def_file)
@@ -285,6 +293,7 @@ class InputManager:
                 check_types(
                     default_module,
                     method,
+                    method[pc.Method_Params.NAME],
                     omit_keys=[ParameterProcessingConst.DEFAULT_PARAM_STRING],
                 )
                 self.retain_update(default_module, method)

--- a/LDAR_Sim/src/programs/method.py
+++ b/LDAR_Sim/src/programs/method.py
@@ -102,12 +102,15 @@ class Method:
         if cost_properties[pdc.Method_Params.PER_DAY] > 0:
             self.cost_type = self.PER_DAY_COST
             self.cost = cost_properties[pdc.Method_Params.PER_DAY]
-        elif cost_properties[pdc.Method_Params.PER_SITE] > 0:
+        elif (
+            pdc.Method_Params.PER_SITE in cost_properties
+            and cost_properties[pdc.Method_Params.PER_SITE] > 0
+        ):
             self.cost_type = self.PER_SITE_COST
             self.cost = cost_properties[pdc.Method_Params.PER_SITE]
         else:
-            self.cost_type = self.PER_SITE_COST
-            self.cost = -1
+            self.cost_type = self.PER_DAY_COST
+            self.cost = 0
 
     def _initialize_sensor(self, sensor_info: dict) -> None:
         """Will initialize a sensor of the correct type based

--- a/LDAR_Sim/src/programs/method.py
+++ b/LDAR_Sim/src/programs/method.py
@@ -64,20 +64,19 @@ class Method:
         self._name: str = name
         self._deployment_type = properties[pdc.Method_Params.DEPLOYMENT_TYPE]
         self._initialize_sensor(properties[pdc.Method_Params.SENSOR])
-        self._max_work_hours: int = properties[pdc.Method_Params.MAX_WORKDAY]
+        self._max_work_hours: int = properties.get(pdc.Method_Params.MAX_WORKDAY, 0)
         self._daylight_sensitive = properties[pdc.Method_Params.CONSIDER_DAYLIGHT]
         self._weather: bool = consider_weather
         self._weather_envs: dict = properties[pdc.Method_Params.WEATHER_ENVS]
         self._is_follow_up: bool = properties[pdc.Method_Params.IS_FOLLOW_UP]
         self._initialize_travel_times(
-            properties[pdc.Method_Params.T_BW_SITES][pdc.Common_Params.VAL]
+            properties.get(pdc.Method_Params.T_BW_SITES, {}).get(pdc.Common_Params.VAL, 0)
         )  # TODO: update this to not use just vals
         self._reporting_delay: int = properties[pdc.Method_Params.REPORTING_DELAY]
-        crews: int = properties[pdc.Method_Params.N_CREWS]
         # TODO Check where these should be saved
         self._site_survey_reports: list[SiteSurveyReport] = []
         self._detection_records: dict[date, list[DetectionRecord]] = {}
-        self.initialize_crews(crews, sites)
+        self.initialize_crews(properties.get(pdc.Method_Params.N_CREWS, 0), sites)
         self.initialize_cost_tracking(properties[pdc.Method_Params.COST])
 
     def initialize_crews(self, crews, sites: "list[Site]") -> None:
@@ -100,12 +99,12 @@ class Method:
 
     def initialize_cost_tracking(self, cost_properties: dict[str, float]):
         self.upfront_cost = cost_properties[pdc.Method_Params.UPFRONT] * self._crews
-        if cost_properties[pdc.Method_Params.PER_SITE] > 0:
-            self.cost_type = self.PER_SITE_COST
-            self.cost = cost_properties[pdc.Method_Params.PER_SITE]
-        elif cost_properties[pdc.Method_Params.PER_DAY] > 0:
+        if cost_properties[pdc.Method_Params.PER_DAY] > 0:
             self.cost_type = self.PER_DAY_COST
             self.cost = cost_properties[pdc.Method_Params.PER_DAY]
+        elif cost_properties[pdc.Method_Params.PER_SITE] > 0:
+            self.cost_type = self.PER_SITE_COST
+            self.cost = cost_properties[pdc.Method_Params.PER_SITE]
         else:
             self.cost_type = self.PER_SITE_COST
             self.cost = -1

--- a/LDAR_Sim/src/programs/site_level_method.py
+++ b/LDAR_Sim/src/programs/site_level_method.py
@@ -88,13 +88,13 @@ class SiteLevelMethod(Method):
             self._inst_threshold = float("inf")
         self._follow_up_schedule: FollowUpMobileSchedule = follow_up_schedule
         self._detection_count = 0
-        self._small_window = properties[pdc.Method_Params.ROLLING_AVRG][
-            pdc.Method_Params.SMALL_WINDOW
-        ]
-        self._large_window = properties[pdc.Method_Params.ROLLING_AVRG][
-            pdc.Method_Params.LARGE_WINDOW
-        ]
         if self._deployment_type == pdc.Deployment_Types.STATIONARY:
+            self._small_window = properties[pdc.Method_Params.ROLLING_AVRG][
+                pdc.Method_Params.SMALL_WINDOW
+            ]
+            self._large_window = properties[pdc.Method_Params.ROLLING_AVRG][
+                pdc.Method_Params.LARGE_WINDOW
+            ]
             self._small_window_threshold: float = properties[pdc.Method_Params.ROLLING_AVRG][
                 pdc.Method_Params.SMALL_WINDOW_THRESHOLD
             ]

--- a/LDAR_Sim/src/utils/check_parameter_types.py
+++ b/LDAR_Sim/src/utils/check_parameter_types.py
@@ -23,10 +23,11 @@ from constants.general_const import Placeholder_Constants as pc
 from constants.error_messages import Initialization_Messages as im
 
 
-def check_types(default, test, omit_keys=None, fatal=False):
+def check_types(default, test, name, omit_keys=None, fatal=False):
     """Helper function to recursively check the type of parameter dictionaries
     :param default: default element to test
     :param test: test element to test
+    :param file_name: name of the file being tested
     :param omit_keys: a list of dictionary keys to omit from further recursive testing
     :param fatal: boolean to control whether sys.exit() is called upon an error
     """
@@ -55,17 +56,18 @@ def check_types(default, test, omit_keys=None, fatal=False):
             for i in test:
                 if i not in omit_keys:
                     if i not in default:
-                        print(im.PARAMETER_CREATION_ERROR_MESSAGE.format(key=i))
+                        print(im.PARAMETER_CREATION_ERROR_MESSAGE.format(key=i, name=name))
+                        fatal = True
                         if fatal:
                             sys.exit()
 
                     else:
-                        check_types(default[i], test[i], omit_keys=omit_keys, fatal=fatal)
+                        check_types(default[i], test[i], name, omit_keys=omit_keys, fatal=fatal)
 
         elif isinstance(test, list):
             if len(default) > 0 and len(test) > 0:
                 for i in range(len(test)):
-                    check_types(default[0], test[i], omit_keys=omit_keys, fatal=fatal)
+                    check_types(default[0], test[i], name, omit_keys=omit_keys, fatal=fatal)
 
     else:
         print(
@@ -74,7 +76,9 @@ def check_types(default, test, omit_keys=None, fatal=False):
                 def_type=str(type(default)),
                 test=str(test),
                 test_type=str(type(test)),
+                name=name,
             )
         )
+        fatal = True
         if fatal:
             sys.exit()

--- a/LDAR_Sim/src/virtual_world/infrastructure.py
+++ b/LDAR_Sim/src/virtual_world/infrastructure.py
@@ -94,7 +94,7 @@ class Infrastructure:
                 val = None
                 val = methods[method]
                 for path in access_path:
-                    val = val[path]
+                    val = val.get(path, 0)
                 prop_params_dict[pdc.Common_Params.METH_SPECIFIC][param][method] = val
         # By default set all methods to be deployed at all sites
         prop_params_dict[pdc.Common_Params.METH_SPECIFIC][

--- a/LDAR_Sim/testing/unit_testing/test_programs/test_method/method_testing_fixtures.py
+++ b/LDAR_Sim/testing/unit_testing/test_programs/test_method/method_testing_fixtures.py
@@ -181,7 +181,11 @@ def simple_method_values_fix(mocker):
             pdc.Method_Params.PRECIP: [0, 1],
         },
         pdc.Method_Params.REPORTING_DELAY: 0,
-        pdc.Method_Params.COST: {pdc.Method_Params.UPFRONT: 1000, pdc.Method_Params.PER_SITE: 500},
+        pdc.Method_Params.COST: {
+            pdc.Method_Params.UPFRONT: 1000,
+            pdc.Method_Params.PER_SITE: 500,
+            pdc.Method_Params.PER_DAY: 0,
+        },
     }
     current_date: date = date(2023, 1, 2)
     state = {"weather": create_random_state(), "daylight": [], "t": []}
@@ -241,7 +245,11 @@ def simple_method_values2_fix(mocker):
             pdc.Method_Params.PRECIP: [0, 1],
         },
         pdc.Method_Params.REPORTING_DELAY: 0,
-        pdc.Method_Params.COST: {pdc.Method_Params.UPFRONT: 1000, pdc.Method_Params.PER_SITE: 500},
+        pdc.Method_Params.COST: {
+            pdc.Method_Params.UPFRONT: 1000,
+            pdc.Method_Params.PER_SITE: 500,
+            pdc.Method_Params.PER_DAY: 0,
+        },
     }
     current_date: date = date(2023, 1, 2)
     state = {"weather": create_random_state(), "daylight": [], "t": []}
@@ -301,7 +309,11 @@ def simple_method_values3_fix(mocker):
             pdc.Method_Params.PRECIP: [0, 1],
         },
         pdc.Method_Params.REPORTING_DELAY: 0,
-        pdc.Method_Params.COST: {pdc.Method_Params.UPFRONT: 1000, pdc.Method_Params.PER_SITE: 500},
+        pdc.Method_Params.COST: {
+            pdc.Method_Params.UPFRONT: 1000,
+            pdc.Method_Params.PER_SITE: 500,
+            pdc.Method_Params.PER_DAY: 0,
+        },
     }
     current_date: date = date(2023, 1, 2)
     state = {"weather": create_random_state(), "daylight": [], "t": []}
@@ -357,7 +369,11 @@ def simple_method_values4_fix(mocker):
             pdc.Method_Params.PRECIP: [0, 1],
         },
         pdc.Method_Params.REPORTING_DELAY: 0,
-        pdc.Method_Params.COST: {pdc.Method_Params.UPFRONT: 1000, pdc.Method_Params.PER_SITE: 500},
+        pdc.Method_Params.COST: {
+            pdc.Method_Params.UPFRONT: 1000,
+            pdc.Method_Params.PER_SITE: 500,
+            pdc.Method_Params.PER_DAY: 0,
+        },
     }
     survey_report = SiteSurveyReport(site_id=1)
     current_date: date = date(2023, 1, 2)
@@ -421,7 +437,11 @@ def simple_method_values5_fix(mocker):
             pdc.Method_Params.PRECIP: [0, 1],
         },
         pdc.Method_Params.REPORTING_DELAY: 0,
-        pdc.Method_Params.COST: {pdc.Method_Params.UPFRONT: 1000, pdc.Method_Params.PER_SITE: 500},
+        pdc.Method_Params.COST: {
+            pdc.Method_Params.UPFRONT: 1000,
+            pdc.Method_Params.PER_SITE: 500,
+            pdc.Method_Params.PER_DAY: 0,
+        },
     }
     survey_report = SiteSurveyReport(site_id=1)
     current_date: date = date(2023, 1, 2)
@@ -489,7 +509,11 @@ def deploy_crews_testing_fix(mocker):
             pdc.Method_Params.PRECIP: [0, 1],
         },
         pdc.Method_Params.REPORTING_DELAY: 0,
-        pdc.Method_Params.COST: {pdc.Method_Params.UPFRONT: 1000, pdc.Method_Params.PER_SITE: 500},
+        pdc.Method_Params.COST: {
+            pdc.Method_Params.UPFRONT: 1000,
+            pdc.Method_Params.PER_SITE: 500,
+            pdc.Method_Params.PER_DAY: 0,
+        },
     }
     weather = create_random_state()
     sites = [site_mock]
@@ -567,7 +591,11 @@ def deploy_crews_testing2_fix(mocker):
             pdc.Method_Params.PRECIP: [0, 1],
         },
         pdc.Method_Params.REPORTING_DELAY: 0,
-        pdc.Method_Params.COST: {pdc.Method_Params.UPFRONT: 1000, pdc.Method_Params.PER_SITE: 500},
+        pdc.Method_Params.COST: {
+            pdc.Method_Params.UPFRONT: 1000,
+            pdc.Method_Params.PER_SITE: 500,
+            pdc.Method_Params.PER_DAY: 0,
+        },
     }
     weather = create_random_state()
     sites = [site_mock]

--- a/LDAR_Sim/testing/unit_testing/test_programs/test_site_level_method/test_site_level_method_constructor.py
+++ b/LDAR_Sim/testing/unit_testing/test_programs/test_site_level_method/test_site_level_method_constructor.py
@@ -46,7 +46,11 @@ def test_site_level_method_creation(mock_follow_up_schedule):
         pdc.Method_Params.T_BW_SITES: {pdc.Common_Params.VAL: []},
         pdc.Method_Params.N_CREWS: 5,
         pdc.Method_Params.REPORTING_DELAY: 7,
-        pdc.Method_Params.COST: {pdc.Method_Params.PER_SITE: 10, pdc.Method_Params.UPFRONT: 5},
+        pdc.Method_Params.COST: {
+            pdc.Method_Params.PER_SITE: 10,
+            pdc.Method_Params.UPFRONT: 5,
+            pdc.Method_Params.PER_DAY: 0,
+        },
         # Include other properties as needed
     }
 

--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -1158,6 +1158,13 @@ The measured total site level emission rate on January 30th is assumed to have l
 
 ## 9\. Method Inputs
 
+**Note of caution:** There are two sets of valid method default parameters based on the [deployment type](#deployment_type) of the parameterized method. These can be found in the following files:
+
+- m_default_mobile.yml - for `mobile` deployment
+- m_default_stationary.yml - for `stationary` deployment
+
+Users should ensure they populate the correct set of parameters according to the method's [deployment type](#deployment_type). Parameters that are mobile or stationary deployment specific, will be labeled with _(mobile parameter)_ or _(stationary parameter)_ respectively.
+
 ### &lt;parameter_level&gt; (methods)
 
 **Data Type:** String


### PR DESCRIPTION
# Pull Request Key Information

## Reason for change

Improve user experience by providing a more tailored default method file for each of the stationary and mobile methods.

## What was changed

- simulator expects different inputs based on the method deployment type
- users must now use the correct default parameters for the given deployment types

## Intended Purpose

Default method files have been split into two files, one for stationary and one for mobile methods

## Testing Completed

All unit tests pass
[results.txt](https://github.com/user-attachments/files/15783089/results.txt)

Manually checked to see if the simulation would run using the following parameter files
[simple_test_case1.zip](https://github.com/user-attachments/files/15783092/simple_test_case1.zip)

Additional Info:
 - The sensitivity module was not touched with this change, and may require updates 
