### PR TITLE
fix: Fix error when setting equip properties

### DIFF
--- a/LDAR_Sim/src/constants/infrastructure_const.py
+++ b/LDAR_Sim/src/constants/infrastructure_const.py
@@ -123,6 +123,25 @@ class Infrastructure_Constants:
         SURVEY_COST_PLACEHOLDER = "_survey_cost"  # Survey Cost - Method specific
         SPATIAL_PLACEHOLDER = "_spatial"  # Spatial coverage - Method specific
 
+        PROPAGATING_PARAMETER_COLUMNS: list[str] = [
+            REP_EMIS_ERS,
+            REP_EMIS_EPR,
+            REP_EMIS_RD,
+            REP_EMIS_RC,
+            REP_EMIS_ED,
+            REP_EMIS_MULTI,
+            NON_REP_EMIS_ERS,
+            NON_REP_EMIS_EPR,
+            NON_REP_EMIS_ED,
+            NON_REP_EMIS_MULTI,
+        ]
+
+        METHOD_SPECIFIC_PROPAGATING_PARAMETERS: list[str] = [
+            SURVEY_TIME_PLACEHOLDER,
+            SURVEY_COST_PLACEHOLDER,
+            SPATIAL_PLACEHOLDER,
+        ]
+
     class Sources_File_Constants:
         COMPONENT = "component"
         SOURCE = "source"

--- a/LDAR_Sim/testing/unit_testing/test_virtual_world/test_equipment/test_clean_propagating_parameters_from_equipment_info.py
+++ b/LDAR_Sim/testing/unit_testing/test_virtual_world/test_equipment/test_clean_propagating_parameters_from_equipment_info.py
@@ -33,6 +33,7 @@ from constants.infrastructure_const import Infrastructure_Constants as IC
         "testing_data_equipment_info_with_propagating_parameters",
         "testing_data_equipment_info_without_propagating_parameters",
         "testing_data_equipment_info_with_method_specific_propagating_parameters",
+        "testing_data_equipment_info_propagating_parameters_only",
     ],
 )
 def test_info_cleaned_as_expected(
@@ -100,3 +101,14 @@ def testing_data_equipment_info_with_method_specific_propagating_parameters_fixt
         "Test Comp2": 2,
     }
     return (pd.Series(info_dict), pd.Series(expected_cleaned_info_dict))
+
+
+@pytest.fixture(name="testing_data_equipment_info_propagating_parameters_only")
+def testing_data_equipment_info_propagating_parameters_only_fixture():
+    info_dict: dict = {}
+
+    for val in IC.Equipment_Group_File_Constants.PROPAGATING_PARAMETER_COLUMNS:
+        info_dict[val] = 0
+
+    expected_cleaned_info_dict: dict = {}
+    return (pd.Series(info_dict), pd.Series(expected_cleaned_info_dict, dtype="int64"))

--- a/LDAR_Sim/testing/unit_testing/test_virtual_world/test_equipment/test_clean_propagating_parameters_from_equipment_info.py
+++ b/LDAR_Sim/testing/unit_testing/test_virtual_world/test_equipment/test_clean_propagating_parameters_from_equipment_info.py
@@ -1,0 +1,102 @@
+"""
+------------------------------------------------------------------------------
+Program:     The LDAR Simulator (LDAR-Sim)
+File:        test_clean_propagating_parameters_from_equipment_info.py
+Purpose:     Tests the cleaning of propagating parameters from equipment info
+
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the MIT License as published
+by the Free Software Foundation, version 3.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+MIT License for more details.
+
+You should have received a copy of the MIT License
+along with this program.  If not, see <https://opensource.org/licenses/MIT>.
+
+------------------------------------------------------------------------------
+"""
+
+import pandas as pd
+import pytest
+from pytest_mock import MockerFixture
+from virtual_world.equipment_groups import Equipment_Group
+from constants.infrastructure_const import Infrastructure_Constants as IC
+
+
+@pytest.mark.parametrize(
+    "fixture_name",
+    [
+        "testing_data_equipment_info_with_propagating_parameters",
+        "testing_data_equipment_info_without_propagating_parameters",
+        "testing_data_equipment_info_with_method_specific_propagating_parameters",
+    ],
+)
+def test_info_cleaned_as_expected(
+    mocker: MockerFixture, request: pytest.FixtureRequest, fixture_name: str
+):
+    equipment_info, expected_cleaned_info = request.getfixturevalue(fixture_name)
+    equipment_info: pd.Series
+    expected_cleaned_info: pd.Series
+
+    mocker.patch.object(Equipment_Group, "__init__", return_value=None)
+    test_equipment: Equipment_Group = Equipment_Group()
+    cleaned_info: pd.Series = test_equipment._clean_propagating_parameters_from_equipment_info(
+        equipment_info
+    )
+    assert cleaned_info.equals(expected_cleaned_info)
+
+
+@pytest.fixture(name="testing_data_equipment_info_with_propagating_parameters")
+def testing_data_equipment_info_with_propagating_parameters_fixture():
+    info_dict: dict = {
+        "Test Comp1": 1,
+        "Test Comp2": 2,
+    }
+    for val in IC.Equipment_Group_File_Constants.PROPAGATING_PARAMETER_COLUMNS:
+        info_dict[val] = 0
+
+    expected_cleaned_info_dict: dict = {
+        "Test Comp1": 1,
+        "Test Comp2": 2,
+    }
+    return (pd.Series(info_dict), pd.Series(expected_cleaned_info_dict))
+
+
+@pytest.fixture(name="testing_data_equipment_info_without_propagating_parameters")
+def testing_data_equipment_info_without_propagating_parameters_fixture():
+    info_dict: dict = {
+        "Test Comp1": 1,
+        "Test Comp2": 2,
+    }
+
+    expected_cleaned_info_dict: dict = {
+        "Test Comp1": 1,
+        "Test Comp2": 2,
+    }
+    return (pd.Series(info_dict), pd.Series(expected_cleaned_info_dict))
+
+
+@pytest.fixture(name="testing_data_equipment_info_with_method_specific_propagating_parameters")
+def testing_data_equipment_info_with_method_specific_propagating_parameters_fixture():
+    info_dict: dict = {
+        "Test Comp1": 1,
+        "Test Comp2": 2,
+    }
+
+    methods: list[str] = ["Method1", "Method2"]
+
+    for method in methods:
+        for (
+            method_specific_param
+        ) in IC.Equipment_Group_File_Constants.METHOD_SPECIFIC_PROPAGATING_PARAMETERS:
+            info_dict[method + method_specific_param] = 0
+
+    expected_cleaned_info_dict: dict = {
+        "Test Comp1": 1,
+        "Test Comp2": 2,
+    }
+    return (pd.Series(info_dict), pd.Series(expected_cleaned_info_dict))


### PR DESCRIPTION
# Pull Request Key Information

## Reason for change

An bug was discovered where users were unable to set properties in the equipment file due to the way component parsing was handled.

## What was changed

This change fixes the issue by adding more robust parsing of the equipment file to allow for setting properties.

## Intended Purpose

This change will allow users to set properties in the equipment file without encountering an error.

## Level of version change required

Patch

## Testing Completed

Basic manual testing completed. 

All unit tests are passing: 
[unit_test_results.txt](https://github.com/user-attachments/files/16102468/unit_test_results.txt)


## Target Issue

N/A

## Additional Information

N/A
