### PR TITLE
<type>: Short summary of change (limit 50 chars)

### DIFF
--- a/LDAR_Sim/src/constants/output_file_constants.py
+++ b/LDAR_Sim/src/constants/output_file_constants.py
@@ -34,7 +34,7 @@ class SummaryOutputVizFileNames:
     )
     TRUE_AND_ESTIMATED_PAIRED_PROBIT_PLOT = "True and Estimated Emissions Probit"
     PROGRAM_MITIGATION_BAR_PLOT = "Program Mitigation Comparison"
-    STACKED_COST_BAR_PLOT = "Stacked Cost Comparison"
+    PROGRAM_COST_VALUE_BAR_PLOT = "Program Cost Value Comparison"
     COST_TO_MIT_BOX_PLOT = "Cost to Mitigation Ratios"
 
     def __iter__(self):
@@ -113,7 +113,7 @@ class MitigationBarConstants:
 
 class StackedCostBarConstants:
     X_LABEL = "Program Name"
-    Y_LABEL = "Median Total Cost ($) for all sites for all years"
+    Y_LABEL = "Median Total Value ($) for all sites for all years"
     WIDTH = 0.75
 
 

--- a/LDAR_Sim/src/default_parameters/outputs_default.yml
+++ b/LDAR_Sim/src/default_parameters/outputs_default.yml
@@ -43,7 +43,7 @@ Summary Visualizations:
   True_and_Estimated_Paired_Emissions_Distribution: true
   True and Estimated Emissions Probit: true
   Program Mitigation Comparison: true
-  Stacked Cost Comparison: true
+  Program Cost Value Comparison: true
   Cost to Mitigation Ratios: true
 Summary Visualization Settings:
   True and Estimated Emissions Probit: 

--- a/LDAR_Sim/src/file_processing/output_processing/summary_output_manager.py
+++ b/LDAR_Sim/src/file_processing/output_processing/summary_output_manager.py
@@ -203,7 +203,9 @@ class SummaryOutputManager:
         ]
         filtered_df.rename(
             columns={
-                output_file_constants.TS_SUMMARY_COLUMNS_ACCESSORS.TOT_COST: output_file_constants.COST_SUMMARY_COLUMNS_ACCESSORS.TOTAL_COST
+                output_file_constants.TS_SUMMARY_COLUMNS_ACCESSORS.TOT_COST: (
+                    output_file_constants.COST_SUMMARY_COLUMNS_ACCESSORS.TOTAL_COST
+                )
             },
             inplace=True,
         )
@@ -223,7 +225,9 @@ class SummaryOutputManager:
         ]
         filtered_df.rename(
             columns={
-                output_file_constants.EMIS_SUMMARY_COLUMNS_ACCESSORS.T_TOT_MIT: output_file_constants.COST_SUMMARY_COLUMNS_ACCESSORS.MITIGATION,
+                output_file_constants.EMIS_SUMMARY_COLUMNS_ACCESSORS.T_TOT_MIT: (
+                    output_file_constants.COST_SUMMARY_COLUMNS_ACCESSORS.MITIGATION
+                ),
             },
             inplace=True,
         )

--- a/LDAR_Sim/src/file_processing/output_processing/summary_visualization_manager.py
+++ b/LDAR_Sim/src/file_processing/output_processing/summary_visualization_manager.py
@@ -48,8 +48,8 @@ class SummaryVisualizationManager:
         output_file_constants.SummaryOutputVizFileNames.PROGRAM_MITIGATION_BAR_PLOT: (
             summary_visualizations.gen_program_mitigation_bars
         ),
-        output_file_constants.SummaryOutputVizFileNames.STACKED_COST_BAR_PLOT: (
-            summary_visualizations.gen_program_stacked_cost_bars
+        output_file_constants.SummaryOutputVizFileNames.PROGRAM_COST_VALUE_BAR_PLOT: (
+            summary_visualizations.gen_program_stacked_cost_value_bars
         ),
         output_file_constants.SummaryOutputVizFileNames.COST_TO_MIT_BOX_PLOT: (
             summary_visualizations.gen_cost_to_mit_boxplot

--- a/LDAR_Sim/src/file_processing/output_processing/summary_visualization_mapper.py
+++ b/LDAR_Sim/src/file_processing/output_processing/summary_visualization_mapper.py
@@ -84,7 +84,7 @@ class SummaryVisualizationMapper:
                     summary_visualization_helpers.format_tick_labels_with_metric_prefix
                 )
             ),
-            output_file_constants.SummaryOutputVizFileNames.STACKED_COST_BAR_PLOT: (
+            output_file_constants.SummaryOutputVizFileNames.PROGRAM_COST_VALUE_BAR_PLOT: (
                 ticker.FuncFormatter(
                     summary_visualization_helpers.format_tick_labels_with_metric_prefix
                 )
@@ -128,7 +128,7 @@ class SummaryVisualizationMapper:
                 "color": output_file_constants.MitigationBarConstants.COLOR,
                 "height": output_file_constants.MitigationBarConstants.HEIGHT,
             },
-            output_file_constants.SummaryOutputVizFileNames.STACKED_COST_BAR_PLOT: {
+            output_file_constants.SummaryOutputVizFileNames.PROGRAM_COST_VALUE_BAR_PLOT: {
                 "align": "center",
                 "x_label": output_file_constants.StackedCostBarConstants.X_LABEL,
                 "y_label": output_file_constants.StackedCostBarConstants.Y_LABEL,

--- a/LDAR_Sim/src/file_processing/output_processing/summary_visualizations.py
+++ b/LDAR_Sim/src/file_processing/output_processing/summary_visualizations.py
@@ -593,7 +593,7 @@ def gen_cost_to_mit_boxplot(
     )
 
 
-def gen_program_stacked_cost_bars(
+def gen_program_stacked_cost_value_bars(
     out_dir: Path,
     visualization_dir: Path,
     baseline_program: str,
@@ -603,7 +603,9 @@ def gen_program_stacked_cost_bars(
     data_source: Path = out_dir / file_name_constants.Output_Files.SummaryFileNames.COST_SUMMARY
     data: pd.DataFrame = pd.read_csv(data_source.with_suffix(".csv"))
 
-    visualization_name: str = output_file_constants.SummaryOutputVizFileNames.STACKED_COST_BAR_PLOT
+    visualization_name: str = (
+        output_file_constants.SummaryOutputVizFileNames.PROGRAM_COST_VALUE_BAR_PLOT
+    )
 
     data = data[
         [


### PR DESCRIPTION
# Pull Request Key Information

## Reason for change

The "stacked cost comparison" visualization is technically a value visualization, not a cost visualization, as cost is shown as negative.

## What was changed

This change updates the name of the visualization and the y-axis label to reflect that the visualization is a value visualization.

## Intended Purpose

Wording now updated to specify the visualization including program cost is value.

## Level of version change required

Patch

## Testing Completed

Manual Testing, see attached images of test run with simple test case 1:
<img width="61" alt="image" src="https://github.com/LDAR-Sim/LDAR_Sim/assets/57332344/ed8d70d7-671b-403d-abe3-db8932a4fdff">
![Program Cost Value Comparison](https://github.com/LDAR-Sim/LDAR_Sim/assets/57332344/3bf25b9d-7b60-4f8e-aa55-cbf8c4839a39)


All unit tests pass: 
[unit_test_results.txt](https://github.com/user-attachments/files/16114150/unit_test_results.txt)

## Target Issue

Closes #230

## Additional Information

N/A
