### PR TITLE
QE initialization bugfix

### DIFF
--- a/LDAR_Sim/src/constants/error_messages.py
+++ b/LDAR_Sim/src/constants/error_messages.py
@@ -100,6 +100,13 @@ class Input_Processing_Messages:
     )
     MISSING_DEPLOYMENT_TYPE_ERROR = "Warning: Deployment type is missing for method: {method}"
 
+    QUANTIFICATION_FILE_NOT_FOUND = (
+        "Warning: Quantification file {quantification_file} not found in {input_dir}."
+    )
+    QUANTIFICATION_INVALID_COLUMN = (
+        "Warning: Quantification column {quantification_column} not found in {quantification_file}."
+    )
+
 
 class Runtime_Warning_Messages:
     POTENTIAL_CREW_SHORTAGE_MESSAGE = (

--- a/LDAR_Sim/src/sensors/quantification/sampling_quantification_predictor.py
+++ b/LDAR_Sim/src/sensors/quantification/sampling_quantification_predictor.py
@@ -48,9 +48,12 @@ class SamplingQuantificationPredictor:
             containing quantification errors to sample from.
         """
         all_quantification_errors: pd.DataFrame = pd.read_csv(input_dir / quantification_file)
-        self._quantification_errors: np.ndarray = all_quantification_errors[
+        target_quantification_errors: np.ndarray = all_quantification_errors[
             quantification_column
         ].values
+        self._quantification_errors: np.ndarray = target_quantification_errors[
+            ~np.isnan(target_quantification_errors)
+        ]
 
     def predict(self, true_rate: float) -> float:
         """

--- a/LDAR_Sim/src/sensors/quantification/sampling_quantification_predictor.py
+++ b/LDAR_Sim/src/sensors/quantification/sampling_quantification_predictor.py
@@ -22,6 +22,7 @@ along with this program.  If not, see <https://opensource.org/licenses/MIT>.
 from pathlib import Path
 import numpy as np
 import pandas as pd
+import constants.error_messages as em
 
 
 class SamplingQuantificationPredictor:
@@ -47,13 +48,31 @@ class SamplingQuantificationPredictor:
             quantification_column (str): The name of the column in the file
             containing quantification errors to sample from.
         """
-        all_quantification_errors: pd.DataFrame = pd.read_csv(input_dir / quantification_file)
-        target_quantification_errors: np.ndarray = all_quantification_errors[
-            quantification_column
-        ].values
-        self._quantification_errors: np.ndarray = target_quantification_errors[
-            ~np.isnan(target_quantification_errors)
-        ]
+        self._set_quantification_errors(quantification_file, quantification_column, input_dir)
+
+    def _set_quantification_errors(
+        self, quantification_file: str, quantification_column: str, input_dir: Path
+    ):
+        try:
+            # Directly read the required column and drop NaN values, reducing memory usage
+            self._quantification_errors = (
+                pd.read_csv(input_dir / quantification_file, usecols=[quantification_column])
+                .dropna()[quantification_column]
+                .to_numpy()
+            )
+        except FileNotFoundError:
+            raise FileNotFoundError(
+                em.Input_Processing_Messages.QUANTIFICATION_FILE_NOT_FOUND.format(
+                    quantification_file=quantification_file, input_dir=input_dir
+                )
+            )
+        except ValueError:
+            raise ValueError(
+                em.Input_Processing_Messages.QUANTIFICATION_INVALID_COLUMN.format(
+                    quantification_column=quantification_column,
+                    quantification_file=quantification_file,
+                )
+            )
 
     def predict(self, true_rate: float) -> float:
         """

--- a/LDAR_Sim/testing/unit_testing/test_sensors/test_quantification/test_sampling_quantification_predictor/test_set_quantification_errors.py
+++ b/LDAR_Sim/testing/unit_testing/test_sensors/test_quantification/test_sampling_quantification_predictor/test_set_quantification_errors.py
@@ -1,0 +1,94 @@
+"""
+------------------------------------------------------------------------------
+Program:     The LDAR Simulator (LDAR-Sim)
+File:        test_set_quantification_errors.py
+Purpose: To provide tests for _set_quantification_errors method in the SamplingQuantificationPredictor class
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the MIT License as published
+by the Free Software Foundation, version 3.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+MIT License for more details.
+You should have received a copy of the MIT License
+along with this program.  If not, see <https://opensource.org/licenses/MIT>.
+
+------------------------------------------------------------------------------
+"""
+
+import pytest
+from unittest.mock import patch
+from pathlib import Path
+import numpy as np
+import pandas as pd
+from sensors.quantification.sampling_quantification_predictor import SamplingQuantificationPredictor
+import constants.error_messages as em
+
+
+@pytest.fixture
+def mock_df():
+    return pd.DataFrame({"valid_column": [1, 2, 3, np.nan]})
+
+
+def mock_SamplingQuantificationPredictor_init(self, quantification_file, quantification_column):
+    return None
+
+
+@pytest.fixture
+def predictor_instance(monkeypatch):
+    monkeypatch.setattr(
+        SamplingQuantificationPredictor,
+        "__init__",
+        mock_SamplingQuantificationPredictor_init,
+    )
+    return SamplingQuantificationPredictor("test_file", "test_column")
+
+
+@patch("pandas.read_csv")
+def test_set_quantification_errors_handles_nan_values_correctly(
+    mock_read_csv, mock_df, predictor_instance
+):
+    mock_read_csv.return_value = mock_df
+    predictor_instance._set_quantification_errors("test_file", "valid_column", Path("test_dir"))
+
+    # Assuming the method filters out NaN values, expect 3 non-NaN entries
+    assert len(predictor_instance._quantification_errors) == 3
+
+
+def test_set_quantification_errors_file_not_found(predictor_instance, tmp_path):
+    """
+    Test that FileNotFoundError is raised when the quantification file does not exist.
+    """
+    with pytest.raises(FileNotFoundError) as excinfo:
+        predictor_instance._set_quantification_errors(
+            quantification_file="nonexistent.csv",
+            quantification_column="any_column",
+            input_dir=tmp_path,
+        )
+    assert em.Input_Processing_Messages.QUANTIFICATION_FILE_NOT_FOUND.format(
+        quantification_file="nonexistent.csv", input_dir=tmp_path
+    ) in str(excinfo.value)
+
+
+def test_set_quantification_errors_invalid_column(predictor_instance, tmp_path):
+    """
+    Test that ValueError is raised when the specified
+        quantification column does not exist in the file.
+    """
+    # Setup a valid quantification file with an unexpected column
+    quantification_file = tmp_path / "quantification.csv"
+    df = pd.DataFrame({"unexpected_column": [1, 2, 3]})
+    df.to_csv(quantification_file, index=False)
+
+    with pytest.raises(ValueError) as excinfo:
+        predictor_instance._set_quantification_errors(
+            quantification_file=str(quantification_file),
+            quantification_column="nonexistent_column",
+            input_dir=tmp_path,
+        )
+    assert em.Input_Processing_Messages.QUANTIFICATION_INVALID_COLUMN.format(
+        quantification_file=str(quantification_file),
+        quantification_column="nonexistent_column",
+    ) in str(excinfo.value)


### PR DESCRIPTION
# Pull Request Key Information

## Reason for change

Original code did not add in handling when NaN values were read in. This resulted in measurements turned to NaN when quantification error is factored in, as NaN * any value = NaN. 

## What was changed

Adjust the initialization/handling of the quantification error values when samples are used. 

## Intended Purpose

Fix the issue where measurements would result in NaN due to invalid QE being used to multiply "measured rate". 

## Level of version change required

Patch

## Testing Completed

New unit tests were added, all existing unit tests pass. 
[results.txt](https://github.com/user-attachments/files/16358030/results.txt)

Manually tested to see that the behavior is gone. 

All E2E tests are passing. 
[V4_simple_non_repairable_emissions_e3c3306d590233f92ae887ddd9e48c39452b5d10.log](https://github.com/user-attachments/files/16358215/V4_simple_non_repairable_emissions_e3c3306d590233f92ae887ddd9e48c39452b5d10.log)
[V4-simple_repairable_emissions_e3c3306d590233f92ae887ddd9e48c39452b5d10.log](https://github.com/user-attachments/files/16358216/V4-simple_repairable_emissions_e3c3306d590233f92ae887ddd9e48c39452b5d10.log)


## Target Issue

Put GitHub keywords to link the pull request to the target issue here. For example: Closes #XX.

## Additional Information

Include any other important information here.
