### PR TITLE
Remove reference prog

### DIFF
--- a/Guides/Version Migration Guides/V3_to_V4_ParameterMigrationGuide.md
+++ b/Guides/Version Migration Guides/V3_to_V4_ParameterMigrationGuide.md
@@ -32,6 +32,7 @@ When moving from V3 to V4, it is advised to read the updated [user manual](../..
 | outputs| functionality moved to [output parameters](../../USER_MANUAL.md#6-output-settings) |
 | start_date| moved to virtual world |
 | end_date| moved to virtual world |
+| reference_program| removed until feature is necessary again |
 
 #### Simulation Settings: New Parameters
 

--- a/LDAR_Sim/simulations/simple_test_case1/Simulation_settings.yaml
+++ b/LDAR_Sim/simulations/simple_test_case1/Simulation_settings.yaml
@@ -3,5 +3,4 @@ simulation_count: 3
 output_directory: ./outputs/simple_test_case_1
 parameter_level: simulation_settings
 preseed_random: true
-reference_program: P_OGI
 version: "4.0"

--- a/LDAR_Sim/simulations/simple_test_case1_sens/Simulation_settings.yaml
+++ b/LDAR_Sim/simulations/simple_test_case1_sens/Simulation_settings.yaml
@@ -3,5 +3,4 @@ simulation_count: 10
 output_directory: ./outputs/sens_test_case1_vw
 parameter_level: simulation_settings
 preseed_random: true
-reference_program: P_OGI
 version: "4.0"

--- a/LDAR_Sim/src/constants/param_default_const.py
+++ b/LDAR_Sim/src/constants/param_default_const.py
@@ -88,7 +88,6 @@ class Sim_Setting_Params:
     INPUT = "input_directory"
     OUTPUT = "output_directory"
     BASELINE = "baseline_program"
-    REFERENCE = "reference_program"
     PROCESS = "processes_count"
     SIMS = "simulation_count"
     PRESEED = "preseed_random"

--- a/LDAR_Sim/src/default_parameters/simulation_settings_default.yml
+++ b/LDAR_Sim/src/default_parameters/simulation_settings_default.yml
@@ -3,7 +3,6 @@ version: "4.0"
 input_directory: "./inputs"
 output_directory: "./outputs"
 baseline_program: P_none
-reference_program: P_OGI
 processes_count: 6 # Recommend: 6
 simulation_count: 2
 preseed_random: False # True/False

--- a/LDAR_Sim/src/ldar_sim_run.py
+++ b/LDAR_Sim/src/ldar_sim_run.py
@@ -128,7 +128,6 @@ def run_ldar_sim(parameter_filenames, DEBUG=False):
         out_dir = get_abs_path(sim_params[pdc.Sim_Setting_Params.OUTPUT])
 
     # --- Assign local variables
-    ref_program = sim_params[pdc.Sim_Setting_Params.REFERENCE]  # noqa
     base_program = sim_params[pdc.Sim_Setting_Params.BASELINE]
     in_dir = get_abs_path(sim_params[pdc.Sim_Setting_Params.INPUT])
     programs = sim_params.pop(pdc.Levels.PROGRAM)

--- a/LDAR_Sim/src/ldar_sim_sensitivity_analysis.py
+++ b/LDAR_Sim/src/ldar_sim_sensitivity_analysis.py
@@ -135,7 +135,6 @@ if __name__ == "__main__":
         programs: list[dict] = simulation_parameters.get_programs()
         virtual_world: dict = simulation_parameters.get_virtual_world()
         output_params: dict = simulation_parameters.get_output()
-        ref_program: str = simulation_setting[pdc.Sim_Setting_Params.REFERENCE]
         base_program: str = simulation_setting[pdc.Sim_Setting_Params.BASELINE]
         in_dir: Path = get_abs_path(simulation_setting[pdc.Sim_Setting_Params.INPUT])
         out_dir: Path = get_abs_path(simulation_setting[pdc.Sim_Setting_Params.OUTPUT])

--- a/LDAR_Sim/src/sensitivity_analysis/parameter_variator.py
+++ b/LDAR_Sim/src/sensitivity_analysis/parameter_variator.py
@@ -219,11 +219,11 @@ def vary_parameter_values(
             simulation_parameters.get_baseline_program(),
         )
         # Edit the base program
-        parameters.alter_parameter(
-            param_default_const.Levels.SIMULATION,
-            param_default_const.Sim_Setting_Params.REFERENCE,
-            f"{sensitivity_program}_{0}",
-        )
+        # parameters.alter_parameter(
+        #     param_default_const.Levels.SIMULATION,
+        #     param_default_const.Sim_Setting_Params.REFERENCE,
+        #     f"{sensitivity_program}_{0}",
+        # )
         # Append the new parameters to the list
         new_simulation_parameters.append(parameters)
     # If the parameter level is not recognized or valid for the sensitivity analysis

--- a/LDAR_Sim/src/sensitivity_analysis/parameter_variator.py
+++ b/LDAR_Sim/src/sensitivity_analysis/parameter_variator.py
@@ -218,12 +218,7 @@ def vary_parameter_values(
             simulation_parameters.baseline_program_name,
             simulation_parameters.get_baseline_program(),
         )
-        # Edit the base program
-        # parameters.alter_parameter(
-        #     param_default_const.Levels.SIMULATION,
-        #     param_default_const.Sim_Setting_Params.REFERENCE,
-        #     f"{sensitivity_program}_{0}",
-        # )
+
         # Append the new parameters to the list
         new_simulation_parameters.append(parameters)
     # If the parameter level is not recognized or valid for the sensitivity analysis

--- a/LDAR_Sim/testing/end_to_end_testing/e2e_suite_runner.py
+++ b/LDAR_Sim/testing/end_to_end_testing/e2e_suite_runner.py
@@ -92,7 +92,6 @@ if __name__ == "__main__":
             # --- Assign local variabls
             in_dir = get_abs_path(sim_params[pdc.Sim_Setting_Params.INPUT], test_dir)
             out_dir = get_abs_path(sim_params[pdc.Sim_Setting_Params.OUTPUT], test_dir)
-            ref_program = sim_params[pdc.Sim_Setting_Params.REFERENCE]
             base_program = sim_params[pdc.Sim_Setting_Params.BASELINE]
             programs = sim_params.pop(pdc.Levels.PROGRAM)
             virtual_world = sim_params.pop(pdc.Levels.VIRTUAL)

--- a/LDAR_Sim/testing/end_to_end_testing/e2e_test_case_creator.py
+++ b/LDAR_Sim/testing/end_to_end_testing/e2e_test_case_creator.py
@@ -114,7 +114,6 @@ if __name__ == "__main__":
     sim_params = input_manager.read_and_validate_parameters(parameter_filenames)
 
     # --- Assign local variabls
-    ref_program = sim_params[pdc.Sim_Setting_Params.REFERENCE]
     base_program = sim_params[pdc.Sim_Setting_Params.BASELINE]
     in_dir = get_abs_path("./inputs", test_creator_dir)
     out_dir = get_abs_path("./expected_outputs", test_case_dir)

--- a/LDAR_Sim/testing/end_to_end_testing/test_suite/V4-simple_repairable_emissions/expected_outputs/parameters.yaml
+++ b/LDAR_Sim/testing/end_to_end_testing/test_suite/V4-simple_repairable_emissions/expected_outputs/parameters.yaml
@@ -812,7 +812,6 @@ programs:
     parameter_level: programs
     program_name: P_stationary_measurement_based
     version: '4.0'
-reference_program: P_OGI
 simulation_count: 2
 version: '4.0'
 virtual_world:

--- a/LDAR_Sim/testing/end_to_end_testing/test_suite/V4-simple_repairable_emissions/params/Simulation_settings.yaml
+++ b/LDAR_Sim/testing/end_to_end_testing/test_suite/V4-simple_repairable_emissions/params/Simulation_settings.yaml
@@ -2,6 +2,5 @@ input_directory: ./inputs
 output_directory: ./outputs
 parameter_level: simulation_settings
 preseed_random: true
-reference_program: P_OGI
 simulation_count: 2
 version: '4.0'

--- a/LDAR_Sim/testing/end_to_end_testing/test_suite/V4_simple_non_repairable_emissions/expected_outputs/parameters.yaml
+++ b/LDAR_Sim/testing/end_to_end_testing/test_suite/V4_simple_non_repairable_emissions/expected_outputs/parameters.yaml
@@ -812,7 +812,6 @@ programs:
     parameter_level: programs
     program_name: P_stationary_measurement_based
     version: '4.0'
-reference_program: P_OGI
 simulation_count: 2
 version: '4.0'
 virtual_world:

--- a/LDAR_Sim/testing/end_to_end_testing/test_suite/V4_simple_non_repairable_emissions/params/Simulation_settings.yaml
+++ b/LDAR_Sim/testing/end_to_end_testing/test_suite/V4_simple_non_repairable_emissions/params/Simulation_settings.yaml
@@ -2,6 +2,5 @@ input_directory: ./inputs
 output_directory: ./outputs
 parameter_level: simulation_settings
 preseed_random: true
-reference_program: P_OGI
 simulation_count: 2
 version: '4.0'

--- a/LDAR_Sim/testing/unit_testing/test_sensitivity_analysis/test_parameter_variator/test_vary_parameter_values.py
+++ b/LDAR_Sim/testing/unit_testing/test_sensitivity_analysis/test_parameter_variator/test_vary_parameter_values.py
@@ -37,7 +37,6 @@ def get_simulation_parameters_1():
         Common_Params.VERSION: "4.0",
         Sim_Setting_Params.INPUT: "test_input",
         Sim_Setting_Params.OUTPUT: "test_output",
-        Sim_Setting_Params.REFERENCE: "test_reference",
     }
     virtual_world = {
         Common_Params.PARAM_LEVEL: Levels.VIRTUAL,

--- a/README.md
+++ b/README.md
@@ -108,8 +108,7 @@ Simulation_settings.yaml =>
 
 ``` yaml
   parameter_level: simulation_settings     // Denotes the parameter level (used for input handling)
-  version: '2.0'              // Denotes the version
-  reference_program: P_OGI    // Denotes the regulatory reference program for relative differences
+  version: '4.0'              // Denotes the version
   baseline_program: P_none    // Denotes a baseline program for estimating program mitigation, usually in place of no formal LDAR
 ```
 
@@ -119,7 +118,7 @@ A Program yaml file is required, the most basic setup is as follows (where a met
 ``` yaml
   program_name: P_OGI           // Denotes program name (must be unique)
   parameter_level: program      // Denotes the program level (used for input handling)
-  version: '2.0'                // Denotes the version
+  version: '4.0'                // Denotes the version
   method_labels:                // Denotes the associated methods
     - OGI 
 ```
@@ -129,7 +128,7 @@ P_none.yaml =>
 ``` yaml
   program_name: P_none
   parameter_level: program
-  version: '2.0'
+  version: '4.0'
   method_labels: []
 
 ```
@@ -140,19 +139,19 @@ A Method yaml file is required, the most basic setup is as follows:
 
 ``` yaml
     parameter_level: method         // Denotes program name (must be unique)
-    version: '2.0'                  // Denotes the version
-    label: OGI                      // Specify the label to link to an associated program
+    version: '4.0'                  // Denotes the version
+    method_name: OGI                      // Specify the label to link to an associated program
     deployment_type: mobile         // How the technology operates, 'mobile', 'stationary' or 'orbit'
     measurement_scale: component    // Does the sensor measure at a site level, equipment level or component level
     is_follow_up: False             // Does the technology survey sites after a screening technology flags the site.
     sensor:                     
-      MDL: [0.0362]                 // Minimum detectable leak in g/s.
+      minimum_detection_limit: [0.0362]                 // Minimum detectable leak in g/s.
     cost:
       per_site: 600                 // Cost per site survey ($)
-    t_bw_sites: 
-      vals: [30]                    // Time to travel between sites (minutes)
-    RS: 2                           // Surveys required per year per site (ie. 2 surveys per site every year)
-    time: 120                       // Time to perform detection at a site (minutes)
+    time_between_sites: 
+      values: [30]                    // Time to travel between sites (minutes)
+    surveys_per_year: 2                           // Surveys required per year per site (ie. 2 surveys per site every year)
+    survey_time: 120                       // Time to perform detection at a site (minutes)
 ```
 
 Check out the [user manual](USER_MANUAL.md) for more info on the parameters.

--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -175,13 +175,12 @@ Parameter files are all key-value pairs (i.e., Python dictionary), with multiple
 - `program`: program parameters that are used to define a specific emissions reduction program (or lack thereof). Commonly, an 'alternative' custom program is compared to a defined regulatory program. Many programs can be compared at once.
 - `method`: emissions reduction methods (e.g., specific LDAR technologies and work practices and/or LDAR service provider companies) that are deployed within a program. Methods are specified in a given program for deployment and multiple methods may be used at once (e.g., satellite + aircraft + OGI follow-up + routine AVO)
 
-A typical simulation would compare at least two programs: a reference program and one or more test programs. Including a baseline program is also necessary.
+A typical simulation would compare at least two programs: a baseline program and one or more test programs.
 
-- `baseline program`: The program against which mitigation is estimated for reference and test programs (mitigation = baseline emissions - LDAR emissions). Typically involves running LDAR-Sim in the absence of a formal LDAR program (commonly denoted as 'P_none'). Even without a formal LDAR program, emissions are eventually removed from the simulation due to operator rounds (e.g., AVO), routine maintenance, refits and retrofits, or other factors.
-- `reference program`: The program against which test programs are compared (e.g., to establish equivalency). The reference program is often defined by regulations that require the use of OGI (commonly denoted 'P_OGI').
+- `baseline program`: The program against which mitigation is estimated for test programs (mitigation = baseline emissions - LDAR emissions). Typically involves running LDAR-Sim in the absence of a formal LDAR program (commonly denoted as 'P_none'). Even without a formal LDAR program, emissions are eventually removed from the simulation due to operator rounds (e.g., AVO), routine maintenance, refits and retrofits, or other factors.
 - `test programs`: A custom alternative program that the user wants to evaluate. Commonly denoted using 'P_' + program name (e.g., 'P_aircraft', 'P_GasCompanyX', 'P_drone', etc.).
 
-A simulation can consist of any number of programs and each program can consist of any number of methods. For example, the reference program could deploy one method (OGI). The test program could deploy two new LDAR methods (magical helicopter and un-magical binoculars). Each program would be run on the asset base multiple times through time to create a statistical representation of the emissions and cost data. Finally, the statistical emissions and cost distributions of the reference program can be compared to those of the test program. It is often the differences between the programs that represents the important information that is of interest to users of LDAR-Sim.
+A simulation can consist of any number of programs and each program can consist of any number of methods. For example, the test program 1 could deploy one method (OGI). The test program 2 could deploy two new LDAR methods (magical helicopter and un-magical binoculars). Each program would be run on the asset base multiple times through time to create a statistical representation of the emissions and cost data. Finally, the statistical emissions and cost distributions of the baseline program can be compared to those of the test program. It is often the differences between the programs that represents the important information that is of interest to users of LDAR-Sim.
 
 In this example, the hierarchy looks like:
 
@@ -190,8 +189,6 @@ Simulation setting parameters
 Virtual world parameters
 Programs:
     Baseline program
-    Reference program:
-        Reference LDAR method (OGI)
     Test program:
         New LDAR method 1 (Magical Helicopter)
         New LDAR method 2 (Un-magical Binoculars)
@@ -322,14 +319,6 @@ Note that programs are interpreted as a flat list of parameters that are incorpo
 **Notes on acquisition:** Typically a program that represents a scenario where there is no formal LDAR or that has no LDAR method is recommended as the baseline program. Simply put, create a program with no methods.
 
 **Notes of caution:** A baseline program is required to successfully run the simulation.
-
-### &lt;reference_program&gt; WIP
-
-**Data type:** String
-
-**Default input:** 'P_OGI'
-
-**Description:** Refers to a [name of a program](#program_name), against which alternative programs are compared.
 
 **Notes on acquisition:** N/A
 
@@ -2608,6 +2597,12 @@ As LDAR-Sim continues to advance, certain parameters may become obsolete and con
 --------------------------------------------------------------------------------
 
 ### Legacy Simulation Settings Parameters
+
+#### &lt;reference_program&gt;
+
+- Removed as of version 4.1.0
+
+The reference program functionality has been temporarily removed to avoid confusion. It will be reinstated once it is re-implemented and becomes relevant.
 
 #### &lt;pregenerate_leaks&gt;
 


### PR DESCRIPTION
# Pull Request Key Information

## Reason for change

The reference program parameter functionality has not yet been reintroduced in the current version of LDAR-Sim. This parameter was causing confusion among users as it currently has no practical function.

## What was changed

Remove the reference program parameter

## Intended Purpose

Reduce confusion

## Level of version change required

Patch

## Testing Completed

Manually ran simple_test_case1 and the sensitivity analysis example without generator files to ensure that everything is working as intended.

All unit tests pass
[results.txt](https://github.com/user-attachments/files/16353694/results.txt)

All end to end tests pass
[V4_simple_non_repairable_emissions_6e74601b69275855561ec431bd93a53030ee2903.log](https://github.com/user-attachments/files/16353683/V4_simple_non_repairable_emissions_6e74601b69275855561ec431bd93a53030ee2903.log)
[V4-simple_repairable_emissions_6e74601b69275855561ec431bd93a53030ee2903.log](https://github.com/user-attachments/files/16353684/V4-simple_repairable_emissions_6e74601b69275855561ec431bd93a53030ee2903.log)

## Target Issue

Closes #269 

## Additional Information

Include any other important information here.
