### PR TITLE
fix: Fix bug with equipment group survey scaling

### DIFF
--- a/LDAR_Sim/src/constants/infrastructure_const.py
+++ b/LDAR_Sim/src/constants/infrastructure_const.py
@@ -84,6 +84,16 @@ class Infrastructure_Constants:
             DEPLOYMENT_YEARS_PLACEHOLDER,
         ]
 
+        PROPAGATING_PARAMS_TO_SCALE: list[str] = [
+            REP_EMIS_EPR,
+            NON_REP_EMIS_EPR,
+        ]
+
+        METH_SPEC_PROP_PARAMS_TO_SCALE: list[str] = [
+            SURVEY_COST_PLACEHOLDER,
+            SURVEY_TIME_PLACEHOLDER,
+        ]
+
         REQUIRED_HEADERS: list[str] = [ID, LAT, LON, TYPE]
 
         OPTIONAL_SHARED_HEADERS: list[str] = [EQG]

--- a/LDAR_Sim/src/virtual_world/sites.py
+++ b/LDAR_Sim/src/virtual_world/sites.py
@@ -158,20 +158,20 @@ class Site:
                     == equipment_group
                 ].iloc[0]
                 prop_params = copy.deepcopy(propagating_params)
-                if (
-                    prop_params[Infrastructure_Constants.Sites_File_Constants.REP_EMIS_EPR]
-                    is not None
-                ):
-                    prop_params[
-                        Infrastructure_Constants.Sites_File_Constants.REP_EMIS_EPR
-                    ] /= equip_count
-                if (
-                    prop_params[Infrastructure_Constants.Sites_File_Constants.NON_REP_EMIS_EPR]
-                    is not None
-                ):
-                    prop_params[
-                        Infrastructure_Constants.Sites_File_Constants.NON_REP_EMIS_EPR
-                    ] /= equip_count
+                for (
+                    param
+                ) in Infrastructure_Constants.Sites_File_Constants.PROPAGATING_PARAMS_TO_SCALE:
+                    if prop_params[param] is not None:
+                        prop_params[param] /= equip_count
+
+                for (
+                    param
+                ) in Infrastructure_Constants.Sites_File_Constants.METH_SPEC_PROP_PARAMS_TO_SCALE:
+                    for method in prop_params[pdc.Common_Params.METH_SPECIFIC][param]:
+                        if prop_params[pdc.Common_Params.METH_SPECIFIC][param][method] is not None:
+                            prop_params[pdc.Common_Params.METH_SPECIFIC][param][
+                                method
+                            ] /= equip_count
 
                 self._equipment_groups.append(
                     Equipment_Group(
@@ -260,14 +260,20 @@ class Site:
                     {placeholder: math.ceil(equip_count / equipment_groups)}
                 )
                 prop_params = copy.deepcopy(propagating_params)
-                if rep_emis_epr is not None and rep_emis_epr > 0:
-                    prop_params[Infrastructure_Constants.Sites_File_Constants.REP_EMIS_EPR] = (
-                        rep_emis_epr / equipment_groups
-                    )
-                if nonrep_emis_epr is not None and nonrep_emis_epr > 0:
-                    prop_params[Infrastructure_Constants.Sites_File_Constants.NON_REP_EMIS_EPR] = (
-                        nonrep_emis_epr / equipment_groups
-                    )
+                for (
+                    param
+                ) in Infrastructure_Constants.Sites_File_Constants.PROPAGATING_PARAMS_TO_SCALE:
+                    if prop_params[param] is not None:
+                        prop_params[param] /= equipment_groups
+                for (
+                    param
+                ) in Infrastructure_Constants.Sites_File_Constants.METH_SPEC_PROP_PARAMS_TO_SCALE:
+                    for method in prop_params[pdc.Common_Params.METH_SPECIFIC][param]:
+                        if prop_params[pdc.Common_Params.METH_SPECIFIC][param][method] is not None:
+                            prop_params[pdc.Common_Params.METH_SPECIFIC][param][
+                                method
+                            ] /= equipment_groups
+
                 self._equipment_groups.append(
                     Equipment_Group(i, infrastructure_inputs, prop_params, equip_group_info)
                 )

--- a/LDAR_Sim/src/virtual_world/sites.py
+++ b/LDAR_Sim/src/virtual_world/sites.py
@@ -71,14 +71,14 @@ class Site:
         self._deployment_years = propagating_params[pdc.Common_Params.METH_SPECIFIC].pop(
             Infrastructure_Constants.Sites_File_Constants.DEPLOYMENT_YEARS_PLACEHOLDER
         )
+        self._deploy_method: dict[str, bool] = propagating_params[
+            pdc.Common_Params.METH_SPECIFIC
+        ].pop(Infrastructure_Constants.Sites_File_Constants.SITE_DEPLOYMENT_PLACEHOLDER)
         self._equipment_groups: list[Equipment_Group] = []
         self._survey_costs: dict[str, float] = {}
         self._create_equipment_groups(equipment_groups, infrastructure_inputs, propagating_params)
         self._set_survey_costs(methods=methods)
         self._latest_tagging_survey_date: date = start_date
-        self._deploy_method: dict[str, bool] = propagating_params[
-            pdc.Common_Params.METH_SPECIFIC
-        ].pop(Infrastructure_Constants.Sites_File_Constants.SITE_DEPLOYMENT_PLACEHOLDER)
 
     def __reduce__(self):
         args = (

--- a/LDAR_Sim/testing/unit_testing/test_virtual_world/test_sites/test_sites_constructor.py
+++ b/LDAR_Sim/testing/unit_testing/test_virtual_world/test_sites/test_sites_constructor.py
@@ -1,8 +1,70 @@
 from typing import Tuple
+from constants.infrastructure_const import Infrastructure_Constants
+from constants.param_default_const import Common_Params as cp
 from src.virtual_world.sites import Site
+from virtual_world.equipment_groups import Equipment_Group
 from testing.unit_testing.test_virtual_world.test_sites.sites_testing_fixtures import (  # noqa
     mock_values_for_simple_site_construction_fix,
 )
+
+
+def get_mock_propagating_params_and_expected_equipment_split(
+    equipment_count: int,
+) -> Tuple[dict, dict]:
+    # Set site level values for propagating parameters that need to be split among equipment groups
+    rep_emis_epr: float = 1.0
+    non_rep_emis_epr: float = 1.0
+    survey_cost_placeholder: dict = {"test": 1.0}
+    survey_time_placeholder: dict = {"test": 1.0}
+    # Calculate the expected values for those parameters at the equipment group level
+    rep_emis_epr_equip: float = rep_emis_epr / equipment_count
+    non_rep_emis_epr_equip = non_rep_emis_epr / equipment_count
+    survey_cost_placeholder_equip: dict = {"test": 1.0 / equipment_count}
+    survey_time_placeholder_equip: dict = {"test": 1.0 / equipment_count}
+    return (
+        {
+            Infrastructure_Constants.Sites_File_Constants.REP_EMIS_ERS: {"test": [1]},
+            Infrastructure_Constants.Sites_File_Constants.REP_EMIS_EPR: 1,
+            Infrastructure_Constants.Sites_File_Constants.REP_EMIS_ED: 1,
+            Infrastructure_Constants.Sites_File_Constants.REP_EMIS_MULTI: True,
+            Infrastructure_Constants.Sites_File_Constants.NON_REP_EMIS_MULTI: True,
+            Infrastructure_Constants.Sites_File_Constants.NON_REP_EMIS_EPR: non_rep_emis_epr,
+            Infrastructure_Constants.Sites_File_Constants.NON_REP_EMIS_ERS: None,
+            Infrastructure_Constants.Sites_File_Constants.REP_EMIS_RD: {cp.VAL: 0},
+            Infrastructure_Constants.Sites_File_Constants.REP_EMIS_RC: {cp.VAL: 100},
+            cp.METH_SPECIFIC: {
+                Infrastructure_Constants.Sites_File_Constants.SURVEY_FREQUENCY_PLACEHOLDER: {},
+                Infrastructure_Constants.Sites_File_Constants.SPATIAL_PLACEHOLDER: {},
+                Infrastructure_Constants.Sites_File_Constants.DEPLOYMENT_MONTHS_PLACEHOLDER: {},
+                Infrastructure_Constants.Sites_File_Constants.DEPLOYMENT_YEARS_PLACEHOLDER: {},
+                Infrastructure_Constants.Sites_File_Constants.SURVEY_FREQUENCY_PLACEHOLDER: {},
+                Infrastructure_Constants.Sites_File_Constants.SITE_DEPLOYMENT_PLACEHOLDER: {},
+                (
+                    Infrastructure_Constants.Equipment_Group_File_Constants.SURVEY_TIME_PLACEHOLDER
+                ): survey_time_placeholder,
+                (
+                    Infrastructure_Constants.Equipment_Group_File_Constants.SURVEY_COST_PLACEHOLDER
+                ): survey_cost_placeholder,
+            },
+        },
+        {
+            Infrastructure_Constants.Sites_File_Constants.REP_EMIS_EPR: rep_emis_epr_equip,
+            Infrastructure_Constants.Sites_File_Constants.NON_REP_EMIS_EPR: non_rep_emis_epr_equip,
+            cp.METH_SPECIFIC: {
+                (
+                    Infrastructure_Constants.Equipment_Group_File_Constants.SURVEY_TIME_PLACEHOLDER
+                ): survey_time_placeholder_equip,
+                (
+                    Infrastructure_Constants.Equipment_Group_File_Constants.SURVEY_COST_PLACEHOLDER
+                ): survey_cost_placeholder_equip,
+                Infrastructure_Constants.Sites_File_Constants.SPATIAL_PLACEHOLDER: {},
+            },
+        },
+    )
+
+
+def mock_equipment_group_init(self, id, infrastructure_inputs, prop_params, info):
+    self.propagating_params = prop_params
 
 
 def test_000_simple_site_is_properly_constructed(
@@ -22,3 +84,30 @@ def test_000_simple_site_is_properly_constructed(
         methods=method,
     )
     assert isinstance(test_site, Site)
+
+
+def test_000_site_properties_properly_split_among_equipment_groups(
+    monkeypatch, mock_values_for_simple_site_construction: Tuple[str, float, float, int, dict, dict]
+):
+    monkeypatch.setattr(Equipment_Group, "__init__", mock_equipment_group_init)
+
+    id, lat, lon, start_date, _, _, site_info, method = mock_values_for_simple_site_construction
+    equipment_groups: int = 3
+    prop_params, split_params = get_mock_propagating_params_and_expected_equipment_split(
+        equipment_groups
+    )
+
+    test_site = Site(
+        id=id,
+        lat=lat,
+        long=lon,
+        start_date=start_date,
+        equipment_groups=equipment_groups,
+        propagating_params=prop_params,
+        infrastructure_inputs=site_info,
+        methods=method,
+    )
+
+    for equip_group in test_site.equipment_groups:
+        for key, param in split_params.items():
+            assert equip_group.propagating_params[key] == param

--- a/LDAR_Sim/testing/unit_testing/test_virtual_world/test_sites/test_sites_constructor.py
+++ b/LDAR_Sim/testing/unit_testing/test_virtual_world/test_sites/test_sites_constructor.py
@@ -1,3 +1,23 @@
+"""
+------------------------------------------------------------------------------
+Program:     The LDAR Simulator (LDAR-Sim)
+File:        test_sites_constructor.py
+Purpose:    Contains unit tests for the Site class constructor
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the MIT License as published
+by the Free Software Foundation, version 3.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+MIT License for more details.
+You should have received a copy of the MIT License
+along with this program.  If not, see <https://opensource.org/licenses/MIT>.
+
+------------------------------------------------------------------------------
+"""
+
 from typing import Tuple
 from constants.infrastructure_const import Infrastructure_Constants
 from constants.param_default_const import Common_Params as cp


### PR DESCRIPTION
# Pull Request Key Information

## Reason for change

Survey times and cost were not being properly proportionally propagated down when using equipment groups. This resulted in inflated survey times and costs when using equipment groups.

## What was changed

Survey times and costs are now properly scaled down when using equipment groups. This is done by scaling the survey times and costs of the equipment group by the number of equipment groups.

## Intended Purpose

Equipment group survey times and costs are now fixed and properly functioning.

## Level of version change required

Patch to next patch version

## Testing Completed

Manual testing. 

All unit tests passing:
 [unit_test_results.txt](https://github.com/user-attachments/files/16037272/unit_test_results.txt)


## Target Issue
N/A

## Additional Information

N/A
