### PR TITLE
<UPD>: Update default parameter data types

### DIFF
--- a/LDAR_Sim/src/default_parameters/m_default_mobile.yml
+++ b/LDAR_Sim/src/default_parameters/m_default_mobile.yml
@@ -13,9 +13,9 @@ coverage:
   spatial: 1.0 # 0.0 to 1.0
   temporal: 1.0 # 0.0 to 1.0
 cost:
-  per_day: 0
-  per_site: 0 # MOBILE ONLY
-  upfront: 0
+  per_day: 0.0
+  per_site: 0.0 # MOBILE ONLY
+  upfront: 0.0
 crew_count: 0 # whole numbers - MOBILE ONLY
 consider_daylight: False
 surveys_per_year: "_placeholder_int_" # days - MOBILE ONLY

--- a/LDAR_Sim/src/default_parameters/m_default_stationary.yml
+++ b/LDAR_Sim/src/default_parameters/m_default_stationary.yml
@@ -13,8 +13,8 @@ coverage:
   spatial: 1.0 # 0.0 to 1.0
   temporal: 1.0 # 0.0 to 1.0
 cost:
-  per_day: 0
-  upfront: 0
+  per_day: 0.0
+  upfront: 0.0
 consider_daylight: False
 reporting_delay: 2 # days
 scheduling:

--- a/LDAR_Sim/src/default_parameters/p_default.yml
+++ b/LDAR_Sim/src/default_parameters/p_default.yml
@@ -6,5 +6,5 @@ economics:
   global_warming_potential_CH4: 28.0
   sale_price_of_natural_gas: 3.0
 duration_estimate:
-  duration_factor: 1
+  duration_factor: 1.0 # A value between 0.0 and 1.0
   duration_method: "component-based" # component-based or measurement-based-conservative

--- a/LDAR_Sim/src/default_parameters/virtual_world_default.yml
+++ b/LDAR_Sim/src/default_parameters/virtual_world_default.yml
@@ -14,7 +14,7 @@ consider_weather: False # True/False
 weather_file: "_placeholder_str_"
 repairs:
   cost:
-    values: [200]
+    values: [200.0]
     file: "_placeholder_str_"
   delay:
     file: "_placeholder_str_" # The file containing sample repair delays, if it exists


### PR DESCRIPTION
# Pull Request Key Information

## Reason for change

Parameters that should have a float datatype were
set to int datatype. This change updates the
default parameter files to have the correct datatype.

## What was changed

Update the existing parameters to have the correct data type

## Intended Purpose

Prevent the bug where values when set to a float prevented the simulation from running.

## Level of version change required

Patch

## Testing Completed

Manually tested that simulation ran when costs and duration factor were set to both an integer and a float. 

All unit tests pass.
[results.txt](https://github.com/user-attachments/files/16090138/results.txt)
