### PR TITLE
V4 deploy true/false table

### DIFF
--- a/LDAR_Sim/src/constants/infrastructure_const.py
+++ b/LDAR_Sim/src/constants/infrastructure_const.py
@@ -193,7 +193,8 @@ class Deployment_TF_Sites_Constants:
     SITE_DEPLOYMENT: str = (
         "{method}" + Infrastructure_Constants.Sites_File_Constants.SITE_DEPLOYMENT_PLACEHOLDER
     )
-    SITE_MEASURED: str = "{method}_measured"
+    METHOD_MEASURED: str = "{method}_measured"
+    MEASURED: str = "Measured"
 
 
 class Virtual_World_To_Prop_Params_Mapping:

--- a/LDAR_Sim/src/constants/infrastructure_const.py
+++ b/LDAR_Sim/src/constants/infrastructure_const.py
@@ -184,6 +184,18 @@ class Infrastructure_Constants:
         ]
 
 
+class Deployment_TF_Sites_Constants:
+    SITE_ID = Infrastructure_Constants.Sites_File_Constants.ID
+    SITE_TYPE = Infrastructure_Constants.Sites_File_Constants.TYPE
+    REQUIRED_SURVEY: str = (
+        "{method}" + Infrastructure_Constants.Sites_File_Constants.SURVEY_FREQUENCY_PLACEHOLDER
+    )
+    SITE_DEPLOYMENT: str = (
+        "{method}" + Infrastructure_Constants.Sites_File_Constants.SITE_DEPLOYMENT_PLACEHOLDER
+    )
+    SITE_MEASURED: str = "{method}_measured"
+
+
 class Virtual_World_To_Prop_Params_Mapping:
     PROPAGATING_PARAMS: dict[str, str] = {
         Infrastructure_Constants.Sites_File_Constants.REP_EMIS_ERS: ".".join(

--- a/LDAR_Sim/src/file_processing/output_processing/program_output_manager.py
+++ b/LDAR_Sim/src/file_processing/output_processing/program_output_manager.py
@@ -41,6 +41,7 @@ from constants.output_file_constants import (
     EMIS_INFO_COLUMNS_TO_KEEP_FOR_DURATION_ESTIMATION,
 )
 from programs.program import Program
+from constants.infrastructure_const import Deployment_TF_Sites_Constants as DTSC
 from constants.param_default_const import Duration_Method as dm
 import file_processing.output_processing.program_output as prog_output
 
@@ -63,6 +64,7 @@ class ProgramOutputManager:
         start_date: date,
         end_date: date,
         program: Program,
+        measured_tf_df: pd.DataFrame,
     ) -> None:
         self.gen_sim_directory()
         summary_filename = self.generate_file_names(Output_Files.EMISSIONS_SUMMARY_FILE)
@@ -91,7 +93,13 @@ class ProgramOutputManager:
                 emis_file_name = self.generate_file_names(Output_Files.EST_EMISSIONS_FILE)
                 fug_file_name = self.generate_file_names(Output_Files.EST_REP_EMISSIONS_FILE)
 
-                emis_estimation.to_csv(self._output_dir / emis_file_name, index=False)
+                measured_tf_df = measured_tf_df.rename(columns={DTSC.SITE_ID: eca.SITE_ID})
+
+                emis_estimation_merged = pd.merge(
+                    emis_estimation, measured_tf_df, on=eca.SITE_ID, how="left"
+                )
+
+                emis_estimation_merged.to_csv(self._output_dir / emis_file_name, index=False)
                 fug_to_remove.to_csv(self._output_dir / fug_file_name, index=False)
         else:
             raise KeyError(f"No function found for program: {program}")

--- a/LDAR_Sim/src/initialization/initialize_infrastructure.py
+++ b/LDAR_Sim/src/initialization/initialize_infrastructure.py
@@ -35,7 +35,15 @@ def hash_dict(in_dict) -> str:
 
 
 def initialize_infrastructure(
-    methods, programs, virtual_world, generator_dir, in_dir, preseed, preseed_val, force_remake
+    methods,
+    programs,
+    virtual_world,
+    generator_dir,
+    in_dir,
+    preseed,
+    preseed_val,
+    force_remake,
+    site_measured_df,
 ) -> Infrastructure:
 
     if not os.path.exists(generator_dir):
@@ -90,7 +98,10 @@ def initialize_infrastructure(
             np.random.seed(preseed_val[0])
 
         infrastructure: Infrastructure = Infrastructure(
-            virtual_world=virtual_world, methods=methods, in_dir=in_dir
+            virtual_world=virtual_world,
+            methods=methods,
+            in_dir=in_dir,
+            site_measured_df=site_measured_df,
         )
 
         # Save the generated Infrastructure and the input file hashes and the virtual world hash.
@@ -148,7 +159,10 @@ def initialize_infrastructure(
                 np.random.seed(preseed_val[0])
 
             infrastructure: Infrastructure = Infrastructure(
-                virtual_world=virtual_world, methods=methods, in_dir=in_dir
+                virtual_world=virtual_world,
+                methods=methods,
+                in_dir=in_dir,
+                site_measured_df=site_measured_df,
             )
             # Save the generated Infrastructure,
             # the input file hashes and the virtual world hash.

--- a/LDAR_Sim/src/initialization/initialize_infrastructure.py
+++ b/LDAR_Sim/src/initialization/initialize_infrastructure.py
@@ -43,7 +43,6 @@ def initialize_infrastructure(
     preseed,
     preseed_val,
     force_remake,
-    site_measured_df,
 ) -> Infrastructure:
 
     if not os.path.exists(generator_dir):
@@ -101,7 +100,6 @@ def initialize_infrastructure(
             virtual_world=virtual_world,
             methods=methods,
             in_dir=in_dir,
-            site_measured_df=site_measured_df,
         )
 
         # Save the generated Infrastructure and the input file hashes and the virtual world hash.
@@ -162,7 +160,6 @@ def initialize_infrastructure(
                 virtual_world=virtual_world,
                 methods=methods,
                 in_dir=in_dir,
-                site_measured_df=site_measured_df,
             )
             # Save the generated Infrastructure,
             # the input file hashes and the virtual world hash.

--- a/LDAR_Sim/src/ldar_sim.py
+++ b/LDAR_Sim/src/ldar_sim.py
@@ -53,6 +53,7 @@ class LdarSim:
         input_dir: WindowsPath,
         output_dir: WindowsPath,
         preseed_timeseries,
+        prog_measured_df,
     ):
         """
         Construct the simulation.
@@ -67,7 +68,7 @@ class LdarSim:
         self._program: Program = program
 
         self._input_dir: WindowsPath = input_dir
-
+        self._measured_tf_df = prog_measured_df
         self.name_str: str = self.SIMULATION_NAME_STR.format(
             program=program.name, sim_number=sim_number
         )
@@ -122,4 +123,5 @@ class LdarSim:
             self._tc._start_date,
             self._tc._end_date,
             self._program,
+            self._measured_tf_df,
         )

--- a/LDAR_Sim/src/utils/prog_method_measured_func.py
+++ b/LDAR_Sim/src/utils/prog_method_measured_func.py
@@ -1,0 +1,64 @@
+"""
+------------------------------------------------------------------------------
+Program:     The LDAR Simulator (LDAR-Sim)
+File:        prog_method_measured_func.py
+Purpose: To contain functions to produce program-method measured true/false 
+data frames
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the MIT License as published
+by the Free Software Foundation, version 3.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+MIT License for more details.
+You should have received a copy of the MIT License
+along with this program.  If not, see <https://opensource.org/licenses/MIT>.
+
+------------------------------------------------------------------------------
+"""
+
+import pandas as pd
+from constants.infrastructure_const import Deployment_TF_Sites_Constants as DTSC
+
+
+def set_up_tf_method_deployed_df(methods: dict[str, dict], site_count) -> pd.DataFrame:
+    """
+    Input:
+    methods: dict[str, dict] - dictionary of methods and their parameters
+    site_count: int - number of sites in the virtual world
+
+    Returns:
+    pd.DataFrame - a null filled dataframe with the columns for the true/false site list
+    """
+    column_names = [DTSC.SITE_ID, DTSC.SITE_TYPE] + [
+        item
+        for method in methods.keys()
+        for item in [
+            DTSC.REQUIRED_SURVEY.format(method=method),
+            DTSC.SITE_DEPLOYMENT.format(method=method),
+            DTSC.METHOD_MEASURED.format(method=method),
+        ]
+    ]
+
+    return pd.DataFrame(index=range(site_count), columns=column_names)
+
+
+def filter_deployment_tf_by_program_methods(
+    tf_df_ori: pd.DataFrame, methods: list[str]
+) -> pd.DataFrame:
+    """
+    Input:
+    tf_df_ori: pd.DataFrame - the original true/false site list dataframe
+    methods: list[str] - list of methods to filter the dataframe
+
+    Returns:
+    pd.DataFrame - a filtered dataframe with the columns for the true/false
+    """
+    formatted_method_columns = [DTSC.METHOD_MEASURED.format(method=method) for method in methods]
+    columns = [DTSC.SITE_ID, DTSC.SITE_TYPE] + formatted_method_columns
+    filtered_df = tf_df_ori[columns].copy()
+    filtered_df[DTSC.MEASURED] = filtered_df[formatted_method_columns].any(axis=1)
+
+    return filtered_df[[DTSC.SITE_ID, DTSC.SITE_TYPE, DTSC.MEASURED]]

--- a/LDAR_Sim/src/virtual_world/infrastructure.py
+++ b/LDAR_Sim/src/virtual_world/infrastructure.py
@@ -262,6 +262,7 @@ class Infrastructure:
                 infrastructure_inputs=infrastructure_inputs,
                 start_date=date(*virtual_world[pdc.Virtual_World_Params.START_DATE]),
                 methods=methods,
+                site_type=srow[IC.Sites_File_Constants.TYPE],
             )
 
             sites.append(new_site)

--- a/LDAR_Sim/src/virtual_world/infrastructure.py
+++ b/LDAR_Sim/src/virtual_world/infrastructure.py
@@ -50,7 +50,7 @@ from weather.weather_lookup import WeatherLookup as WL
 
 class Infrastructure:
 
-    def __init__(self, virtual_world, methods, in_dir, site_measured_df) -> None:
+    def __init__(self, virtual_world, methods, in_dir) -> None:
         self.emission_rate_source_dictionary: dict[str, EmissionsSource] = process_emission_sources(
             inputs_path=in_dir, virtual_world=virtual_world
         )
@@ -62,10 +62,6 @@ class Infrastructure:
             virtual_world=virtual_world,
             methods=methods,
             in_dir=in_dir,
-        )
-        self.gen_site_measured_tf_data(
-            methods,
-            site_measured_df,
         )
 
     def __reduce__(self):
@@ -289,6 +285,9 @@ class Infrastructure:
             for method in methods:
                 # If the method is a follow-up method, we do not know if it will ever be triggered
                 # therefore  we set it to False
+                # Follow-up methods will always  be called with another method, and because of this
+                # setting it false is fine, the other method will ensure that the site measured
+                # value is set to true
                 if methods[method][pdc.Method_Params.IS_FOLLOW_UP]:
                     surveyed = False
                     deployed = False

--- a/LDAR_Sim/src/virtual_world/sites.py
+++ b/LDAR_Sim/src/virtual_world/sites.py
@@ -340,6 +340,9 @@ class Site:
     def get_id(self) -> str:
         return self._site_ID
 
+    def get_type(self) -> str:
+        return self._site_type
+
     def get_loc(self) -> tuple[float, float]:
         return self._lat, self._long
 

--- a/LDAR_Sim/testing/unit_testing/test_virtual_world/test_infrastructure/test_filter_df_by_relevant_method.py
+++ b/LDAR_Sim/testing/unit_testing/test_virtual_world/test_infrastructure/test_filter_df_by_relevant_method.py
@@ -1,0 +1,88 @@
+"""
+------------------------------------------------------------------------------
+Program:     The LDAR Simulator (LDAR-Sim)
+File:        test_filter_df_by_relevant_method.py
+Purpose: Contains unit tests related to filtering the true/false deployment data
+frame for the relevant program, based on the provided method.
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the MIT License as published
+by the Free Software Foundation, version 3.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+MIT License for more details.
+You should have received a copy of the MIT License
+along with this program.  If not, see <https://opensource.org/licenses/MIT>.
+
+------------------------------------------------------------------------------
+"""
+
+import pandas as pd
+import pytest
+from src.ldar_sim_run import filter_df_by_relevant_method
+from src.constants.infrastructure_const import Deployment_TF_Sites_Constants as DTSC
+
+
+def simple_fixture():
+    data_ori = {
+        DTSC.SITE_ID: [1, 2, 3, 4, 5],
+        DTSC.SITE_TYPE: ["A", "A", "A", "A", "A"],
+        DTSC.REQUIRED_SURVEY.format(method="A"): [True, True, True, True, True],
+        DTSC.SITE_DEPLOYMENT.format(method="A"): [False, True, False, True, False],
+        DTSC.METHOD_MEASURED.format(method="A"): [False, True, False, True, False],
+        DTSC.REQUIRED_SURVEY.format(method="B"): [True, True, True, True, True],
+        DTSC.SITE_DEPLOYMENT.format(method="B"): [False, True, False, True, False],
+        DTSC.METHOD_MEASURED.format(method="B"): [False, True, False, True, False],
+        DTSC.REQUIRED_SURVEY.format(method="C"): [True, True, True, True, True],
+        DTSC.SITE_DEPLOYMENT.format(method="C"): [False, True, False, True, False],
+        DTSC.METHOD_MEASURED.format(method="C"): [False, True, False, True, False],
+        DTSC.REQUIRED_SURVEY.format(method="D"): [True, True, True, True, True],
+        DTSC.SITE_DEPLOYMENT.format(method="D"): [False, True, False, True, False],
+        DTSC.METHOD_MEASURED.format(method="D"): [False, True, False, True, False],
+    }
+    prog_method = ["A", "B"]
+    data_filtered_result = {
+        DTSC.SITE_ID: [1, 2, 3, 4, 5],
+        DTSC.SITE_TYPE: ["A", "A", "A", "A", "A"],
+        DTSC.MEASURED: [False, True, False, True, False],
+    }
+    return (pd.DataFrame(data_ori), prog_method, pd.DataFrame(data_filtered_result))
+
+
+def complex_fixture():
+    data_ori = {
+        DTSC.SITE_ID: [1, 2, 3, 4, 5],
+        DTSC.SITE_TYPE: ["A", "A", "A", "A", "A"],
+        DTSC.REQUIRED_SURVEY.format(method="A"): [True, True, True, True, True],
+        DTSC.SITE_DEPLOYMENT.format(method="A"): [False, True, False, True, False],
+        DTSC.METHOD_MEASURED.format(method="A"): [False, True, False, True, False],
+        DTSC.REQUIRED_SURVEY.format(method="B"): [True, False, True, False, True],
+        DTSC.SITE_DEPLOYMENT.format(method="B"): [True, False, True, False, True],
+        DTSC.METHOD_MEASURED.format(method="B"): [True, False, True, False, True],
+        DTSC.REQUIRED_SURVEY.format(method="C"): [True, True, True, True, True],
+        DTSC.SITE_DEPLOYMENT.format(method="C"): [False, True, False, True, False],
+        DTSC.METHOD_MEASURED.format(method="C"): [False, True, False, True, False],
+        DTSC.REQUIRED_SURVEY.format(method="D"): [True, True, True, True, True],
+        DTSC.SITE_DEPLOYMENT.format(method="D"): [False, True, False, True, False],
+        DTSC.METHOD_MEASURED.format(method="D"): [False, True, False, True, False],
+    }
+    prog_method = ["A", "B"]
+    data_filtered_result = {
+        DTSC.SITE_ID: [1, 2, 3, 4, 5],
+        DTSC.SITE_TYPE: ["A", "A", "A", "A", "A"],
+        DTSC.MEASURED: [True, True, True, True, True],
+    }
+    return (pd.DataFrame(data_ori), prog_method, pd.DataFrame(data_filtered_result))
+
+
+@pytest.mark.parametrize("fixture", [simple_fixture(), complex_fixture()])
+def test_filter_df_by_relevant_method(fixture):
+    truefalse_df, prog_method, expected = fixture
+
+    result = filter_df_by_relevant_method(truefalse_df, prog_method)
+
+    assert list(result.columns) == list(expected.columns)
+    assert len(result) == len(expected)
+    assert result.equals(expected)

--- a/LDAR_Sim/testing/unit_testing/test_virtual_world/test_infrastructure/test_filter_df_by_relevant_method.py
+++ b/LDAR_Sim/testing/unit_testing/test_virtual_world/test_infrastructure/test_filter_df_by_relevant_method.py
@@ -21,7 +21,7 @@ along with this program.  If not, see <https://opensource.org/licenses/MIT>.
 
 import pandas as pd
 import pytest
-from src.ldar_sim_run import filter_df_by_relevant_method
+from src.ldar_sim_run import filter_deployment_tf_by_program_methods
 from src.constants.infrastructure_const import Deployment_TF_Sites_Constants as DTSC
 
 
@@ -77,11 +77,37 @@ def complex_fixture():
     return (pd.DataFrame(data_ori), prog_method, pd.DataFrame(data_filtered_result))
 
 
-@pytest.mark.parametrize("fixture", [simple_fixture(), complex_fixture()])
+def three_method_fixture():
+    data_ori = {
+        DTSC.SITE_ID: [1, 2, 3, 4, 5],
+        DTSC.SITE_TYPE: ["A", "A", "A", "A", "A"],
+        DTSC.REQUIRED_SURVEY.format(method="A"): [True, True, True, False, True],
+        DTSC.SITE_DEPLOYMENT.format(method="A"): [True, True, False, False, False],
+        DTSC.METHOD_MEASURED.format(method="A"): [True, True, False, False, False],
+        DTSC.REQUIRED_SURVEY.format(method="B"): [False, False, True, False, True],
+        DTSC.SITE_DEPLOYMENT.format(method="B"): [False, False, True, False, True],
+        DTSC.METHOD_MEASURED.format(method="B"): [False, False, True, False, True],
+        DTSC.REQUIRED_SURVEY.format(method="C"): [True, True, True, True, True],
+        DTSC.SITE_DEPLOYMENT.format(method="C"): [False, True, False, True, False],
+        DTSC.METHOD_MEASURED.format(method="C"): [False, True, False, True, False],
+        DTSC.REQUIRED_SURVEY.format(method="D"): [True, True, True, True, True],
+        DTSC.SITE_DEPLOYMENT.format(method="D"): [False, True, False, True, False],
+        DTSC.METHOD_MEASURED.format(method="D"): [False, True, False, True, False],
+    }
+    prog_method = ["A", "B", "C"]
+    data_filtered_result = {
+        DTSC.SITE_ID: [1, 2, 3, 4, 5],
+        DTSC.SITE_TYPE: ["A", "A", "A", "A", "A"],
+        DTSC.MEASURED: [True, True, True, True, True],
+    }
+    return (pd.DataFrame(data_ori), prog_method, pd.DataFrame(data_filtered_result))
+
+
+@pytest.mark.parametrize("fixture", [simple_fixture(), complex_fixture(), three_method_fixture()])
 def test_filter_df_by_relevant_method(fixture):
     truefalse_df, prog_method, expected = fixture
 
-    result = filter_df_by_relevant_method(truefalse_df, prog_method)
+    result = filter_deployment_tf_by_program_methods(truefalse_df, prog_method)
 
     assert list(result.columns) == list(expected.columns)
     assert len(result) == len(expected)

--- a/LDAR_Sim/testing/unit_testing/test_virtual_world/test_infrastructure/test_populate_tf_site.py
+++ b/LDAR_Sim/testing/unit_testing/test_virtual_world/test_infrastructure/test_populate_tf_site.py
@@ -1,0 +1,245 @@
+"""
+------------------------------------------------------------------------------
+Program:     The LDAR Simulator (LDAR-Sim)
+File:        test_populate_tf_site.py
+Purpose: Contains unit tests related to populating the true/false deployment
+site list data frame
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the MIT License as published
+by the Free Software Foundation, version 3.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+MIT License for more details.
+You should have received a copy of the MIT License
+along with this program.  If not, see <https://opensource.org/licenses/MIT>.
+
+------------------------------------------------------------------------------
+"""
+
+import pandas as pd
+from src.constants.infrastructure_const import (
+    Deployment_TF_Sites_Constants as DTSC,
+)
+from src.virtual_world.infrastructure import Infrastructure
+import itertools
+
+EXPECTED_COLUMNS = [
+    DTSC.SITE_ID,
+    DTSC.SITE_TYPE,
+    DTSC.REQUIRED_SURVEY.format(method="A"),
+    DTSC.SITE_DEPLOYMENT.format(method="A"),
+    DTSC.SITE_MEASURED.format(method="A"),
+    DTSC.REQUIRED_SURVEY.format(method="B"),
+    DTSC.SITE_DEPLOYMENT.format(method="B"),
+    DTSC.SITE_MEASURED.format(method="B"),
+]
+
+METHODS_PARAMS: dict = {
+    "A": {"parameter_level": "methods", "version": "4.0", "method_name": "A"},
+    "B": {"parameter_level": "methods", "version": "4.0", "method_name": "B"},
+}
+
+
+def make_empty_df():
+    return pd.DataFrame(index=range(5), columns=EXPECTED_COLUMNS)
+
+
+def test_simple_generation_tf_sites(monkeypatch):
+    """
+    Test that the generation of the true/false site list is correct
+    """
+
+    class MockSite:
+        def get_id(self):
+            return 1
+
+        def get_type(self):
+            return "A"
+
+        def do_site_deployment(self, method):
+            return True
+
+        def get_required_surveys(self, method):
+            return 2
+
+    def mock_infrastructure_initialization(self, virtual_world, methods, in_dir, site_measured_df):
+        self._sites = [MockSite() for _ in range(5)]
+
+    monkeypatch.setattr(
+        "src.virtual_world.infrastructure.Infrastructure.__init__",
+        mock_infrastructure_initialization,
+    )
+
+    site_tf_df = make_empty_df()
+
+    infra = Infrastructure({}, METHODS_PARAMS, None, site_tf_df)
+
+    infra.gen_site_measured_tf_data(METHODS_PARAMS, site_tf_df)
+
+    data = {
+        DTSC.SITE_ID: [1, 1, 1, 1, 1],
+        DTSC.SITE_TYPE: ["A", "A", "A", "A", "A"],
+        DTSC.REQUIRED_SURVEY.format(method="A"): [True, True, True, True, True],
+        DTSC.SITE_DEPLOYMENT.format(method="A"): [True, True, True, True, True],
+        DTSC.SITE_MEASURED.format(method="A"): [True, True, True, True, True],
+        DTSC.REQUIRED_SURVEY.format(method="B"): [True, True, True, True, True],
+        DTSC.SITE_DEPLOYMENT.format(method="B"): [True, True, True, True, True],
+        DTSC.SITE_MEASURED.format(method="B"): [True, True, True, True, True],
+    }
+    expected: pd.DataFrame = pd.DataFrame(data)
+
+    assert list(site_tf_df.columns) == list(expected.columns)
+    assert len(site_tf_df) == len(expected)
+    pd.testing.assert_frame_equal(site_tf_df, expected, check_index_type=False, check_dtype=False)
+
+
+def test_simple_fail_generation_tf_sites(monkeypatch):
+    """
+    Test that the generation of the true/false site list is correct
+    """
+
+    class MockSite:
+        def get_id(self):
+            return 1
+
+        def get_type(self):
+            return "A"
+
+        def do_site_deployment(self, method):
+            return True
+
+        def get_required_surveys(self, method):
+            return 0
+
+    def mock_infrastructure_initialization(self, virtual_world, methods, in_dir, site_measured_df):
+        self._sites = [MockSite() for _ in range(5)]
+
+    monkeypatch.setattr(
+        "src.virtual_world.infrastructure.Infrastructure.__init__",
+        mock_infrastructure_initialization,
+    )
+
+    site_tf_df = make_empty_df()
+
+    infra = Infrastructure({}, METHODS_PARAMS, None, site_tf_df)
+
+    infra.gen_site_measured_tf_data(METHODS_PARAMS, site_tf_df)
+
+    data = {
+        DTSC.SITE_ID: [1, 1, 1, 1, 1],
+        DTSC.SITE_TYPE: ["A", "A", "A", "A", "A"],
+        DTSC.REQUIRED_SURVEY.format(method="A"): [False, False, False, False, False],
+        DTSC.SITE_DEPLOYMENT.format(method="A"): [True, True, True, True, True],
+        DTSC.SITE_MEASURED.format(method="A"): [False, False, False, False, False],
+        DTSC.REQUIRED_SURVEY.format(method="B"): [False, False, False, False, False],
+        DTSC.SITE_DEPLOYMENT.format(method="B"): [True, True, True, True, True],
+        DTSC.SITE_MEASURED.format(method="B"): [False, False, False, False, False],
+    }
+    expected: pd.DataFrame = pd.DataFrame(data)
+
+    assert list(site_tf_df.columns) == list(expected.columns)
+    assert len(site_tf_df) == len(expected)
+    pd.testing.assert_frame_equal(site_tf_df, expected, check_index_type=False, check_dtype=False)
+
+
+def test_simple_fail_generation_tf_sites2(monkeypatch):
+    """
+    Test that the generation of the true/false site list is correct
+    """
+
+    class MockSite:
+        def get_id(self):
+            return 1
+
+        def get_type(self):
+            return "A"
+
+        def do_site_deployment(self, method):
+            return False
+
+        def get_required_surveys(self, method):
+            return 5
+
+    def mock_infrastructure_initialization(self, virtual_world, methods, in_dir, site_measured_df):
+        self._sites = [MockSite() for _ in range(5)]
+
+    monkeypatch.setattr(
+        "src.virtual_world.infrastructure.Infrastructure.__init__",
+        mock_infrastructure_initialization,
+    )
+
+    site_tf_df = make_empty_df()
+
+    infra = Infrastructure({}, METHODS_PARAMS, None, site_tf_df)
+
+    infra.gen_site_measured_tf_data(METHODS_PARAMS, site_tf_df)
+
+    data = {
+        DTSC.SITE_ID: [1, 1, 1, 1, 1],
+        DTSC.SITE_TYPE: ["A", "A", "A", "A", "A"],
+        DTSC.REQUIRED_SURVEY.format(method="A"): [True, True, True, True, True],
+        DTSC.SITE_DEPLOYMENT.format(method="A"): [False, False, False, False, False],
+        DTSC.SITE_MEASURED.format(method="A"): [False, False, False, False, False],
+        DTSC.REQUIRED_SURVEY.format(method="B"): [True, True, True, True, True],
+        DTSC.SITE_DEPLOYMENT.format(method="B"): [False, False, False, False, False],
+        DTSC.SITE_MEASURED.format(method="B"): [False, False, False, False, False],
+    }
+    expected: pd.DataFrame = pd.DataFrame(data)
+
+    assert list(site_tf_df.columns) == list(expected.columns)
+    assert len(site_tf_df) == len(expected)
+    pd.testing.assert_frame_equal(site_tf_df, expected, check_index_type=False, check_dtype=False)
+
+
+def test_complex_generation_tf_sites(monkeypatch):
+    """
+    Test that the generation of the true/false site list is correct
+    """
+
+    class MockSite:
+        return_values = itertools.cycle([False, False, True, True])
+
+        def get_id(self):
+            return 1
+
+        def get_type(self):
+            return "A"
+
+        def do_site_deployment(self, method):
+            return next(MockSite.return_values)
+
+        def get_required_surveys(self, method):
+            return 5
+
+    def mock_infrastructure_initialization(self, virtual_world, methods, in_dir, site_measured_df):
+        self._sites = [MockSite() for _ in range(5)]
+
+    monkeypatch.setattr(
+        "src.virtual_world.infrastructure.Infrastructure.__init__",
+        mock_infrastructure_initialization,
+    )
+
+    site_tf_df = make_empty_df()
+
+    infra = Infrastructure({}, METHODS_PARAMS, None, site_tf_df)
+
+    infra.gen_site_measured_tf_data(METHODS_PARAMS, site_tf_df)
+
+    data = {
+        DTSC.SITE_ID: [1, 1, 1, 1, 1],
+        DTSC.SITE_TYPE: ["A", "A", "A", "A", "A"],
+        DTSC.REQUIRED_SURVEY.format(method="A"): [True, True, True, True, True],
+        DTSC.SITE_DEPLOYMENT.format(method="A"): [False, True, False, True, False],
+        DTSC.SITE_MEASURED.format(method="A"): [False, True, False, True, False],
+        DTSC.REQUIRED_SURVEY.format(method="B"): [True, True, True, True, True],
+        DTSC.SITE_DEPLOYMENT.format(method="B"): [False, True, False, True, False],
+        DTSC.SITE_MEASURED.format(method="B"): [False, True, False, True, False],
+    }
+    expected: pd.DataFrame = pd.DataFrame(data)
+
+    assert list(site_tf_df.columns) == list(expected.columns)
+    assert len(site_tf_df) == len(expected)
+    pd.testing.assert_frame_equal(site_tf_df, expected, check_index_type=False, check_dtype=False)

--- a/LDAR_Sim/testing/unit_testing/test_virtual_world/test_infrastructure/test_populate_tf_site.py
+++ b/LDAR_Sim/testing/unit_testing/test_virtual_world/test_infrastructure/test_populate_tf_site.py
@@ -19,6 +19,7 @@ along with this program.  If not, see <https://opensource.org/licenses/MIT>.
 ------------------------------------------------------------------------------
 """
 
+import pytest
 import pandas as pd
 from src.constants.infrastructure_const import (
     Deployment_TF_Sites_Constants as DTSC,
@@ -89,299 +90,181 @@ METHODS_PARAMS_STATIONARY: dict = {
 }
 
 
+class MockSite:
+    def __init__(self, site_id, site_type, deployment, surveys):
+        self.site_id = site_id
+        self.site_type = site_type
+        self.deployment = deployment
+        self.surveys = surveys
+
+    def get_id(self):
+        return self.site_id
+
+    def get_type(self):
+        return self.site_type
+
+    def do_site_deployment(self, method):
+        return self.deployment
+
+    def get_required_surveys(self, method):
+        return self.surveys
+
+
+def mock_infrastructure_initialization(
+    self, virtual_world, methods, in_dir, site_measured_df, mock_site
+):
+    self._sites = mock_site
+
+
 def make_empty_df():
     return pd.DataFrame(index=range(5), columns=EXPECTED_COLUMNS)
 
 
-def test_simple_generation_tf_sites(monkeypatch):
+@pytest.mark.parametrize(
+    "mock_site,methods_params,expected_data",
+    [
+        (
+            [
+                MockSite(1, "A", True, 2),
+                MockSite(1, "A", True, 2),
+                MockSite(1, "A", True, 2),
+                MockSite(1, "A", True, 2),
+                MockSite(1, "A", True, 2),
+            ],
+            METHODS_PARAMS,
+            {
+                DTSC.SITE_ID: [1, 1, 1, 1, 1],
+                DTSC.SITE_TYPE: ["A", "A", "A", "A", "A"],
+                DTSC.REQUIRED_SURVEY.format(method="A"): [True, True, True, True, True],
+                DTSC.SITE_DEPLOYMENT.format(method="A"): [True, True, True, True, True],
+                DTSC.METHOD_MEASURED.format(method="A"): [True, True, True, True, True],
+                DTSC.REQUIRED_SURVEY.format(method="B"): [True, True, True, True, True],
+                DTSC.SITE_DEPLOYMENT.format(method="B"): [True, True, True, True, True],
+                DTSC.METHOD_MEASURED.format(method="B"): [True, True, True, True, True],
+            },
+        ),
+        (
+            [
+                MockSite(1, "A", True, 2),
+                MockSite(1, "A", True, 2),
+                MockSite(1, "A", True, 2),
+                MockSite(1, "A", True, 2),
+                MockSite(1, "A", True, 2),
+            ],
+            METHODS_PARAMS_STATIONARY,
+            {
+                DTSC.SITE_ID: [1, 1, 1, 1, 1],
+                DTSC.SITE_TYPE: ["A", "A", "A", "A", "A"],
+                DTSC.REQUIRED_SURVEY.format(method="A"): [True, True, True, True, True],
+                DTSC.SITE_DEPLOYMENT.format(method="A"): [True, True, True, True, True],
+                DTSC.METHOD_MEASURED.format(method="A"): [True, True, True, True, True],
+                DTSC.REQUIRED_SURVEY.format(method="B"): [True, True, True, True, True],
+                DTSC.SITE_DEPLOYMENT.format(method="B"): [True, True, True, True, True],
+                DTSC.METHOD_MEASURED.format(method="B"): [True, True, True, True, True],
+            },
+        ),
+        (
+            [
+                MockSite(1, "A", True, 2),
+                MockSite(1, "A", True, 2),
+                MockSite(1, "A", True, 2),
+                MockSite(1, "A", True, 2),
+                MockSite(1, "A", True, 2),
+            ],
+            METHODS_PARAMS_FOLLOW_UP,
+            {
+                DTSC.SITE_ID: [1, 1, 1, 1, 1],
+                DTSC.SITE_TYPE: ["A", "A", "A", "A", "A"],
+                DTSC.REQUIRED_SURVEY.format(method="A"): [False, False, False, False, False],
+                DTSC.SITE_DEPLOYMENT.format(method="A"): [False, False, False, False, False],
+                DTSC.METHOD_MEASURED.format(method="A"): [False, False, False, False, False],
+                DTSC.REQUIRED_SURVEY.format(method="B"): [True, True, True, True, True],
+                DTSC.SITE_DEPLOYMENT.format(method="B"): [True, True, True, True, True],
+                DTSC.METHOD_MEASURED.format(method="B"): [True, True, True, True, True],
+            },
+        ),
+        (
+            [
+                MockSite(1, "A", True, 0),
+                MockSite(1, "A", True, 0),
+                MockSite(1, "A", True, 0),
+                MockSite(1, "A", True, 0),
+                MockSite(1, "A", True, 0),
+            ],
+            METHODS_PARAMS,
+            {
+                DTSC.SITE_ID: [1, 1, 1, 1, 1],
+                DTSC.SITE_TYPE: ["A", "A", "A", "A", "A"],
+                DTSC.REQUIRED_SURVEY.format(method="A"): [False, False, False, False, False],
+                DTSC.SITE_DEPLOYMENT.format(method="A"): [True, True, True, True, True],
+                DTSC.METHOD_MEASURED.format(method="A"): [False, False, False, False, False],
+                DTSC.REQUIRED_SURVEY.format(method="B"): [False, False, False, False, False],
+                DTSC.SITE_DEPLOYMENT.format(method="B"): [True, True, True, True, True],
+                DTSC.METHOD_MEASURED.format(method="B"): [False, False, False, False, False],
+            },
+        ),
+        (
+            [
+                MockSite(1, "A", False, 5),
+                MockSite(1, "A", False, 5),
+                MockSite(1, "A", False, 5),
+                MockSite(1, "A", False, 5),
+                MockSite(1, "A", False, 5),
+            ],
+            METHODS_PARAMS,
+            {
+                DTSC.SITE_ID: [1, 1, 1, 1, 1],
+                DTSC.SITE_TYPE: ["A", "A", "A", "A", "A"],
+                DTSC.REQUIRED_SURVEY.format(method="A"): [True, True, True, True, True],
+                DTSC.SITE_DEPLOYMENT.format(method="A"): [False, False, False, False, False],
+                DTSC.METHOD_MEASURED.format(method="A"): [False, False, False, False, False],
+                DTSC.REQUIRED_SURVEY.format(method="B"): [True, True, True, True, True],
+                DTSC.SITE_DEPLOYMENT.format(method="B"): [False, False, False, False, False],
+                DTSC.METHOD_MEASURED.format(method="B"): [False, False, False, False, False],
+            },
+        ),
+        (
+            [
+                MockSite(1, "A", False, 5),
+                MockSite(1, "A", True, 5),
+                MockSite(1, "A", False, 5),
+                MockSite(1, "A", True, 5),
+                MockSite(1, "A", False, 5),
+            ],
+            METHODS_PARAMS,
+            {
+                DTSC.SITE_ID: [1, 1, 1, 1, 1],
+                DTSC.SITE_TYPE: ["A", "A", "A", "A", "A"],
+                DTSC.REQUIRED_SURVEY.format(method="A"): [True, True, True, True, True],
+                DTSC.SITE_DEPLOYMENT.format(method="A"): [False, True, False, True, False],
+                DTSC.METHOD_MEASURED.format(method="A"): [False, True, False, True, False],
+                DTSC.REQUIRED_SURVEY.format(method="B"): [True, True, True, True, True],
+                DTSC.SITE_DEPLOYMENT.format(method="B"): [False, True, False, True, False],
+                DTSC.METHOD_MEASURED.format(method="B"): [False, True, False, True, False],
+            },
+        ),
+    ],
+)
+def test_generation_tf_sites(monkeypatch, mock_site, methods_params, expected_data):
     """
     Test that the generation of the true/false site list is correct
     """
-
-    class MockSite:
-        def get_id(self):
-            return 1
-
-        def get_type(self):
-            return "A"
-
-        def do_site_deployment(self, method):
-            return True
-
-        def get_required_surveys(self, method):
-            return 2
-
-    def mock_infrastructure_initialization(self, virtual_world, methods, in_dir, site_measured_df):
-        self._sites = [MockSite() for _ in range(5)]
-
     monkeypatch.setattr(
         "src.virtual_world.infrastructure.Infrastructure.__init__",
-        mock_infrastructure_initialization,
+        lambda self, virtual_world, methods, in_dir, site_measured_df: mock_infrastructure_initialization(  # noqa
+            self, virtual_world, methods, in_dir, site_measured_df, mock_site
+        ),
     )
 
     site_tf_df = make_empty_df()
 
-    infra = Infrastructure({}, METHODS_PARAMS, None, site_tf_df)
+    infra = Infrastructure({}, methods_params, None, site_tf_df)
 
-    infra.gen_site_measured_tf_data(METHODS_PARAMS, site_tf_df)
+    infra.gen_site_measured_tf_data(methods_params, site_tf_df)
 
-    data = {
-        DTSC.SITE_ID: [1, 1, 1, 1, 1],
-        DTSC.SITE_TYPE: ["A", "A", "A", "A", "A"],
-        DTSC.REQUIRED_SURVEY.format(method="A"): [True, True, True, True, True],
-        DTSC.SITE_DEPLOYMENT.format(method="A"): [True, True, True, True, True],
-        DTSC.METHOD_MEASURED.format(method="A"): [True, True, True, True, True],
-        DTSC.REQUIRED_SURVEY.format(method="B"): [True, True, True, True, True],
-        DTSC.SITE_DEPLOYMENT.format(method="B"): [True, True, True, True, True],
-        DTSC.METHOD_MEASURED.format(method="B"): [True, True, True, True, True],
-    }
-    expected: pd.DataFrame = pd.DataFrame(data)
+    expected: pd.DataFrame = pd.DataFrame(expected_data)
 
-    assert list(site_tf_df.columns) == list(expected.columns)
-    assert len(site_tf_df) == len(expected)
-    pd.testing.assert_frame_equal(site_tf_df, expected, check_index_type=False, check_dtype=False)
-
-def test_simple_generation_tf_sites_stationary(monkeypatch):
-    """
-    Test that the generation of the true/false site list is correct
-    """
-
-    class MockSite:
-        def get_id(self):
-            return 1
-
-        def get_type(self):
-            return "A"
-
-        def do_site_deployment(self, method):
-            return True
-
-        def get_required_surveys(self, method):
-            return 2
-
-    def mock_infrastructure_initialization(self, virtual_world, methods, in_dir, site_measured_df):
-        self._sites = [MockSite() for _ in range(5)]
-
-    monkeypatch.setattr(
-        "src.virtual_world.infrastructure.Infrastructure.__init__",
-        mock_infrastructure_initialization,
-    )
-
-    site_tf_df = make_empty_df()
-
-    infra = Infrastructure({}, METHODS_PARAMS_STATIONARY, None, site_tf_df)
-
-    infra.gen_site_measured_tf_data(METHODS_PARAMS_STATIONARY, site_tf_df)
-
-    data = {
-        DTSC.SITE_ID: [1, 1, 1, 1, 1],
-        DTSC.SITE_TYPE: ["A", "A", "A", "A", "A"],
-        DTSC.REQUIRED_SURVEY.format(method="A"): [True, True, True, True, True],
-        DTSC.SITE_DEPLOYMENT.format(method="A"): [True, True, True, True, True],
-        DTSC.METHOD_MEASURED.format(method="A"): [True, True, True, True, True],
-        DTSC.REQUIRED_SURVEY.format(method="B"): [True, True, True, True, True],
-        DTSC.SITE_DEPLOYMENT.format(method="B"): [True, True, True, True, True],
-        DTSC.METHOD_MEASURED.format(method="B"): [True, True, True, True, True],
-    }
-    expected: pd.DataFrame = pd.DataFrame(data)
-
-    assert list(site_tf_df.columns) == list(expected.columns)
-    assert len(site_tf_df) == len(expected)
-    pd.testing.assert_frame_equal(site_tf_df, expected, check_index_type=False, check_dtype=False)
-
-
-def test_simple_generation_tf_sites_for_followup(monkeypatch):
-    """
-    Test that the generation of the true/false site list is correct
-    """
-
-    class MockSite:
-        def get_id(self):
-            return 1
-
-        def get_type(self):
-            return "A"
-
-        def do_site_deployment(self, method):
-            return True
-
-        def get_required_surveys(self, method):
-            return 2
-
-    def mock_infrastructure_initialization(self, virtual_world, methods, in_dir, site_measured_df):
-        self._sites = [MockSite() for _ in range(5)]
-
-    monkeypatch.setattr(
-        "src.virtual_world.infrastructure.Infrastructure.__init__",
-        mock_infrastructure_initialization,
-    )
-
-    site_tf_df = make_empty_df()
-
-    infra = Infrastructure({}, METHODS_PARAMS_FOLLOW_UP, None, site_tf_df)
-
-    infra.gen_site_measured_tf_data(METHODS_PARAMS_FOLLOW_UP, site_tf_df)
-
-    data = {
-        DTSC.SITE_ID: [1, 1, 1, 1, 1],
-        DTSC.SITE_TYPE: ["A", "A", "A", "A", "A"],
-        DTSC.REQUIRED_SURVEY.format(method="A"): [False, False, False, False, False],
-        DTSC.SITE_DEPLOYMENT.format(method="A"): [False, False, False, False, False],
-        DTSC.METHOD_MEASURED.format(method="A"): [False, False, False, False, False],
-        DTSC.REQUIRED_SURVEY.format(method="B"): [True, True, True, True, True],
-        DTSC.SITE_DEPLOYMENT.format(method="B"): [True, True, True, True, True],
-        DTSC.METHOD_MEASURED.format(method="B"): [True, True, True, True, True],
-    }
-    expected: pd.DataFrame = pd.DataFrame(data)
-
-    assert list(site_tf_df.columns) == list(expected.columns)
-    assert len(site_tf_df) == len(expected)
-    pd.testing.assert_frame_equal(site_tf_df, expected, check_index_type=False, check_dtype=False)
-
-
-def test_simple_fail_generation_tf_sites(monkeypatch):
-    """
-    Test that the generation of the true/false site list is correct
-    """
-
-    class MockSite:
-        def get_id(self):
-            return 1
-
-        def get_type(self):
-            return "A"
-
-        def do_site_deployment(self, method):
-            return True
-
-        def get_required_surveys(self, method):
-            return 0
-
-    def mock_infrastructure_initialization(self, virtual_world, methods, in_dir, site_measured_df):
-        self._sites = [MockSite() for _ in range(5)]
-
-    monkeypatch.setattr(
-        "src.virtual_world.infrastructure.Infrastructure.__init__",
-        mock_infrastructure_initialization,
-    )
-
-    site_tf_df = make_empty_df()
-
-    infra = Infrastructure({}, METHODS_PARAMS, None, site_tf_df)
-
-    infra.gen_site_measured_tf_data(METHODS_PARAMS, site_tf_df)
-
-    data = {
-        DTSC.SITE_ID: [1, 1, 1, 1, 1],
-        DTSC.SITE_TYPE: ["A", "A", "A", "A", "A"],
-        DTSC.REQUIRED_SURVEY.format(method="A"): [False, False, False, False, False],
-        DTSC.SITE_DEPLOYMENT.format(method="A"): [True, True, True, True, True],
-        DTSC.METHOD_MEASURED.format(method="A"): [False, False, False, False, False],
-        DTSC.REQUIRED_SURVEY.format(method="B"): [False, False, False, False, False],
-        DTSC.SITE_DEPLOYMENT.format(method="B"): [True, True, True, True, True],
-        DTSC.METHOD_MEASURED.format(method="B"): [False, False, False, False, False],
-    }
-    expected: pd.DataFrame = pd.DataFrame(data)
-
-    assert list(site_tf_df.columns) == list(expected.columns)
-    assert len(site_tf_df) == len(expected)
-    pd.testing.assert_frame_equal(site_tf_df, expected, check_index_type=False, check_dtype=False)
-
-
-def test_simple_fail_generation_tf_sites2(monkeypatch):
-    """
-    Test that the generation of the true/false site list is correct
-    """
-
-    class MockSite:
-        def get_id(self):
-            return 1
-
-        def get_type(self):
-            return "A"
-
-        def do_site_deployment(self, method):
-            return False
-
-        def get_required_surveys(self, method):
-            return 5
-
-    def mock_infrastructure_initialization(self, virtual_world, methods, in_dir, site_measured_df):
-        self._sites = [MockSite() for _ in range(5)]
-
-    monkeypatch.setattr(
-        "src.virtual_world.infrastructure.Infrastructure.__init__",
-        mock_infrastructure_initialization,
-    )
-
-    site_tf_df = make_empty_df()
-
-    infra = Infrastructure({}, METHODS_PARAMS, None, site_tf_df)
-
-    infra.gen_site_measured_tf_data(METHODS_PARAMS, site_tf_df)
-
-    data = {
-        DTSC.SITE_ID: [1, 1, 1, 1, 1],
-        DTSC.SITE_TYPE: ["A", "A", "A", "A", "A"],
-        DTSC.REQUIRED_SURVEY.format(method="A"): [True, True, True, True, True],
-        DTSC.SITE_DEPLOYMENT.format(method="A"): [False, False, False, False, False],
-        DTSC.METHOD_MEASURED.format(method="A"): [False, False, False, False, False],
-        DTSC.REQUIRED_SURVEY.format(method="B"): [True, True, True, True, True],
-        DTSC.SITE_DEPLOYMENT.format(method="B"): [False, False, False, False, False],
-        DTSC.METHOD_MEASURED.format(method="B"): [False, False, False, False, False],
-    }
-    expected: pd.DataFrame = pd.DataFrame(data)
-
-    assert list(site_tf_df.columns) == list(expected.columns)
-    assert len(site_tf_df) == len(expected)
-    pd.testing.assert_frame_equal(site_tf_df, expected, check_index_type=False, check_dtype=False)
-
-
-def test_complex_generation_tf_sites(monkeypatch):
-    """
-    Test that the generation of the true/false site list is correct
-    """
-
-    class MockSite:
-        return_values = itertools.cycle([False, False, True, True])
-
-        def get_id(self):
-            return 1
-
-        def get_type(self):
-            return "A"
-
-        def do_site_deployment(self, method):
-            return next(MockSite.return_values)
-
-        def get_required_surveys(self, method):
-            return 5
-
-    def mock_infrastructure_initialization(self, virtual_world, methods, in_dir, site_measured_df):
-        self._sites = [MockSite() for _ in range(5)]
-
-    monkeypatch.setattr(
-        "src.virtual_world.infrastructure.Infrastructure.__init__",
-        mock_infrastructure_initialization,
-    )
-
-    site_tf_df = make_empty_df()
-
-    infra = Infrastructure({}, METHODS_PARAMS, None, site_tf_df)
-
-    infra.gen_site_measured_tf_data(METHODS_PARAMS, site_tf_df)
-
-    data = {
-        DTSC.SITE_ID: [1, 1, 1, 1, 1],
-        DTSC.SITE_TYPE: ["A", "A", "A", "A", "A"],
-        DTSC.REQUIRED_SURVEY.format(method="A"): [True, True, True, True, True],
-        DTSC.SITE_DEPLOYMENT.format(method="A"): [False, True, False, True, False],
-        DTSC.METHOD_MEASURED.format(method="A"): [False, True, False, True, False],
-        DTSC.REQUIRED_SURVEY.format(method="B"): [True, True, True, True, True],
-        DTSC.SITE_DEPLOYMENT.format(method="B"): [False, True, False, True, False],
-        DTSC.METHOD_MEASURED.format(method="B"): [False, True, False, True, False],
-    }
-    expected: pd.DataFrame = pd.DataFrame(data)
+    expected: pd.DataFrame = pd.DataFrame(expected_data)
 
     assert list(site_tf_df.columns) == list(expected.columns)
     assert len(site_tf_df) == len(expected)

--- a/LDAR_Sim/testing/unit_testing/test_virtual_world/test_infrastructure/test_populate_tf_site.py
+++ b/LDAR_Sim/testing/unit_testing/test_virtual_world/test_infrastructure/test_populate_tf_site.py
@@ -25,7 +25,6 @@ from src.constants.infrastructure_const import (
     Deployment_TF_Sites_Constants as DTSC,
 )
 from src.virtual_world.infrastructure import Infrastructure
-import itertools
 
 EXPECTED_COLUMNS = [
     DTSC.SITE_ID,
@@ -120,135 +119,155 @@ def make_empty_df():
     return pd.DataFrame(index=range(5), columns=EXPECTED_COLUMNS)
 
 
+@pytest.fixture
+def mock_sites_all_true_deploy_survey_fix():
+    inputs = [
+        MockSite(1, "A", True, 2),
+        MockSite(1, "A", True, 2),
+        MockSite(1, "A", True, 2),
+        MockSite(1, "A", True, 2),
+        MockSite(1, "A", True, 2),
+    ]
+    results = {
+        DTSC.SITE_ID: [1, 1, 1, 1, 1],
+        DTSC.SITE_TYPE: ["A", "A", "A", "A", "A"],
+        DTSC.REQUIRED_SURVEY.format(method="A"): [True, True, True, True, True],
+        DTSC.SITE_DEPLOYMENT.format(method="A"): [True, True, True, True, True],
+        DTSC.METHOD_MEASURED.format(method="A"): [True, True, True, True, True],
+        DTSC.REQUIRED_SURVEY.format(method="B"): [True, True, True, True, True],
+        DTSC.SITE_DEPLOYMENT.format(method="B"): [True, True, True, True, True],
+        DTSC.METHOD_MEASURED.format(method="B"): [True, True, True, True, True],
+    }
+    return (inputs, METHODS_PARAMS, results)
+
+
+@pytest.fixture
+def mock_sites_all_true_deploy_survey_stationary_fix():
+    input = [
+        MockSite(1, "A", True, 2),
+        MockSite(1, "A", True, 2),
+        MockSite(1, "A", True, 2),
+        MockSite(1, "A", True, 2),
+        MockSite(1, "A", True, 2),
+    ]
+    results = {
+        DTSC.SITE_ID: [1, 1, 1, 1, 1],
+        DTSC.SITE_TYPE: ["A", "A", "A", "A", "A"],
+        DTSC.REQUIRED_SURVEY.format(method="A"): [True, True, True, True, True],
+        DTSC.SITE_DEPLOYMENT.format(method="A"): [True, True, True, True, True],
+        DTSC.METHOD_MEASURED.format(method="A"): [True, True, True, True, True],
+        DTSC.REQUIRED_SURVEY.format(method="B"): [True, True, True, True, True],
+        DTSC.SITE_DEPLOYMENT.format(method="B"): [True, True, True, True, True],
+        DTSC.METHOD_MEASURED.format(method="B"): [True, True, True, True, True],
+    }
+    return (input, METHODS_PARAMS_STATIONARY, results)
+
+
+@pytest.fixture
+def mock_sites_all_true_deploy_survey_followup_fix():
+    input = [
+        MockSite(1, "A", True, 2),
+        MockSite(1, "A", True, 2),
+        MockSite(1, "A", True, 2),
+        MockSite(1, "A", True, 2),
+        MockSite(1, "A", True, 2),
+    ]
+    results = {
+        DTSC.SITE_ID: [1, 1, 1, 1, 1],
+        DTSC.SITE_TYPE: ["A", "A", "A", "A", "A"],
+        DTSC.REQUIRED_SURVEY.format(method="A"): [False, False, False, False, False],
+        DTSC.SITE_DEPLOYMENT.format(method="A"): [False, False, False, False, False],
+        DTSC.METHOD_MEASURED.format(method="A"): [False, False, False, False, False],
+        DTSC.REQUIRED_SURVEY.format(method="B"): [True, True, True, True, True],
+        DTSC.SITE_DEPLOYMENT.format(method="B"): [True, True, True, True, True],
+        DTSC.METHOD_MEASURED.format(method="B"): [True, True, True, True, True],
+    }
+    return (input, METHODS_PARAMS_FOLLOW_UP, results)
+
+
+@pytest.fixture
+def mock_sites_true_deploy_false_survey_fix():
+    input = [
+        MockSite(1, "A", True, 0),
+        MockSite(1, "A", True, 0),
+        MockSite(1, "A", True, 0),
+        MockSite(1, "A", True, 0),
+        MockSite(1, "A", True, 0),
+    ]
+    results = {
+        DTSC.SITE_ID: [1, 1, 1, 1, 1],
+        DTSC.SITE_TYPE: ["A", "A", "A", "A", "A"],
+        DTSC.REQUIRED_SURVEY.format(method="A"): [False, False, False, False, False],
+        DTSC.SITE_DEPLOYMENT.format(method="A"): [True, True, True, True, True],
+        DTSC.METHOD_MEASURED.format(method="A"): [False, False, False, False, False],
+        DTSC.REQUIRED_SURVEY.format(method="B"): [False, False, False, False, False],
+        DTSC.SITE_DEPLOYMENT.format(method="B"): [True, True, True, True, True],
+        DTSC.METHOD_MEASURED.format(method="B"): [False, False, False, False, False],
+    }
+    return (input, METHODS_PARAMS, results)
+
+
+@pytest.fixture
+def mock_sites_false_deploy_true_survey_fix():
+    inputs = [
+        MockSite(1, "A", False, 5),
+        MockSite(2, "A", False, 5),
+        MockSite(3, "A", False, 5),
+        MockSite(4, "A", False, 5),
+        MockSite(5, "A", False, 5),
+    ]
+    results = {
+        DTSC.SITE_ID: [1, 2, 3, 4, 5],
+        DTSC.SITE_TYPE: ["A", "A", "A", "A", "A"],
+        DTSC.REQUIRED_SURVEY.format(method="A"): [True, True, True, True, True],
+        DTSC.SITE_DEPLOYMENT.format(method="A"): [False, False, False, False, False],
+        DTSC.METHOD_MEASURED.format(method="A"): [False, False, False, False, False],
+        DTSC.REQUIRED_SURVEY.format(method="B"): [True, True, True, True, True],
+        DTSC.SITE_DEPLOYMENT.format(method="B"): [False, False, False, False, False],
+        DTSC.METHOD_MEASURED.format(method="B"): [False, False, False, False, False],
+    }
+
+    return (inputs, METHODS_PARAMS, results)
+
+
+@pytest.fixture
+def mock_sites_mix_deploy_mix_survey_fix():
+    inputs = [
+        MockSite(1, "A", False, 5),
+        MockSite(1, "A", True, 5),
+        MockSite(1, "A", False, 5),
+        MockSite(1, "A", True, 5),
+        MockSite(1, "A", False, 5),
+    ]
+    results = {
+        DTSC.SITE_ID: [1, 1, 1, 1, 1],
+        DTSC.SITE_TYPE: ["A", "A", "A", "A", "A"],
+        DTSC.REQUIRED_SURVEY.format(method="A"): [True, True, True, True, True],
+        DTSC.SITE_DEPLOYMENT.format(method="A"): [False, True, False, True, False],
+        DTSC.METHOD_MEASURED.format(method="A"): [False, True, False, True, False],
+        DTSC.REQUIRED_SURVEY.format(method="B"): [True, True, True, True, True],
+        DTSC.SITE_DEPLOYMENT.format(method="B"): [False, True, False, True, False],
+        DTSC.METHOD_MEASURED.format(method="B"): [False, True, False, True, False],
+    }
+    return (inputs, METHODS_PARAMS, results)
+
+
 @pytest.mark.parametrize(
-    "mock_site,methods_params,expected_data",
+    "fixture_data",
     [
-        (
-            [
-                MockSite(1, "A", True, 2),
-                MockSite(1, "A", True, 2),
-                MockSite(1, "A", True, 2),
-                MockSite(1, "A", True, 2),
-                MockSite(1, "A", True, 2),
-            ],
-            METHODS_PARAMS,
-            {
-                DTSC.SITE_ID: [1, 1, 1, 1, 1],
-                DTSC.SITE_TYPE: ["A", "A", "A", "A", "A"],
-                DTSC.REQUIRED_SURVEY.format(method="A"): [True, True, True, True, True],
-                DTSC.SITE_DEPLOYMENT.format(method="A"): [True, True, True, True, True],
-                DTSC.METHOD_MEASURED.format(method="A"): [True, True, True, True, True],
-                DTSC.REQUIRED_SURVEY.format(method="B"): [True, True, True, True, True],
-                DTSC.SITE_DEPLOYMENT.format(method="B"): [True, True, True, True, True],
-                DTSC.METHOD_MEASURED.format(method="B"): [True, True, True, True, True],
-            },
-        ),
-        (
-            [
-                MockSite(1, "A", True, 2),
-                MockSite(1, "A", True, 2),
-                MockSite(1, "A", True, 2),
-                MockSite(1, "A", True, 2),
-                MockSite(1, "A", True, 2),
-            ],
-            METHODS_PARAMS_STATIONARY,
-            {
-                DTSC.SITE_ID: [1, 1, 1, 1, 1],
-                DTSC.SITE_TYPE: ["A", "A", "A", "A", "A"],
-                DTSC.REQUIRED_SURVEY.format(method="A"): [True, True, True, True, True],
-                DTSC.SITE_DEPLOYMENT.format(method="A"): [True, True, True, True, True],
-                DTSC.METHOD_MEASURED.format(method="A"): [True, True, True, True, True],
-                DTSC.REQUIRED_SURVEY.format(method="B"): [True, True, True, True, True],
-                DTSC.SITE_DEPLOYMENT.format(method="B"): [True, True, True, True, True],
-                DTSC.METHOD_MEASURED.format(method="B"): [True, True, True, True, True],
-            },
-        ),
-        (
-            [
-                MockSite(1, "A", True, 2),
-                MockSite(1, "A", True, 2),
-                MockSite(1, "A", True, 2),
-                MockSite(1, "A", True, 2),
-                MockSite(1, "A", True, 2),
-            ],
-            METHODS_PARAMS_FOLLOW_UP,
-            {
-                DTSC.SITE_ID: [1, 1, 1, 1, 1],
-                DTSC.SITE_TYPE: ["A", "A", "A", "A", "A"],
-                DTSC.REQUIRED_SURVEY.format(method="A"): [False, False, False, False, False],
-                DTSC.SITE_DEPLOYMENT.format(method="A"): [False, False, False, False, False],
-                DTSC.METHOD_MEASURED.format(method="A"): [False, False, False, False, False],
-                DTSC.REQUIRED_SURVEY.format(method="B"): [True, True, True, True, True],
-                DTSC.SITE_DEPLOYMENT.format(method="B"): [True, True, True, True, True],
-                DTSC.METHOD_MEASURED.format(method="B"): [True, True, True, True, True],
-            },
-        ),
-        (
-            [
-                MockSite(1, "A", True, 0),
-                MockSite(1, "A", True, 0),
-                MockSite(1, "A", True, 0),
-                MockSite(1, "A", True, 0),
-                MockSite(1, "A", True, 0),
-            ],
-            METHODS_PARAMS,
-            {
-                DTSC.SITE_ID: [1, 1, 1, 1, 1],
-                DTSC.SITE_TYPE: ["A", "A", "A", "A", "A"],
-                DTSC.REQUIRED_SURVEY.format(method="A"): [False, False, False, False, False],
-                DTSC.SITE_DEPLOYMENT.format(method="A"): [True, True, True, True, True],
-                DTSC.METHOD_MEASURED.format(method="A"): [False, False, False, False, False],
-                DTSC.REQUIRED_SURVEY.format(method="B"): [False, False, False, False, False],
-                DTSC.SITE_DEPLOYMENT.format(method="B"): [True, True, True, True, True],
-                DTSC.METHOD_MEASURED.format(method="B"): [False, False, False, False, False],
-            },
-        ),
-        (
-            [
-                MockSite(1, "A", False, 5),
-                MockSite(1, "A", False, 5),
-                MockSite(1, "A", False, 5),
-                MockSite(1, "A", False, 5),
-                MockSite(1, "A", False, 5),
-            ],
-            METHODS_PARAMS,
-            {
-                DTSC.SITE_ID: [1, 1, 1, 1, 1],
-                DTSC.SITE_TYPE: ["A", "A", "A", "A", "A"],
-                DTSC.REQUIRED_SURVEY.format(method="A"): [True, True, True, True, True],
-                DTSC.SITE_DEPLOYMENT.format(method="A"): [False, False, False, False, False],
-                DTSC.METHOD_MEASURED.format(method="A"): [False, False, False, False, False],
-                DTSC.REQUIRED_SURVEY.format(method="B"): [True, True, True, True, True],
-                DTSC.SITE_DEPLOYMENT.format(method="B"): [False, False, False, False, False],
-                DTSC.METHOD_MEASURED.format(method="B"): [False, False, False, False, False],
-            },
-        ),
-        (
-            [
-                MockSite(1, "A", False, 5),
-                MockSite(1, "A", True, 5),
-                MockSite(1, "A", False, 5),
-                MockSite(1, "A", True, 5),
-                MockSite(1, "A", False, 5),
-            ],
-            METHODS_PARAMS,
-            {
-                DTSC.SITE_ID: [1, 1, 1, 1, 1],
-                DTSC.SITE_TYPE: ["A", "A", "A", "A", "A"],
-                DTSC.REQUIRED_SURVEY.format(method="A"): [True, True, True, True, True],
-                DTSC.SITE_DEPLOYMENT.format(method="A"): [False, True, False, True, False],
-                DTSC.METHOD_MEASURED.format(method="A"): [False, True, False, True, False],
-                DTSC.REQUIRED_SURVEY.format(method="B"): [True, True, True, True, True],
-                DTSC.SITE_DEPLOYMENT.format(method="B"): [False, True, False, True, False],
-                DTSC.METHOD_MEASURED.format(method="B"): [False, True, False, True, False],
-            },
-        ),
+        "mock_sites_all_true_deploy_survey_fix",
+        "mock_sites_all_true_deploy_survey_stationary_fix",
+        "mock_sites_all_true_deploy_survey_followup_fix",
+        "mock_sites_true_deploy_false_survey_fix",
+        "mock_sites_false_deploy_true_survey_fix",
+        "mock_sites_mix_deploy_mix_survey_fix",
     ],
 )
-def test_generation_tf_sites(monkeypatch, mock_site, methods_params, expected_data):
+def test_generation_tf_sites(request, fixture_data, monkeypatch):
     """
     Test that the generation of the true/false site list is correct
     """
+    mock_site, methods_params, expected_data = request.getfixturevalue(fixture_data)
     monkeypatch.setattr(
         "src.virtual_world.infrastructure.Infrastructure.__init__",
         lambda self, virtual_world, methods, in_dir, site_measured_df: mock_infrastructure_initialization(  # noqa
@@ -261,8 +280,6 @@ def test_generation_tf_sites(monkeypatch, mock_site, methods_params, expected_da
     infra = Infrastructure({}, methods_params, None, site_tf_df)
 
     infra.gen_site_measured_tf_data(methods_params, site_tf_df)
-
-    expected: pd.DataFrame = pd.DataFrame(expected_data)
 
     expected: pd.DataFrame = pd.DataFrame(expected_data)
 

--- a/LDAR_Sim/testing/unit_testing/test_virtual_world/test_infrastructure/test_populate_tf_site.py
+++ b/LDAR_Sim/testing/unit_testing/test_virtual_world/test_infrastructure/test_populate_tf_site.py
@@ -31,15 +31,61 @@ EXPECTED_COLUMNS = [
     DTSC.SITE_TYPE,
     DTSC.REQUIRED_SURVEY.format(method="A"),
     DTSC.SITE_DEPLOYMENT.format(method="A"),
-    DTSC.SITE_MEASURED.format(method="A"),
+    DTSC.METHOD_MEASURED.format(method="A"),
     DTSC.REQUIRED_SURVEY.format(method="B"),
     DTSC.SITE_DEPLOYMENT.format(method="B"),
-    DTSC.SITE_MEASURED.format(method="B"),
+    DTSC.METHOD_MEASURED.format(method="B"),
 ]
 
 METHODS_PARAMS: dict = {
-    "A": {"parameter_level": "methods", "version": "4.0", "method_name": "A"},
-    "B": {"parameter_level": "methods", "version": "4.0", "method_name": "B"},
+    "A": {
+        "parameter_level": "methods",
+        "version": "4.0",
+        "method_name": "A",
+        "is_follow_up": False,
+        "deployment_type": "mobile",
+    },
+    "B": {
+        "parameter_level": "methods",
+        "version": "4.0",
+        "method_name": "B",
+        "is_follow_up": False,
+        "deployment_type": "mobile",
+    },
+}
+
+METHODS_PARAMS_FOLLOW_UP: dict = {
+    "A": {
+        "parameter_level": "methods",
+        "version": "4.0",
+        "method_name": "A",
+        "is_follow_up": True,
+        "deployment_type": "mobile",
+    },
+    "B": {
+        "parameter_level": "methods",
+        "version": "4.0",
+        "method_name": "B",
+        "is_follow_up": False,
+        "deployment_type": "mobile",
+    },
+}
+
+METHODS_PARAMS_STATIONARY: dict = {
+    "A": {
+        "parameter_level": "methods",
+        "version": "4.0",
+        "method_name": "A",
+        "is_follow_up": False,
+        "deployment_type": "stationary",
+    },
+    "B": {
+        "parameter_level": "methods",
+        "version": "4.0",
+        "method_name": "B",
+        "is_follow_up": False,
+        "deployment_type": "mobile",
+    },
 }
 
 
@@ -84,10 +130,107 @@ def test_simple_generation_tf_sites(monkeypatch):
         DTSC.SITE_TYPE: ["A", "A", "A", "A", "A"],
         DTSC.REQUIRED_SURVEY.format(method="A"): [True, True, True, True, True],
         DTSC.SITE_DEPLOYMENT.format(method="A"): [True, True, True, True, True],
-        DTSC.SITE_MEASURED.format(method="A"): [True, True, True, True, True],
+        DTSC.METHOD_MEASURED.format(method="A"): [True, True, True, True, True],
         DTSC.REQUIRED_SURVEY.format(method="B"): [True, True, True, True, True],
         DTSC.SITE_DEPLOYMENT.format(method="B"): [True, True, True, True, True],
-        DTSC.SITE_MEASURED.format(method="B"): [True, True, True, True, True],
+        DTSC.METHOD_MEASURED.format(method="B"): [True, True, True, True, True],
+    }
+    expected: pd.DataFrame = pd.DataFrame(data)
+
+    assert list(site_tf_df.columns) == list(expected.columns)
+    assert len(site_tf_df) == len(expected)
+    pd.testing.assert_frame_equal(site_tf_df, expected, check_index_type=False, check_dtype=False)
+
+def test_simple_generation_tf_sites_stationary(monkeypatch):
+    """
+    Test that the generation of the true/false site list is correct
+    """
+
+    class MockSite:
+        def get_id(self):
+            return 1
+
+        def get_type(self):
+            return "A"
+
+        def do_site_deployment(self, method):
+            return True
+
+        def get_required_surveys(self, method):
+            return 2
+
+    def mock_infrastructure_initialization(self, virtual_world, methods, in_dir, site_measured_df):
+        self._sites = [MockSite() for _ in range(5)]
+
+    monkeypatch.setattr(
+        "src.virtual_world.infrastructure.Infrastructure.__init__",
+        mock_infrastructure_initialization,
+    )
+
+    site_tf_df = make_empty_df()
+
+    infra = Infrastructure({}, METHODS_PARAMS_STATIONARY, None, site_tf_df)
+
+    infra.gen_site_measured_tf_data(METHODS_PARAMS_STATIONARY, site_tf_df)
+
+    data = {
+        DTSC.SITE_ID: [1, 1, 1, 1, 1],
+        DTSC.SITE_TYPE: ["A", "A", "A", "A", "A"],
+        DTSC.REQUIRED_SURVEY.format(method="A"): [True, True, True, True, True],
+        DTSC.SITE_DEPLOYMENT.format(method="A"): [True, True, True, True, True],
+        DTSC.METHOD_MEASURED.format(method="A"): [True, True, True, True, True],
+        DTSC.REQUIRED_SURVEY.format(method="B"): [True, True, True, True, True],
+        DTSC.SITE_DEPLOYMENT.format(method="B"): [True, True, True, True, True],
+        DTSC.METHOD_MEASURED.format(method="B"): [True, True, True, True, True],
+    }
+    expected: pd.DataFrame = pd.DataFrame(data)
+
+    assert list(site_tf_df.columns) == list(expected.columns)
+    assert len(site_tf_df) == len(expected)
+    pd.testing.assert_frame_equal(site_tf_df, expected, check_index_type=False, check_dtype=False)
+
+
+def test_simple_generation_tf_sites_for_followup(monkeypatch):
+    """
+    Test that the generation of the true/false site list is correct
+    """
+
+    class MockSite:
+        def get_id(self):
+            return 1
+
+        def get_type(self):
+            return "A"
+
+        def do_site_deployment(self, method):
+            return True
+
+        def get_required_surveys(self, method):
+            return 2
+
+    def mock_infrastructure_initialization(self, virtual_world, methods, in_dir, site_measured_df):
+        self._sites = [MockSite() for _ in range(5)]
+
+    monkeypatch.setattr(
+        "src.virtual_world.infrastructure.Infrastructure.__init__",
+        mock_infrastructure_initialization,
+    )
+
+    site_tf_df = make_empty_df()
+
+    infra = Infrastructure({}, METHODS_PARAMS_FOLLOW_UP, None, site_tf_df)
+
+    infra.gen_site_measured_tf_data(METHODS_PARAMS_FOLLOW_UP, site_tf_df)
+
+    data = {
+        DTSC.SITE_ID: [1, 1, 1, 1, 1],
+        DTSC.SITE_TYPE: ["A", "A", "A", "A", "A"],
+        DTSC.REQUIRED_SURVEY.format(method="A"): [False, False, False, False, False],
+        DTSC.SITE_DEPLOYMENT.format(method="A"): [False, False, False, False, False],
+        DTSC.METHOD_MEASURED.format(method="A"): [False, False, False, False, False],
+        DTSC.REQUIRED_SURVEY.format(method="B"): [True, True, True, True, True],
+        DTSC.SITE_DEPLOYMENT.format(method="B"): [True, True, True, True, True],
+        DTSC.METHOD_MEASURED.format(method="B"): [True, True, True, True, True],
     }
     expected: pd.DataFrame = pd.DataFrame(data)
 
@@ -133,10 +276,10 @@ def test_simple_fail_generation_tf_sites(monkeypatch):
         DTSC.SITE_TYPE: ["A", "A", "A", "A", "A"],
         DTSC.REQUIRED_SURVEY.format(method="A"): [False, False, False, False, False],
         DTSC.SITE_DEPLOYMENT.format(method="A"): [True, True, True, True, True],
-        DTSC.SITE_MEASURED.format(method="A"): [False, False, False, False, False],
+        DTSC.METHOD_MEASURED.format(method="A"): [False, False, False, False, False],
         DTSC.REQUIRED_SURVEY.format(method="B"): [False, False, False, False, False],
         DTSC.SITE_DEPLOYMENT.format(method="B"): [True, True, True, True, True],
-        DTSC.SITE_MEASURED.format(method="B"): [False, False, False, False, False],
+        DTSC.METHOD_MEASURED.format(method="B"): [False, False, False, False, False],
     }
     expected: pd.DataFrame = pd.DataFrame(data)
 
@@ -182,10 +325,10 @@ def test_simple_fail_generation_tf_sites2(monkeypatch):
         DTSC.SITE_TYPE: ["A", "A", "A", "A", "A"],
         DTSC.REQUIRED_SURVEY.format(method="A"): [True, True, True, True, True],
         DTSC.SITE_DEPLOYMENT.format(method="A"): [False, False, False, False, False],
-        DTSC.SITE_MEASURED.format(method="A"): [False, False, False, False, False],
+        DTSC.METHOD_MEASURED.format(method="A"): [False, False, False, False, False],
         DTSC.REQUIRED_SURVEY.format(method="B"): [True, True, True, True, True],
         DTSC.SITE_DEPLOYMENT.format(method="B"): [False, False, False, False, False],
-        DTSC.SITE_MEASURED.format(method="B"): [False, False, False, False, False],
+        DTSC.METHOD_MEASURED.format(method="B"): [False, False, False, False, False],
     }
     expected: pd.DataFrame = pd.DataFrame(data)
 
@@ -233,10 +376,10 @@ def test_complex_generation_tf_sites(monkeypatch):
         DTSC.SITE_TYPE: ["A", "A", "A", "A", "A"],
         DTSC.REQUIRED_SURVEY.format(method="A"): [True, True, True, True, True],
         DTSC.SITE_DEPLOYMENT.format(method="A"): [False, True, False, True, False],
-        DTSC.SITE_MEASURED.format(method="A"): [False, True, False, True, False],
+        DTSC.METHOD_MEASURED.format(method="A"): [False, True, False, True, False],
         DTSC.REQUIRED_SURVEY.format(method="B"): [True, True, True, True, True],
         DTSC.SITE_DEPLOYMENT.format(method="B"): [False, True, False, True, False],
-        DTSC.SITE_MEASURED.format(method="B"): [False, True, False, True, False],
+        DTSC.METHOD_MEASURED.format(method="B"): [False, True, False, True, False],
     }
     expected: pd.DataFrame = pd.DataFrame(data)
 

--- a/LDAR_Sim/testing/unit_testing/test_virtual_world/test_infrastructure/test_set_up_tf_site.py
+++ b/LDAR_Sim/testing/unit_testing/test_virtual_world/test_infrastructure/test_set_up_tf_site.py
@@ -2,8 +2,7 @@
 ------------------------------------------------------------------------------
 Program:     The LDAR Simulator (LDAR-Sim)
 File:        test_populate_tf_site.py
-Purpose: Contains unit tests related to populating the true/false deployment
-site list data frame
+Purpose: Contains unit to ensure proper formatting of the true/false dataframe
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the MIT License as published

--- a/LDAR_Sim/testing/unit_testing/test_virtual_world/test_infrastructure/test_set_up_tf_site.py
+++ b/LDAR_Sim/testing/unit_testing/test_virtual_world/test_infrastructure/test_set_up_tf_site.py
@@ -1,0 +1,47 @@
+"""
+------------------------------------------------------------------------------
+Program:     The LDAR Simulator (LDAR-Sim)
+File:        test_populate_tf_site.py
+Purpose: Contains unit tests related to populating the true/false deployment
+site list data frame
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the MIT License as published
+by the Free Software Foundation, version 3.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+MIT License for more details.
+You should have received a copy of the MIT License
+along with this program.  If not, see <https://opensource.org/licenses/MIT>.
+
+------------------------------------------------------------------------------
+"""
+
+from src.ldar_sim_run import set_up_tf_df
+from src.constants.infrastructure_const import Deployment_TF_Sites_Constants as DTSC
+
+
+METHODS_PARAMS: dict = {
+    "A": {"parameter_level": "methods", "version": "4.0", "method_name": "A"},
+    "B": {"parameter_level": "methods", "version": "4.0", "method_name": "B"},
+}
+
+
+def test_set_up_tf_df():
+    n_sites: int = 5
+    result = set_up_tf_df(METHODS_PARAMS, n_sites)
+    expected_columns = [
+        DTSC.SITE_ID,
+        DTSC.SITE_TYPE,
+        DTSC.REQUIRED_SURVEY.format(method="A"),
+        DTSC.SITE_DEPLOYMENT.format(method="A"),
+        DTSC.SITE_MEASURED.format(method="A"),
+        DTSC.REQUIRED_SURVEY.format(method="B"),
+        DTSC.SITE_DEPLOYMENT.format(method="B"),
+        DTSC.SITE_MEASURED.format(method="B"),
+    ]
+
+    assert len(result) == 5
+    assert list(result.columns) == expected_columns

--- a/LDAR_Sim/testing/unit_testing/test_virtual_world/test_infrastructure/test_set_up_tf_site.py
+++ b/LDAR_Sim/testing/unit_testing/test_virtual_world/test_infrastructure/test_set_up_tf_site.py
@@ -18,7 +18,7 @@ along with this program.  If not, see <https://opensource.org/licenses/MIT>.
 ------------------------------------------------------------------------------
 """
 
-from src.ldar_sim_run import set_up_tf_df
+from src.utils.prog_method_measured_func import set_up_tf_method_deployed_df
 from src.constants.infrastructure_const import Deployment_TF_Sites_Constants as DTSC
 
 
@@ -30,7 +30,7 @@ METHODS_PARAMS: dict = {
 
 def test_set_up_tf_df():
     n_sites: int = 5
-    result = set_up_tf_df(METHODS_PARAMS, n_sites)
+    result = set_up_tf_method_deployed_df(METHODS_PARAMS, n_sites)
     expected_columns = [
         DTSC.SITE_ID,
         DTSC.SITE_TYPE,

--- a/LDAR_Sim/testing/unit_testing/test_virtual_world/test_infrastructure/test_set_up_tf_site.py
+++ b/LDAR_Sim/testing/unit_testing/test_virtual_world/test_infrastructure/test_set_up_tf_site.py
@@ -37,10 +37,10 @@ def test_set_up_tf_df():
         DTSC.SITE_TYPE,
         DTSC.REQUIRED_SURVEY.format(method="A"),
         DTSC.SITE_DEPLOYMENT.format(method="A"),
-        DTSC.SITE_MEASURED.format(method="A"),
+        DTSC.METHOD_MEASURED.format(method="A"),
         DTSC.REQUIRED_SURVEY.format(method="B"),
         DTSC.SITE_DEPLOYMENT.format(method="B"),
-        DTSC.SITE_MEASURED.format(method="B"),
+        DTSC.METHOD_MEASURED.format(method="B"),
     ]
 
     assert len(result) == 5


### PR DESCRIPTION
# Pull Request Key Information

## Reason for change

Part 1 of a set of changes needed to allow for a better estimate when only deploying at part of the full infrastructure.

## What was changed

Added additional column to the estimated_emissions.csv that provides a True/False value on if the given site has been measured or not, and the site_type. 
Fixed a bug where the site_type was not making it into the Site initialization.

## Intended Purpose

Part one of a set of changes.

## Testing Completed

Added unit tests for the relevant new functions. 
All unit tests pass. 
[results.txt](https://github.com/user-attachments/files/15814229/results.txt)

Did not unit test the join of the produced dataframe with the output dataframe, as it was just a single pandas join function and the output could be checked with the csv. 

Ran the simple simulation case 1 which had  stationary, OGI and follow-up methods. 