### PR TITLE
Initial sites flagging bugfix

### DIFF
--- a/LDAR_Sim/src/programs/site_level_method.py
+++ b/LDAR_Sim/src/programs/site_level_method.py
@@ -275,7 +275,7 @@ class SiteLevelMethod(Method):
         for detection_record in new_detections:
             # Check that the site hasn't gotten a survey with a method
             # that can tag leaks since the date the detection was made
-            if detection_record.site.get_latest_tagging_survey_date() < date_to_check:
+            if detection_record.site.get_latest_tagging_survey_date() <= date_to_check:
                 if self._deployment_type == pdc.Deployment_Types.STATIONARY:
                     self.update_stationary(date_to_check, detection_record)
                 else:


### PR DESCRIPTION
# Pull Request Key Information

## Reason for change

An edge was discovered in which the sites with emissions detected on the first day of the simulation were not being correctly flagged due to logic put in place to prevent redundant flagging of sites with tagged emissions.
    
## What was changed

The logic was updated to allow for the flagging of sites with emissions detected on the first day of the simulation.

## Intended Purpose

Resolve the discovered bug.

## Level of version change required

Patch

## Testing Completed

All unit tests pass: 
[unit_test_results.txt](https://github.com/user-attachments/files/16255369/unit_test_results.txt)

Manually tested

## Target Issue

N/A

## Additional Information

This change has a side effect of allowing potentially redundant flagging of sites in the specific edge case that they receive a tagging and a flagging survey from 2 different method on the same day. Previously, this would result in the flagged method being unable to flag the site, whereas now, it can.
