### PR TITLE
<FIX>: Fix estimated emission to be min.0

### DIFF
--- a/LDAR_Sim/src/file_processing/output_processing/summary_outputs.py
+++ b/LDAR_Sim/src/file_processing/output_processing/summary_outputs.py
@@ -164,8 +164,10 @@ def generate_emissions_estimation_summary(directory: str, outputs_mapper: Summar
         ]
     ]
 
-    subtracted_df = est_emissions_summary_df[columns_to_subtract].sub(
-        est_rep_emissions_summary_df[columns_to_subtract]
+    subtracted_df = (
+        est_emissions_summary_df[columns_to_subtract]
+        .sub(est_rep_emissions_summary_df[columns_to_subtract])
+        .clip(lower=0)
     )
 
     # Combine the result with columns not involved in subtraction

--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -931,6 +931,8 @@ The measured total site level emission rate on January 30th is assumed to have l
 
 **Notes of caution:** All emissions estimation in simulation is based on the assumption that technologies quantify emissions.
 
+If an emission estimation results in a negative value due to considerations of repairable emissions, the simulator will automatically set this value to 0 for reporting purposes.
+
 --------------------------------------------------------------------------------
 
 ## 9\. Method Inputs


### PR DESCRIPTION
# Pull Request Key Information

## Reason for change

It was still possible to get negative emissions observed in the emissions summary for yearly estimated emissions.

## What was changed

Fix such that if the estimated emissions is smaller than the fugitives to remove, the estimated is set to 0.

## Intended Purpose

Prevent negatives from being observed as an emission estimate.

## Level of version change required

Patch

## Testing Completed

Manually tested  - the following is the new Emissions Summary output. See #257  for original output, input and parameter files
![image](https://github.com/user-attachments/assets/5563a1ba-f065-4ad8-b9cf-e6d82e12b47c)
Same emissions as before still exists:
![image](https://github.com/user-attachments/assets/d2e674e6-f535-46e3-8148-199849e22552)

All unit tests pass.
[result.txt](https://github.com/user-attachments/files/16199781/result.txt)

## Target Issue

Linked to #257 -> see this issue for more details

## Additional Information

Include any other important information here.
