### PR TITLE
fix: Resolve Error from having no repairable emissions

### DIFF
--- a/LDAR_Sim/src/file_processing/output_processing/summary_outputs.py
+++ b/LDAR_Sim/src/file_processing/output_processing/summary_outputs.py
@@ -42,7 +42,12 @@ def summarize_program_outputs(
                 )
             ):
                 new_summary_row: dict[str, Any] = {}
-                data = pd.read_csv(entry.path)
+                # Check to make sure the entry is not empty before reading it
+                # If it is empty, initialize the data variable to an empty dataframe
+                try:
+                    data = pd.read_csv(entry.path)
+                except pd.errors.EmptyDataError:
+                    data = pd.DataFrame()
                 new_summary_row[
                     output_file_constants.SummaryFileColumns.CommonColumns.PROGRAM_NAME
                 ] = (


### PR DESCRIPTION
# Pull Request Key Information

## Reason for change

An error from attempting to read in empty data was occurring when simulating a scenario with no repairable emissions.

## What was changed

Added an except block to catch the error and instead initialize the repairable emissions dataframe with an empty dataframe.

## Intended Purpose

This change will allow the simulation to run without error when no repairable emissions are present.

## Level of version change required

Patch to 4.0.1

## Testing Completed

All unit tests pass: 
[unit_test_results.txt](https://github.com/user-attachments/files/15904577/unit_test_results.txt)
Error was resolved in manual test.

## Target Issue

N/A

## Additional Information

N/A
