### PR TITLE
fix: Fix bug in metric prefix formatter

### DIFF
--- a/LDAR_Sim/src/file_processing/output_processing/summary_visualization_helpers.py
+++ b/LDAR_Sim/src/file_processing/output_processing/summary_visualization_helpers.py
@@ -41,6 +41,8 @@ def format_tick_labels_with_metric_prefix(x, pos):
     """
     Function to format tick labels as words with metric prefixes
     """
+    if abs(x) < 1:
+        return "{:.1f}".format(x)
     powers = [18, 15, 12, 9, 6, 3, 0]
     label = ["H", "Q", "T", "B", "M", "K", ""]
     for i, power in enumerate(powers):


### PR DESCRIPTION
# Pull Request Key Information

## Reason for change

There was a bug in the metric prefix formatter that was causing the tick labels to be incorrect.
This was due to the fact that the formatter was not correctly handling the case where the value was between -1 and 1, resulting in any ticks in that range being lost.

## What was changed

Added a check to the metric prefix formatter to handle the case where the value is between -1 and 1. This ensures that the tick labels are correctly displayed.

## Intended Purpose

The tick labels are now correctly displayed on the visualization.

## Level of version change required

Patch bump

## Testing Completed

Manually tested to ensure all values now returning as expected.

All unit tests passing: 
[unit_test_results.txt](https://github.com/user-attachments/files/15960706/unit_test_results.txt)


## Target Issue

N/A

## Additional Information

N/A
