### PR TITLE
<FIX>: Properly update the site list for sites considered for follow-ups and in queue for follow-up

### DIFF
--- a/LDAR_Sim/src/programs/site_level_method.py
+++ b/LDAR_Sim/src/programs/site_level_method.py
@@ -146,8 +146,9 @@ class SiteLevelMethod(Method):
         # If the site is already queued to get a follow-up,
         # update the queue priority based on new results
         elif self._site_IDs_in_follow_up_queue[detection_record.site_id]:
-            existing_plan = self._follow_up_schedule.get_plan_from_queue(detection_record.site_id)
-            existing_plan: StationaryFollowUpSurveyPlanner
+            existing_plan: StationaryFollowUpSurveyPlanner = (
+                self._follow_up_schedule.get_plan_from_queue(detection_record.site_id)
+            )
             existing_plan.update_with_latest_survey(
                 detection_record,
                 self._redund_filter,
@@ -163,7 +164,6 @@ class SiteLevelMethod(Method):
                 self._follow_up_schedule.add_to_survey_queue(existing_plan)
             else:
                 self._site_IDs_in_follow_up_queue[detection_record.site_id] = False
-                self._site_IDs_in_consideration_for_flag[detection_record.site_id] = False
 
         # Otherwise, the site is not already in processing for a follow-up,
         # process as normal
@@ -179,7 +179,6 @@ class SiteLevelMethod(Method):
                     )
                 )
                 self._site_IDs_in_follow_up_queue[detection_record.site_id] = True
-                self._site_IDs_in_consideration_for_flag[detection_record.site_id] = False
 
             elif detection_record.rate_detected != 0 and (
                 detection_record.rate_detected >= self._small_window_threshold
@@ -246,7 +245,6 @@ class SiteLevelMethod(Method):
             else:
                 # Site is no longer in consideration for follow-up
                 self._site_IDs_in_follow_up_queue[detection_record.site_id] = False
-                self._site_IDs_in_consideration_for_flag[detection_record.site_id] = False
         # Otherwise, the site is not already in processing for a follow-up,
         # process as normal
         else:
@@ -256,7 +254,6 @@ class SiteLevelMethod(Method):
                     FollowUpSurveyPlanner(detection_record, date_to_check)
                 )
                 self._site_IDs_in_follow_up_queue[detection_record.site_id] = True
-                self._site_IDs_in_consideration_for_flag[detection_record.site_id] = False
             # if the detected rate is non-zero, and above the threshold add to queue
             elif (
                 detection_record.rate_detected != 0

--- a/LDAR_Sim/src/scheduling/follow_up_mobile_schedule.py
+++ b/LDAR_Sim/src/scheduling/follow_up_mobile_schedule.py
@@ -111,11 +111,18 @@ class FollowUpMobileSchedule(GenericSchedule):
         )
 
     def update(self, workplan: Workplan, current_date: date) -> None:
-        super().update(workplan, current_date)
-
         reports, planners = workplan.get_reports()
-        for site_id, report in reports.items():
-            planner = planners[site_id]
+        reports: dict[str, SiteSurveyReport]
+        planners: dict[str, ScheduledSurveyPlanner]
 
-            if report.survey_complete:
+        for site_id, report in reports.items():
+            planner: ScheduledSurveyPlanner = planners[site_id]
+
+            if not report.survey_complete:
+                if report.survey_in_progress:
+                    self.add_unfinished_to_survey_queue(planner)
+                else:
+                    self.add_previous_queued_to_survey_queue(planner)
+            else:
+                planner.add_to_surveys_done(current_date)
                 self._site_IDs_in_queue[planner.site_id] = False

--- a/LDAR_Sim/src/scheduling/follow_up_mobile_schedule.py
+++ b/LDAR_Sim/src/scheduling/follow_up_mobile_schedule.py
@@ -111,17 +111,11 @@ class FollowUpMobileSchedule(GenericSchedule):
         )
 
     def update(self, workplan: Workplan, current_date: date) -> None:
-        reports, planners = workplan.get_reports()
-        reports: dict[str, SiteSurveyReport]
-        planners: dict[str, ScheduledSurveyPlanner]
-        for site_id, report in reports.items():
-            planner: ScheduledSurveyPlanner = planners[site_id]
+        super().update(workplan, current_date)
 
-            if not report.survey_complete:
-                if report.survey_in_progress:
-                    self.add_unfinished_to_survey_queue(planner)
-                else:
-                    self.add_previous_queued_to_survey_queue(planner)
-            else:
-                planner.add_to_surveys_done(current_date)
+        reports, planners = workplan.get_reports()
+        for site_id, report in reports.items():
+            planner = planners[site_id]
+
+            if report.survey_complete:
                 self._site_IDs_in_queue[planner.site_id] = False

--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,9 @@
 ## 2024-07-11 - Version 4.0.5
 
 1. Fixed crew count always being overwritten by estimated crew count
+2. Update language around sensitivity analysis
+3. Update language of stacked cost (now value) bar chart
+4. Fix bug with sites considered for follow-ups and queue for follow-ups
 
 ## 2024-07-07 - Version 4.0.4
 


### PR DESCRIPTION
# Pull Request Key Information

## Reason for change

The dictionary for considering sites for flagging was set up to be used but never populated

## What was changed

- site candidates for flagged should no longer be endlessly added to the candidate pool

## Intended Purpose

Fix the incorrect follow-up behavior

## Level of version change required

Patch

## Testing Completed

Manually tested the behavior
All unit tests pass.
[results.txt](https://github.com/user-attachments/files/16169242/results.txt)

