### PR TITLE
Removed unused cost parameters

### DIFF
--- a/LDAR_Sim/src/default_parameters/p_default.yml
+++ b/LDAR_Sim/src/default_parameters/p_default.yml
@@ -3,10 +3,8 @@ parameter_level: "programs"
 program_name: "default"
 method_labels: []
 economics:
-  carbon_price_tonnes_CO2_equivalent: 65.0
   global_warming_potential_CH4: 28.0
   sale_price_of_natural_gas: 3.0
-  verification_cost: 0
 duration_estimate:
   duration_factor: 1
   duration_method: "component-based" # component-based or measurement-based-conservative


### PR DESCRIPTION
# Pull Request Key Information

## Reason for change

Some cost parameters are no longer in use with v4 outputs, they may get reintroduced in the future

## What was changed

Removed unused parameters

## Intended Purpose

Removed unused parameters

## Testing Completed

Ran sample simulations
All unit tests pass
[results.txt](https://github.com/user-attachments/files/15877159/results.txt)

