### PR TITLE
<FIX>: Fixed pre-generate emission dates

### DIFF
--- a/LDAR_Sim/src/virtual_world/sources.py
+++ b/LDAR_Sim/src/virtual_world/sources.py
@@ -297,7 +297,7 @@ class Source:
         # for the given source, the loop will break once the first is made,
         # since no other emissions should exist
         last_emis_day: date = sim_start_date
-        for day in range(self._emis_duration, 1, -1):
+        for day in range(self._emis_duration, 0, -1):
             create_emis: int = np.random.binomial(1, self._emis_prod_rate)
             if not create_emis:
                 continue

--- a/LDAR_Sim/testing/unit_testing/test_initialization/test_sources/test_generate_emissions.py
+++ b/LDAR_Sim/testing/unit_testing/test_initialization/test_sources/test_generate_emissions.py
@@ -143,22 +143,22 @@ def simple_inputs():
 
 
 def expected_dictionary():
-    return {"source1": [date(2021, 5, 21)]}
+    return {"source1": [date(2021, 5, 20)]}
 
 
 def expected_dictionary2():
     return {
         "source1": [
-            date(2021, 1, 12),
-            date(2021, 2, 13),
-            date(2021, 3, 3),
-            date(2021, 3, 5),
-            date(2021, 5, 21),
-            date(2021, 6, 5),
-            date(2021, 7, 21),
-            date(2021, 9, 19),
-            date(2021, 10, 5),
-            date(2021, 10, 17),
+            date(2021, 1, 11),
+            date(2021, 2, 12),
+            date(2021, 3, 2),
+            date(2021, 3, 4),
+            date(2021, 5, 20),
+            date(2021, 6, 4),
+            date(2021, 7, 20),
+            date(2021, 9, 18),
+            date(2021, 10, 4),
+            date(2021, 10, 16),
         ]
     }
 
@@ -176,20 +176,20 @@ def expected_dictionary3():
             date(2020, 9, 28),
             date(2020, 10, 14),
             date(2020, 10, 26),
+            date(2021, 2, 25),
             date(2021, 2, 26),
-            date(2021, 2, 27),
-            date(2021, 3, 4),
-            date(2021, 3, 25),
-            date(2021, 3, 29),
-            date(2021, 4, 25),
-            date(2021, 7, 18),
-            date(2021, 8, 20),
-            date(2021, 8, 24),
-            date(2021, 9, 13),
-            date(2021, 9, 18),
-            date(2021, 10, 6),
-            date(2021, 10, 23),
-            date(2021, 12, 30),
+            date(2021, 3, 3),
+            date(2021, 3, 24),
+            date(2021, 3, 28),
+            date(2021, 4, 24),
+            date(2021, 7, 17),
+            date(2021, 8, 19),
+            date(2021, 8, 23),
+            date(2021, 9, 12),
+            date(2021, 9, 17),
+            date(2021, 10, 5),
+            date(2021, 10, 22),
+            date(2021, 12, 29),
         ]
     }
 

--- a/LDAR_Sim/testing/unit_testing/test_virtual_world/test_sources/test_generate_emissions.py
+++ b/LDAR_Sim/testing/unit_testing/test_virtual_world/test_sources/test_generate_emissions.py
@@ -168,4 +168,4 @@ def test_001_test_multi_emission_creation(mocker) -> None:
         emission_rate_source_dictionary,
         repair_delay_dataframe,
     )
-    assert len(emissions_dict["test"]) == 728
+    assert len(emissions_dict["test"]) == 729


### PR DESCRIPTION
# Pull Request Key Information

## Reason for change

The previous update did not include the last day before the emission

## What was changed

Change generate emissions  to include the missing day in the emissions regeneration

## Intended Purpose

Address the bug that was introduced

## Level of version change required

Patch

## Testing Completed

All unit tests pass. 
Additional manual testing was done to ensure that the logic was sound. 
E2E tests were not done as it's expected to be broken and #271 will be remaking them. 