### PR TITLE
<FIX>Crew count bugfix

### DIFF
--- a/LDAR_Sim/src/constants/error_messages.py
+++ b/LDAR_Sim/src/constants/error_messages.py
@@ -105,6 +105,10 @@ class Runtime_Warning_Messages:
     POTENTIAL_CREW_SHORTAGE_MESSAGE = (
         "Warning: LDAR-Sim has detected a potential for crew shortage for the method: {method}"
     )
+    FOLLOW_UP_METHOD_CREW_ESTIMATION = (
+        "Warning: LDAR-Sim as defaulted to a single crew for the following follow-up method: {method}"
+        "This may lead to crew shortages, please provide a crew count for this method if this is not intended."
+    )
 
 
 class Output_Processing_Messages:

--- a/LDAR_Sim/src/programs/method.py
+++ b/LDAR_Sim/src/programs/method.py
@@ -173,10 +173,12 @@ class Method:
             )
 
         else:
+            print(rwm.FOLLOW_UP_METHOD_CREW_ESTIMATION.format(method=self._name))
             estimate_req_n_crews = 1
-        if crews > 0 and estimate_req_n_crews > crews:
+        if crews > 0:
+            if estimate_req_n_crews > crews:
+                print(rwm.POTENTIAL_CREW_SHORTAGE_MESSAGE.format(method=self._name))
             estimate_req_n_crews = crews
-            print(rwm.POTENTIAL_CREW_SHORTAGE_MESSAGE.format(method=self._name))
         return estimate_req_n_crews
 
     def _get_avg_t_bt_sites(self) -> float:

--- a/LDAR_Sim/testing/unit_testing/test_programs/test_component_level_method/component_method_testing_fixtures.py
+++ b/LDAR_Sim/testing/unit_testing/test_programs/test_component_level_method/component_method_testing_fixtures.py
@@ -270,7 +270,7 @@ def deploy_crews_testing4_fix(mocker):
     )
     mocker.patch.object(site_mock, "get_detectable_emissions", mock_get_detectable_emissions)
     properties: dict = {
-        pdc.Method_Params.N_CREWS: 5,
+        pdc.Method_Params.N_CREWS: 1,
         pdc.Method_Params.SENSOR: {
             pdc.Method_Params.TYPE: "default",
             pdc.Method_Params.MDL: 1,

--- a/LDAR_Sim/testing/unit_testing/test_programs/test_method/method_testing_fixtures.py
+++ b/LDAR_Sim/testing/unit_testing/test_programs/test_method/method_testing_fixtures.py
@@ -181,7 +181,7 @@ def simple_method_values_fix(mocker):
         mock_get_method_survey_time,
     )
     properties: dict = {
-        pdc.Method_Params.N_CREWS: 5,
+        pdc.Method_Params.N_CREWS: 3,
         pdc.Method_Params.SENSOR: "default",
         pdc.Method_Params.DEPLOYMENT_TYPE: "mobile",
         pdc.Method_Params.MAX_WORKDAY: 8,
@@ -245,7 +245,7 @@ def simple_method_values2_fix(mocker):
         mock_get_method_survey_time,
     )
     properties: dict = {
-        pdc.Method_Params.N_CREWS: 5,
+        pdc.Method_Params.N_CREWS: 0,
         pdc.Method_Params.SENSOR: "default",
         pdc.Method_Params.DEPLOYMENT_TYPE: "mobile",
         pdc.Method_Params.MAX_WORKDAY: 1,
@@ -309,7 +309,6 @@ def simple_method_values3_fix(mocker):
         mock_get_method_survey_time,
     )
     properties: dict = {
-        pdc.Method_Params.N_CREWS: 5,
         pdc.Method_Params.SENSOR: "default",
         pdc.Method_Params.DEPLOYMENT_TYPE: "mobile",
         pdc.Method_Params.MAX_WORKDAY: 1,
@@ -507,7 +506,7 @@ def deploy_crews_testing_fix(mocker):
     mocker.patch.object(DefaultSiteLevelSensor, "detect_emissions", mock_detect_emissions)
     mocker.patch.object(site_mock, "get_detectable_emissions", mock_get_detectable_emissions)
     properties: dict = {
-        pdc.Method_Params.N_CREWS: 5,
+        pdc.Method_Params.N_CREWS: 1,
         pdc.Method_Params.SENSOR: {
             pdc.Method_Params.TYPE: "default",
             pdc.Method_Params.MDL: 1,
@@ -796,7 +795,7 @@ def deploy_crews_testing4_fix(mocker):
     mocker.patch.object(DefaultSiteLevelSensor, "detect_emissions", mock_detect_emissions)
     mocker.patch.object(site_mock, "get_detectable_emissions", mock_get_detectable_emissions)
     properties: dict = {
-        pdc.Method_Params.N_CREWS: 5,
+        pdc.Method_Params.N_CREWS: 1,
         pdc.Method_Params.SENSOR: {
             pdc.Method_Params.TYPE: "default",
             pdc.Method_Params.MDL: 1,

--- a/LDAR_Sim/testing/unit_testing/test_programs/test_method/test_estimate_method_crews_required.py
+++ b/LDAR_Sim/testing/unit_testing/test_programs/test_method/test_estimate_method_crews_required.py
@@ -28,16 +28,16 @@ from testing.unit_testing.test_programs.test_method.method_testing_fixtures impo
 from src.virtual_world.infrastructure import Site
 
 
-def test_000_return_estimate_not_followup_simple(simple_method_values):
+def test_000_return_provided_value(simple_method_values):
     mocker, properties, current_date, state = simple_method_values
     sites = [mocker.Mock(spec=Site) for i in range(5)]
     method = Method("test_method", properties, True, sites)
 
-    expected_crews_required = 1
+    expected_crews_required = 3
     assert method._crews == expected_crews_required
 
 
-def test_000_return_estimate_not_followup(simple_method_values2):
+def test_000_return_estimated_not_followup(simple_method_values2):
     mocker, properties, current_date, state = simple_method_values2
     sites = [mocker.Mock(spec=Site) for i in range(500)]
     method = Method("test_method", properties, True, sites)

--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -1246,7 +1246,8 @@ See the following files for examples on setting this value at a more granular le
 
 **Default input:** 0
 
-**Description:** The maximum number of distinct, independent crews that will be deployed using the same method. If the `crew_count` is not provided, LDAR-Sim will provide crews as needed.
+**Description:** The maximum number of distinct, independent crews that will be deployed using the same method. If the `crew_count` is not provided, LDAR-Sim will provide crews as needed. When explicitly stated, the maximum number of crews will be utilized for the given method.
+Warning, for follow-up mobile methods, crew count will be defaulted to 1 if not explicitly stated, which may lead to crew shortage.
 
 **Notes on acquisition:** No data acquisition required.
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 2024-07-11 - Version 4.0.5
+
+1. Fixed crew count always being overwritten by estimated crew count
+
 ## 2024-07-07 - Version 4.0.4
 
 1. Fixed per day costs


### PR DESCRIPTION
# Pull Request Key Information

## Reason for change

Crew counts even when provided, the estimate values always over-wrote. In some cases, such as follow-ups, this could lead to crew shortages because it would always default to 1.

## What was changed

Crew counts when provided, will always be used.

## Intended Purpose

Allow users to specify crew count

## Level of version change required

Patch

## Testing Completed

Manual testing
Updated unit tests
All unit tests pass
[results.txt](https://github.com/user-attachments/files/16169755/results.txt)
