### PR TITLE
<ENH>: Remove mitigation plots when no mitigation

### DIFF
--- a/LDAR_Sim/src/file_processing/output_processing/summary_visualization_helpers.py
+++ b/LDAR_Sim/src/file_processing/output_processing/summary_visualization_helpers.py
@@ -180,7 +180,7 @@ def gen_annual_mitigation_summary_list(
         mit_ann_columns = mit_ann_columns[1:]
 
     annual_mitigation_lists = {}
-    there_is_mitigation = False
+    is_there_mitigation = False
     for program_name in program_names:
         mitigation_list = np.ravel(
             emis_summary_info.loc[
@@ -191,14 +191,15 @@ def gen_annual_mitigation_summary_list(
         ).tolist()
         # Check if there is any mitigation in the program only
         # if there has not been any mitigation found yet
-        if not there_is_mitigation:
-            there_is_mitigation = is_list_non_zero(mitigation_list)
+        if not is_there_mitigation:
+            is_there_mitigation = is_list_non_zero(mitigation_list)
         annual_mitigation_lists[program_name] = mitigation_list
     # If there is mitigation, return the mitigation lists
-    if there_is_mitigation:
+    if is_there_mitigation:
         return annual_mitigation_lists
-    # Return none if there is no mitigation in any program
-    return None
+    else:
+        # Return none if there is no mitigation in any program
+        return None
 
 
 def is_list_non_zero(list) -> bool:

--- a/LDAR_Sim/src/file_processing/output_processing/summary_visualization_helpers.py
+++ b/LDAR_Sim/src/file_processing/output_processing/summary_visualization_helpers.py
@@ -180,7 +180,7 @@ def gen_annual_mitigation_summary_list(
         mit_ann_columns = mit_ann_columns[1:]
 
     annual_mitigation_lists = {}
-
+    there_is_mitigation = False
     for program_name in program_names:
         mitigation_list = np.ravel(
             emis_summary_info.loc[
@@ -189,9 +189,20 @@ def gen_annual_mitigation_summary_list(
                 mit_ann_columns,
             ].values
         ).tolist()
-
+        # Check if there is any mitigation in the program only
+        # if there has not been any mitigation found yet
+        if not there_is_mitigation:
+            there_is_mitigation = is_list_non_zero(mitigation_list)
         annual_mitigation_lists[program_name] = mitigation_list
-    return annual_mitigation_lists
+    # If there is mitigation, return the mitigation lists
+    if there_is_mitigation:
+        return annual_mitigation_lists
+    # Return none if there is no mitigation in any program
+    return None
+
+
+def is_list_non_zero(list) -> bool:
+    return all(item != 0 for item in list)
 
 
 def gen_true_estimated_annualized_statistics(

--- a/LDAR_Sim/src/file_processing/output_processing/summary_visualizations.py
+++ b/LDAR_Sim/src/file_processing/output_processing/summary_visualizations.py
@@ -549,7 +549,9 @@ def gen_program_mitigation_bars(
     annual_mitigation_data: dict[str, list[float]] = (
         summary_visualization_helpers.gen_annual_mitigation_summary_list(data, program_names)
     )
-
+    # if no mitigation data was found, return
+    if annual_mitigation_data is None:
+        return
     plot_bar_chart(
         annual_mitigation_data,
         visualization_dir,
@@ -576,6 +578,12 @@ def gen_cost_to_mit_boxplot(
             output_file_constants.COST_SUMMARY_COLUMNS_ACCESSORS.MITIGATION_RATIO,
         ]
     ]
+    # Mitigation ratio will be infinite if there is no mitigation.
+    # if all mitigation ratios are infinite, do not plot.
+    if np.isinf(
+        filtered_data[output_file_constants.COST_SUMMARY_COLUMNS_ACCESSORS.MITIGATION_RATIO]
+    ).all():
+        return
 
     plot_box_whisker(
         filtered_data,

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 2024-06-19 - Version 4.0.2
+
+1. Mitigation related plots will automatically not be rendered when there are no mitigation in the simulation.
+
 ## 2024-06-19 - Version 4.0.1
 
 1. Fixed an Issue where users would encounter an error when trying to simulate only non-repairable emissions

--- a/changelog.md
+++ b/changelog.md
@@ -1,8 +1,9 @@
 # Change Log
 
-## 2024-06-19 - Version 4.0.2
+## 2024-06-120 - Version 4.0.2
 
 1. Mitigation related plots will automatically not be rendered when there are no mitigation in the simulation.
+2. Updated the sensitivity analysis module script to be in line with the ldar_sim_run script
 
 ## 2024-06-19 - Version 4.0.1
 


### PR DESCRIPTION
# Pull Request Key Information

## Reason for change

Plots that require mitigation values break when there is no mitigation (all emissions are non-repairable in simulation)

## What was changed

Added checks for the cost to mitigation plot and the mitigation bar chart to ensure that they are only made when there are values to graph.

## Intended Purpose

Remove visualizations that require mitigation numbers when there is no mitigation.

## Level of version change required

Patch bump.

## Testing Completed

All unit tests pass. 
[results.txt](https://github.com/user-attachments/files/15906182/results.txt)

Ran manual simulation where there were only non-repairable emissions.
Ran manual simulation where there were both repairable and non-repairable emissions. 

## Target Issue

Closes #222 

