### PR TITLE
fix: Fixed summary output creation failure bug

### DIFF
--- a/LDAR_Sim/src/file_processing/output_processing/summary_output_helpers.py
+++ b/LDAR_Sim/src/file_processing/output_processing/summary_output_helpers.py
@@ -150,13 +150,17 @@ def clear_directory(dir: Path):
 
 
 def mark_outputs_to_keep(dir: Path):
+    rename_operations: list[tuple[str, str]] = []
     with os.scandir(dir) as entries:
         for entry in entries:
             if entry.is_file():
                 old_file_path = entry.path
                 new_name = file_processing_const.Multi_Sim_Output_Const.OUTPUT_KEEP_STR + entry.name
                 new_file_path = os.path.join(dir, new_name)
-                os.rename(old_file_path, new_file_path)
+                rename_operations.append((old_file_path, new_file_path))
+
+    for old_file_path, new_file_path in rename_operations:
+        os.rename(old_file_path, new_file_path)
 
 
 def get_non_baseline_prog_names(programs, baseline_program) -> list:

--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,13 @@
 # Change Log
 
-## 2024-06-120 - Version 4.0.2
+## 2024-07-02 - Version 4.0.3
+
+1. Fixed potential crew shortage warning message
+2. Fixed tick labels on output visualizations to show numbers between -1 to 1, specifically 0 when using metric prefixes
+3. Added option to disable program specific visualizations
+4. Fixed error that would sometimes occur with summary output generation
+
+## 2024-06-20 - Version 4.0.2
 
 1. Mitigation related plots will automatically not be rendered when there are no mitigation in the simulation.
 2. Updated the sensitivity analysis module script to be in line with the ldar_sim_run script


### PR DESCRIPTION
# Pull Request Key Information

## Reason for change

Summary output creation would sometimes fail due a bug in the code. This bug was caused by the code not properly handling renaming and keeping non-summary output files.

## What was changed

Fixed code to rename and keep non-summary output files to prevent summary output creation failure.

## Intended Purpose

Summary output creation will no longer fail due to a bug.

## Level of version change required

Patch to next patch version

## Testing Completed

Manual testing

All unit tests passing:
[unit_test_results.txt](https://github.com/user-attachments/files/16070424/unit_test_results.txt)

## Target Issue

N/A

## Additional Information

N/A
