### PR TITLE
feat: Add extrapolation to annual emis calcs

### DIFF
--- a/LDAR_Sim/src/constants/infrastructure_const.py
+++ b/LDAR_Sim/src/constants/infrastructure_const.py
@@ -194,7 +194,7 @@ class Deployment_TF_Sites_Constants:
         "{method}" + Infrastructure_Constants.Sites_File_Constants.SITE_DEPLOYMENT_PLACEHOLDER
     )
     METHOD_MEASURED: str = "{method}_measured"
-    MEASURED: str = "Measured"
+    MEASURED: str = "Site Measured"
 
 
 class Virtual_World_To_Prop_Params_Mapping:

--- a/LDAR_Sim/src/constants/output_file_constants.py
+++ b/LDAR_Sim/src/constants/output_file_constants.py
@@ -258,6 +258,8 @@ class EMIS_DATA_COL_ACCESSORS:
     PREV_CONDITION = "Use Previous Condition"
     NEXT_CONDITION = "Use Next Condition"
     NEXT_SURVEY_DATE = "Next Survey Date"
+    SITE_MEASURED = "Site Measured"
+    SITE_TYPE = "Site Type"
 
 
 EMIS_ESTIMATION_OUTPUT_COLUMNS = [

--- a/LDAR_Sim/src/file_processing/output_processing/program_output_manager.py
+++ b/LDAR_Sim/src/file_processing/output_processing/program_output_manager.py
@@ -94,6 +94,7 @@ class ProgramOutputManager:
                 fug_file_name = self.generate_file_names(Output_Files.EST_REP_EMISSIONS_FILE)
 
                 measured_tf_df = measured_tf_df.rename(columns={DTSC.SITE_ID: eca.SITE_ID})
+                measured_tf_df = measured_tf_df.rename(columns={DTSC.SITE_TYPE: eca.SITE_TYPE})
 
                 emis_estimation_merged = pd.merge(
                     emis_estimation, measured_tf_df, on=eca.SITE_ID, how="left"

--- a/LDAR_Sim/src/file_processing/output_processing/summary_output_mapper.py
+++ b/LDAR_Sim/src/file_processing/output_processing/summary_output_mapper.py
@@ -210,12 +210,9 @@ class SummaryOutputMapper:
         file_name_constants.Output_Files.SummaryFileNames.EMIS_EST_SUMMARY: {
             output_file_constants.EMIS_SUMMARY_COLUMNS_ACCESSORS.EST_ANN_EMIS: lambda year: (
                 lambda df: (
-                    summary_output_helpers.get_yearly_value_for_multi_day_stat(
+                    summary_output_helpers.get_annual_emissions_at_all_sites_with_extrapolation(
                         df,
-                        output_file_constants.EMIS_DATA_COL_ACCESSORS.EST_VOL_EMIT,
                         year,
-                        output_file_constants.EMIS_DATA_COL_ACCESSORS.START_DATE,
-                        output_file_constants.EMIS_DATA_COL_ACCESSORS.END_DATE,
                     )
                 )
             )

--- a/LDAR_Sim/testing/unit_testing/test_file_processing/test_output_processing/test_summary_output_helpers/test_get_annual_emissions_at_all_sites_with_extrapolation.py
+++ b/LDAR_Sim/testing/unit_testing/test_file_processing/test_output_processing/test_summary_output_helpers/test_get_annual_emissions_at_all_sites_with_extrapolation.py
@@ -56,7 +56,7 @@ def mock_est_emis_data_1_subtype_few_sites_fix():
                 "2025-12-31",
             ],
             ofc.EMIS_DATA_COL_ACCESSORS.M_RATE: [0, 3, 0, 0, 0, 0],
-            ofc.EMIS_DATA_COL_ACCESSORS.EST_VOL_EMIT: [0, 1551, 0, 0, 0, 0],
+            ofc.EMIS_DATA_COL_ACCESSORS.EST_VOL_EMIT: [0, 1554, 0, 0, 0, 0],
             ofc.EMIS_DATA_COL_ACCESSORS.SITE_MEASURED: [True, True, True, True, False, False],
             ofc.EMIS_DATA_COL_ACCESSORS.SITE_TYPE: ["A", "A", "A", "A", "A", "A"],
         }
@@ -66,7 +66,7 @@ def mock_est_emis_data_1_subtype_few_sites_fix():
 @pytest.fixture(name="mock_est_emis_data_1_subtype_few_sites_expected_results")
 def mock_est_emis_data_1_subtype_few_sites_expected_results_fix():
     return {
-        2024: 2190,
+        2024: 2196,
         2025: 912,
     }
 
@@ -127,15 +127,15 @@ def mock_est_emis_data_1_subtype_multiple_sites_fix():
             ofc.EMIS_DATA_COL_ACCESSORS.M_RATE: [0, 3, 0, 0, 0, 0, 4, 0, 0, 2, 0, 0, 0, 0],
             ofc.EMIS_DATA_COL_ACCESSORS.EST_VOL_EMIT: [
                 0,
-                1551,  # Emitting 1095 year 1 and 456 year 2
+                1554,  # Emitting 1098 year 1 and 456 year 2
                 0,
                 0,
                 0,
                 0,
-                2680,  # Emitting 1220 year 1 and 1460 year 2
+                2684,  # Emitting 1224 year 1 and 1460 year 2
                 0,
                 0,
-                1156,  # Emitting 730 year 1 and 426 year 2
+                1158,  # Emitting 732 year 1 and 426 year 2
                 0,
                 0,
                 0,
@@ -180,10 +180,10 @@ def mock_est_emis_data_1_subtype_multiple_sites_fix():
 @pytest.fixture(name="mock_est_emis_data_1_subtype_multiple_sites_expected_results")
 def mock_est_emis_data_1_subtype_multiple_sites_expected_results_fix():
     return {
-        # 4(1095 + 1220 + 730)/3 = 4060
-        2024: 4060,
+        # 4(1098 + 1224 + 732)/3 = 4072
+        2024: 4072,
         # 4(456 + 1460 + 426)/3 = 3122.7
-        2025: 3122.7,
+        2025: 3122.6666667,
     }
 
 
@@ -373,35 +373,35 @@ def mock_est_emis_data_3_subtypes_multiple_sites_fix():
             ],
             ofc.EMIS_DATA_COL_ACCESSORS.EST_VOL_EMIT: [
                 0,
-                1551,  # Emitting 1095 year 1 and 456 year 2
+                1554,  # Emitting 1098 year 1 and 456 year 2
                 0,
                 0,
                 0,
                 0,
-                2680,  # Emitting 1220 year 1 and 1460 year 2
+                2684,  # Emitting 1224 year 1 and 1460 year 2
                 0,
                 0,
-                1156,  # Emitting 730 year 1 and 426 year 2
-                0,
-                0,
-                0,
-                0,
-                0,
-                0,
-                2680,  # Emitting 1220 year 1 and 1460 year 2
-                0,
-                0,
-                1156,  # Emitting 730 year 1 and 426 year 2
+                1158,  # Emitting 732 year 1 and 426 year 2
                 0,
                 0,
                 0,
                 0,
                 0,
                 0,
-                2680,  # Emitting 1220 year 1 and 1460 year 2
+                2684,  # Emitting 1224 year 1 and 1460 year 2
                 0,
                 0,
-                1734,  # Emitting 1095 year 1 and 639 year 2
+                1158,  # Emitting 732 year 1 and 426 year 2
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                2684,  # Emitting 1224 year 1 and 1460 year 2
+                0,
+                0,
+                1737,  # Emitting 1098 year 1 and 639 year 2
                 0,
                 0,
                 0,
@@ -486,10 +486,10 @@ def mock_est_emis_data_3_subtypes_multiple_sites_fix():
 @pytest.fixture(name="mock_est_emis_data_3_subtypes_multiple_sites_expected_results")
 def mock_est_emis_data_3_subtypes_multiple_sites_expected_results_fix():
     return {
-        # 4(1095 + 1220 + 730)/3 + 3(1220 + 730)/2 + 3(1220 + 1095)/2 = 10457.5
-        2024: 10457.5,
+        # 4(1098 + 1224 + 732)/3 + 3(1224 + 732)/2 + 3(1224 + 1098)/2 = 10457.5
+        2024: 10489,
         # 4(456 + 1460 + 426)/3 + 3(1460 + 426)/2 + 3(1460 + 639)/2 = 9100.166666667
-        2025: 9100.17,
+        2025: 9100.166666667,
     }
 
 
@@ -546,4 +546,4 @@ def test_get_annual_emissions_at_all_sites_with_extrapolation_returns_expected(
     )
 
     # Check if the result matches the expected output
-    assert annual_emis_data == pytest.approx(mock_est_emis_data_expected_results[year], 1e-1)
+    assert annual_emis_data == pytest.approx(mock_est_emis_data_expected_results[year], 1e-5)

--- a/LDAR_Sim/testing/unit_testing/test_file_processing/test_output_processing/test_summary_output_helpers/test_get_annual_emissions_at_all_sites_with_extrapolation.py
+++ b/LDAR_Sim/testing/unit_testing/test_file_processing/test_output_processing/test_summary_output_helpers/test_get_annual_emissions_at_all_sites_with_extrapolation.py
@@ -1,0 +1,549 @@
+"""
+------------------------------------------------------------------------------
+Program:     The LDAR Simulator (LDAR-Sim)
+File:        test_get_annual_emissions_at_all_sites_with_extrapolation.py
+Purpose: Unit testing the get_annual_emissions_at_all_sites_with_extrapolation method.
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the MIT License as published
+by the Free Software Foundation, version 3.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+MIT License for more details.
+You should have received a copy of the MIT License
+along with this program.  If not, see <https://opensource.org/licenses/MIT>.
+
+------------------------------------------------------------------------------
+"""
+
+import pandas as pd
+import pytest
+from constants import output_file_constants as ofc
+from file_processing.output_processing.summary_output_helpers import (
+    get_annual_emissions_at_all_sites_with_extrapolation,
+)
+
+
+@pytest.fixture(name="mock_est_emis_data_1_subtype_few_sites")
+def mock_est_emis_data_1_subtype_few_sites_fix():
+    return pd.DataFrame(
+        {
+            ofc.EMIS_DATA_COL_ACCESSORS.SITE_ID: [1, 1, 1, 1, 2, 2],
+            ofc.EMIS_DATA_COL_ACCESSORS.SURVEY_COMPLETION_DATE: [
+                "2024-01-01",
+                "2024-06-01",
+                "2025-06-01",
+                "2025-12-31",
+                "2024-01-01",
+                "2025-12-31",
+            ],
+            ofc.EMIS_DATA_COL_ACCESSORS.START_DATE: [
+                "2024-01-01",
+                "2024-01-01",
+                "2025-06-01",
+                "2025-12-31",
+                "2024-01-01",
+                "2025-12-31",
+            ],
+            ofc.EMIS_DATA_COL_ACCESSORS.END_DATE: [
+                "2024-01-01",
+                "2025-06-01",
+                "2025-12-31",
+                "2025-12-31",
+                "2025-12-31",
+                "2025-12-31",
+            ],
+            ofc.EMIS_DATA_COL_ACCESSORS.M_RATE: [0, 3, 0, 0, 0, 0],
+            ofc.EMIS_DATA_COL_ACCESSORS.EST_VOL_EMIT: [0, 1551, 0, 0, 0, 0],
+            ofc.EMIS_DATA_COL_ACCESSORS.SITE_MEASURED: [True, True, True, True, False, False],
+            ofc.EMIS_DATA_COL_ACCESSORS.SITE_TYPE: ["A", "A", "A", "A", "A", "A"],
+        }
+    )
+
+
+@pytest.fixture(name="mock_est_emis_data_1_subtype_few_sites_expected_results")
+def mock_est_emis_data_1_subtype_few_sites_expected_results_fix():
+    return {
+        2024: 2190,
+        2025: 912,
+    }
+
+
+@pytest.fixture(name="mock_est_emis_data_1_subtype_multiple_sites")
+def mock_est_emis_data_1_subtype_multiple_sites_fix():
+    return pd.DataFrame(
+        {
+            ofc.EMIS_DATA_COL_ACCESSORS.SITE_ID: [1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3, 4, 4],
+            ofc.EMIS_DATA_COL_ACCESSORS.SURVEY_COMPLETION_DATE: [
+                "2024-01-01",
+                "2024-06-01",
+                "2025-06-01",
+                "2025-12-31",
+                "2024-01-01",
+                "2024-03-01",
+                "2025-04-01",
+                "2025-12-31",
+                "2024-01-01",
+                "2024-07-01",
+                "2025-08-01",
+                "2025-12-31",
+                "2024-01-01",
+                "2025-12-31",
+            ],
+            ofc.EMIS_DATA_COL_ACCESSORS.START_DATE: [
+                "2024-01-01",
+                "2024-01-01",
+                "2025-06-01",
+                "2025-12-31",
+                "2024-01-01",
+                "2024-03-01",
+                "2024-03-01",
+                "2025-12-31",
+                "2024-01-01",
+                "2024-01-01",
+                "2025-08-01",
+                "2025-12-31",
+                "2024-01-01",
+                "2025-12-31",
+            ],
+            ofc.EMIS_DATA_COL_ACCESSORS.END_DATE: [
+                "2024-01-01",
+                "2025-06-01",
+                "2025-12-31",
+                "2025-12-31",
+                "2024-03-01",
+                "2024-03-01",
+                "2025-12-31",
+                "2025-12-31",
+                "2024-01-01",
+                "2025-08-01",
+                "2025-12-31",
+                "2025-12-31",
+                "2025-12-31",
+                "2025-12-31",
+            ],
+            ofc.EMIS_DATA_COL_ACCESSORS.M_RATE: [0, 3, 0, 0, 0, 0, 4, 0, 0, 2, 0, 0, 0, 0],
+            ofc.EMIS_DATA_COL_ACCESSORS.EST_VOL_EMIT: [
+                0,
+                1551,  # Emitting 1095 year 1 and 456 year 2
+                0,
+                0,
+                0,
+                0,
+                2680,  # Emitting 1220 year 1 and 1460 year 2
+                0,
+                0,
+                1156,  # Emitting 730 year 1 and 426 year 2
+                0,
+                0,
+                0,
+                0,
+            ],
+            ofc.EMIS_DATA_COL_ACCESSORS.SITE_MEASURED: [
+                True,
+                True,
+                True,
+                True,
+                True,
+                True,
+                True,
+                True,
+                True,
+                True,
+                True,
+                True,
+                False,
+                False,
+            ],
+            ofc.EMIS_DATA_COL_ACCESSORS.SITE_TYPE: [
+                "A",
+                "A",
+                "A",
+                "A",
+                "A",
+                "A",
+                "A",
+                "A",
+                "A",
+                "A",
+                "A",
+                "A",
+                "A",
+                "A",
+            ],
+        }
+    )
+
+
+@pytest.fixture(name="mock_est_emis_data_1_subtype_multiple_sites_expected_results")
+def mock_est_emis_data_1_subtype_multiple_sites_expected_results_fix():
+    return {
+        # 4(1095 + 1220 + 730)/3 = 4060
+        2024: 4060,
+        # 4(456 + 1460 + 426)/3 = 3122.7
+        2025: 3122.7,
+    }
+
+
+@pytest.fixture(name="mock_est_emis_data_3_subtypes_multiple_sites")
+def mock_est_emis_data_3_subtypes_multiple_sites_fix():
+    return pd.DataFrame(
+        {
+            ofc.EMIS_DATA_COL_ACCESSORS.SITE_ID: [
+                1,
+                1,
+                1,
+                1,
+                2,
+                2,
+                2,
+                2,
+                3,
+                3,
+                3,
+                3,
+                4,
+                4,
+                5,
+                5,
+                5,
+                5,
+                6,
+                6,
+                6,
+                6,
+                7,
+                7,
+                8,
+                8,
+                8,
+                8,
+                9,
+                9,
+                9,
+                9,
+                10,
+                10,
+            ],
+            ofc.EMIS_DATA_COL_ACCESSORS.SURVEY_COMPLETION_DATE: [
+                "2024-01-01",
+                "2024-06-01",
+                "2025-06-01",
+                "2025-12-31",
+                "2024-01-01",
+                "2024-03-01",
+                "2025-04-01",
+                "2025-12-31",
+                "2024-01-01",
+                "2024-07-01",
+                "2025-08-01",
+                "2025-12-31",
+                "2024-01-01",
+                "2025-12-31",
+                "2024-01-01",
+                "2024-03-01",
+                "2025-04-01",
+                "2025-12-31",
+                "2024-01-01",
+                "2024-07-01",
+                "2025-08-01",
+                "2025-12-31",
+                "2024-01-01",
+                "2025-12-31",
+                "2024-01-01",
+                "2024-03-01",
+                "2025-04-01",
+                "2025-12-31",
+                "2024-01-01",
+                "2024-07-01",
+                "2025-08-01",
+                "2025-12-31",
+                "2024-01-01",
+                "2025-12-31",
+            ],
+            ofc.EMIS_DATA_COL_ACCESSORS.START_DATE: [
+                "2024-01-01",
+                "2024-01-01",
+                "2025-06-01",
+                "2025-12-31",
+                "2024-01-01",
+                "2024-03-01",
+                "2024-03-01",
+                "2025-12-31",
+                "2024-01-01",
+                "2024-01-01",
+                "2025-08-01",
+                "2025-12-31",
+                "2024-01-01",
+                "2025-12-31",
+                "2024-01-01",
+                "2024-03-01",
+                "2024-03-01",
+                "2025-12-31",
+                "2024-01-01",
+                "2024-01-01",
+                "2025-08-01",
+                "2025-12-31",
+                "2024-01-01",
+                "2025-12-31",
+                "2024-01-01",
+                "2024-03-01",
+                "2024-03-01",
+                "2025-12-31",
+                "2024-01-01",
+                "2024-01-01",
+                "2025-08-01",
+                "2025-12-31",
+                "2024-01-01",
+                "2025-12-31",
+            ],
+            ofc.EMIS_DATA_COL_ACCESSORS.END_DATE: [
+                "2024-01-01",
+                "2025-06-01",
+                "2025-12-31",
+                "2025-12-31",
+                "2024-03-01",
+                "2024-03-01",
+                "2025-12-31",
+                "2025-12-31",
+                "2024-01-01",
+                "2025-08-01",
+                "2025-12-31",
+                "2025-12-31",
+                "2025-12-31",
+                "2025-12-31",
+                "2024-03-01",
+                "2024-03-01",
+                "2025-12-31",
+                "2025-12-31",
+                "2024-01-01",
+                "2025-08-01",
+                "2025-12-31",
+                "2025-12-31",
+                "2025-12-31",
+                "2025-12-31",
+                "2024-03-01",
+                "2024-03-01",
+                "2025-12-31",
+                "2025-12-31",
+                "2024-01-01",
+                "2025-08-01",
+                "2025-12-31",
+                "2025-12-31",
+                "2025-12-31",
+                "2025-12-31",
+            ],
+            ofc.EMIS_DATA_COL_ACCESSORS.M_RATE: [
+                0,
+                3,
+                0,
+                0,
+                0,
+                0,
+                4,
+                0,
+                0,
+                2,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                4,
+                0,
+                0,
+                2,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                4,
+                0,
+                0,
+                3,
+                0,
+                0,
+                0,
+                0,
+            ],
+            ofc.EMIS_DATA_COL_ACCESSORS.EST_VOL_EMIT: [
+                0,
+                1551,  # Emitting 1095 year 1 and 456 year 2
+                0,
+                0,
+                0,
+                0,
+                2680,  # Emitting 1220 year 1 and 1460 year 2
+                0,
+                0,
+                1156,  # Emitting 730 year 1 and 426 year 2
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                2680,  # Emitting 1220 year 1 and 1460 year 2
+                0,
+                0,
+                1156,  # Emitting 730 year 1 and 426 year 2
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                2680,  # Emitting 1220 year 1 and 1460 year 2
+                0,
+                0,
+                1734,  # Emitting 1095 year 1 and 639 year 2
+                0,
+                0,
+                0,
+                0,
+            ],
+            ofc.EMIS_DATA_COL_ACCESSORS.SITE_MEASURED: [
+                True,
+                True,
+                True,
+                True,
+                True,
+                True,
+                True,
+                True,
+                True,
+                True,
+                True,
+                True,
+                False,
+                False,
+                True,
+                True,
+                True,
+                True,
+                True,
+                True,
+                True,
+                True,
+                False,
+                False,
+                True,
+                True,
+                True,
+                True,
+                True,
+                True,
+                True,
+                True,
+                False,
+                False,
+            ],
+            ofc.EMIS_DATA_COL_ACCESSORS.SITE_TYPE: [
+                "A",
+                "A",
+                "A",
+                "A",
+                "A",
+                "A",
+                "A",
+                "A",
+                "A",
+                "A",
+                "A",
+                "A",
+                "A",
+                "A",
+                "B",
+                "B",
+                "B",
+                "B",
+                "B",
+                "B",
+                "B",
+                "B",
+                "B",
+                "B",
+                "C",
+                "C",
+                "C",
+                "C",
+                "C",
+                "C",
+                "C",
+                "C",
+                "C",
+                "C",
+            ],
+        }
+    )
+
+
+@pytest.fixture(name="mock_est_emis_data_3_subtypes_multiple_sites_expected_results")
+def mock_est_emis_data_3_subtypes_multiple_sites_expected_results_fix():
+    return {
+        # 4(1095 + 1220 + 730)/3 + 3(1220 + 730)/2 + 3(1220 + 1095)/2 = 10457.5
+        2024: 10457.5,
+        # 4(456 + 1460 + 426)/3 + 3(1460 + 426)/2 + 3(1460 + 639)/2 = 9100.166666667
+        2025: 9100.17,
+    }
+
+
+@pytest.mark.parametrize(
+    "mock_est_emis_data_name, mock_est_emis_data_expected_results_name, year",
+    [
+        (
+            "mock_est_emis_data_1_subtype_few_sites",
+            "mock_est_emis_data_1_subtype_few_sites_expected_results",
+            2024,
+        ),
+        (
+            "mock_est_emis_data_1_subtype_few_sites",
+            "mock_est_emis_data_1_subtype_few_sites_expected_results",
+            2025,
+        ),
+        (
+            "mock_est_emis_data_1_subtype_multiple_sites",
+            "mock_est_emis_data_1_subtype_multiple_sites_expected_results",
+            2024,
+        ),
+        (
+            "mock_est_emis_data_1_subtype_multiple_sites",
+            "mock_est_emis_data_1_subtype_multiple_sites_expected_results",
+            2025,
+        ),
+        (
+            "mock_est_emis_data_3_subtypes_multiple_sites",
+            "mock_est_emis_data_3_subtypes_multiple_sites_expected_results",
+            2024,
+        ),
+        (
+            "mock_est_emis_data_3_subtypes_multiple_sites",
+            "mock_est_emis_data_3_subtypes_multiple_sites_expected_results",
+            2025,
+        ),
+    ],
+)
+def test_get_annual_emissions_at_all_sites_with_extrapolation_returns_expected(
+    request: pytest.FixtureRequest,
+    mock_est_emis_data_name: str,
+    mock_est_emis_data_expected_results_name: str,
+    year: str,
+):
+    # Get the fixture values
+    mock_est_emis_data: pd.DataFrame = request.getfixturevalue(mock_est_emis_data_name)
+    mock_est_emis_data_expected_results: dict = request.getfixturevalue(
+        mock_est_emis_data_expected_results_name
+    )
+
+    # Compute the result
+    annual_emis_data: float = get_annual_emissions_at_all_sites_with_extrapolation(
+        mock_est_emis_data, year
+    )
+
+    # Check if the result matches the expected output
+    assert annual_emis_data == pytest.approx(mock_est_emis_data_expected_results[year], 1e-1)

--- a/LDAR_Sim/testing/unit_testing/test_file_processing/test_output_processing/test_summary_outputs/test_gen_emissions_estimate_summary.py
+++ b/LDAR_Sim/testing/unit_testing/test_file_processing/test_output_processing/test_summary_outputs/test_gen_emissions_estimate_summary.py
@@ -65,6 +65,9 @@ def mock_scandir_emis_sum(dir: Path):
 mock_emis_csv_data = {
     "test_0_estimated_emissions.csv": pd.DataFrame(
         {
+            eca.SITE_ID: [1, 1, 1, 1],
+            eca.SITE_TYPE: ["A", "A", "A", "A"],
+            eca.SITE_MEASURED: [True, True, True, True],
             eca.EST_VOL_EMIT: [0, 1, 2, 3],
             eca.M_RATE: [9, 8, 7, 6],
             eca.REPAIRABLE: [True, True, True, False],
@@ -74,6 +77,9 @@ mock_emis_csv_data = {
     ),
     "test_1_estimated_emissions.csv": pd.DataFrame(
         {
+            eca.SITE_ID: [1, 1, 1, 1],
+            eca.SITE_TYPE: ["A", "A", "A", "A"],
+            eca.SITE_MEASURED: [True, True, True, True],
             eca.EST_VOL_EMIT: [4, 5, 6, 7],
             eca.M_RATE: [5, 4, 3, 2],
             eca.START_DATE: ["2024-01-01", "2024-01-01", "2025-01-01", "2025-01-01"],
@@ -82,6 +88,9 @@ mock_emis_csv_data = {
     ),
     "test_2_estimated_emissions.csv": pd.DataFrame(
         {
+            eca.SITE_ID: [1, 1, 1, 1],
+            eca.SITE_TYPE: ["A", "A", "A", "A"],
+            eca.SITE_MEASURED: [True, True, True, True],
             eca.EST_VOL_EMIT: [8, 9, 10, 11],
             eca.M_RATE: [2, 1, 0, 0],
             eca.START_DATE: ["2024-01-01", "2024-01-01", "2025-01-01", "2025-01-01"],

--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -1874,7 +1874,7 @@ This parameter can also be set in the following file:
 
 - [Site type file](#method_site_deployment-site-type-file)
 
-_TODO_ update description more when the scale up feature is implemented.
+**Note:** If site deployment is set to False for a site/site(s) in the sites file for all non follow-up methods that make up a program, that site will functionally not be measured by the program. In this case, estimated emissions are then computed using the annual average of all estimated emissions from all measured sites of the same type or if that is not possible, the annual average of all measured sites.
 
 --------------------------------------------------------------------------------
 

--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -842,7 +842,7 @@ method_labels: ["aircraft","OGI_FU"]
 
 **Notes of caution:** Using a GWP of CH4 for a 20-year time period may dramatically change results but all options should be explored.
 
-#### &lt;sale_price_of_natural_gas&gt; 
+#### &lt;sale_price_of_natural_gas&gt;
 
 **Data Type:** Numeric
 
@@ -1874,7 +1874,7 @@ This parameter can also be set in the following file:
 
 - [Site type file](#method_site_deployment-site-type-file)
 
-**Note:** If site deployment is set to False for a site/site(s) in the sites file for all non follow-up methods that make up a program, that site will functionally not be measured by the program. In this case, estimated emissions are then computed using the annual average of all estimated emissions from all measured sites of the same type or if that is not possible, the annual average of all measured sites.
+**Note:** If site deployment is set to False for a site/site(s) in the sites file for all non-follow-up methods that make up a program, that site will be functionally not measured by the program. In this case, estimated emissions are computed using the annual average of all estimated emissions from all measured sites of the same type or, if not possible, the annual average of all measured sites.
 
 --------------------------------------------------------------------------------
 
@@ -2112,6 +2112,8 @@ This parameter can also be set in the following files:
 This parameter can also be set in the following file:
 
 - [Sites file](#method_site_deployment-sites-file)
+
+**Note:** If site_type deployment is set to False for a site_type in the sites file for all non-follow-up methods that make up a program, that site_type will be functionally not measured by the program. In this case, estimated emissions are computed using the annual average of all estimated emissions from all measured sites.
 
 --------------------------------------------------------------------------------
 


### PR DESCRIPTION
# Pull Request Key Information

## Reason for change

LDAR-Sim v4 should be able to model uncertainty resulting from extrapolating emissions from a sample of sites to all sites in the infrastructure.

## What was changed

This change adds the ability to extrapolate
emissions at sites that are not measured in the sample using the emissions data from sites with the same site type that are measured.

## Intended Purpose

Uncertainty in emissions estimates will be improved for programs measuring only a subset of sites in the total infrastructure.

## Level of version change required

N/A

## Testing Completed

All unit tests pass: 
[unit_test_results.txt](https://github.com/user-attachments/files/15861066/unit_test_results.txt)


Manually ran tested a modified simple simulation 1: with a custom facilities file - Ran 1 simulation with 50% OGI deployment and one with full OGI deployment and ensured that results were different. 
[Measurement Extrapolation Testing.zip](https://github.com/user-attachments/files/15860993/Measurement.Extrapolation.Testing.zip)


## Target Issue

N/A

## Additional Information

N/A
