### PR TITLE
<ENH>: Remove pregenerated files in script

### DIFF
--- a/LDAR_Sim/testing/end_to_end_testing/e2e_suite_runner.py
+++ b/LDAR_Sim/testing/end_to_end_testing/e2e_suite_runner.py
@@ -27,6 +27,7 @@ import pandas as pd
 from pathlib import Path
 from datetime import date
 from testing_utils.result_verification import compare_outputs
+from testing_utils.remove_generator import remove_non_preseed_files
 
 # Get directories and set up root
 e2e_test_dir: Path = Path(os.path.dirname(os.path.realpath(__file__)))
@@ -124,8 +125,7 @@ if __name__ == "__main__":
             input_manager.write_parameters(out_dir / Output_Files.PARAMETER_FILE)
 
             generator_dir = in_dir / Generator_Files.GENERATOR_FOLDER
-            if os.path.exists(generator_dir):
-                print(rm.GEN_WARNING_MSG)
+            remove_non_preseed_files(generator_dir)
             print(rm.INIT_INFRA)
             simulation_count: int = sim_params[pdc.Sim_Setting_Params.SIMS]
             emis_preseed_val: list[int] = None

--- a/LDAR_Sim/testing/end_to_end_testing/e2e_test_case_creator.py
+++ b/LDAR_Sim/testing/end_to_end_testing/e2e_test_case_creator.py
@@ -29,6 +29,7 @@ from typing import Any
 from datetime import date
 import yaml
 import gc
+from testing_utils.remove_generator import remove_non_preseed_files
 
 # Get directories and set up root
 e2e_test_dir: Path = Path(os.path.dirname(os.path.realpath(__file__)))
@@ -274,3 +275,6 @@ if __name__ == "__main__":
     shutil.move(params_dir, test_case_dir)
     shutil.move(in_dir, test_case_dir)
     shutil.move(test_case_dir, tests_dir / sys.argv[3])
+
+    test_generator = tests_dir / sys.argv[3] / "inputs" / "generator"
+    remove_non_preseed_files(test_generator)

--- a/LDAR_Sim/testing/end_to_end_testing/testing_utils/remove_generator.py
+++ b/LDAR_Sim/testing/end_to_end_testing/testing_utils/remove_generator.py
@@ -1,0 +1,37 @@
+"""
+------------------------------------------------------------------------------
+Program:     The LDAR Simulator (LDAR-Sim)
+File:        remove_generator.py
+Purpose: Contains function for removing all the non-preseed generator files
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the MIT License as published
+by the Free Software Foundation, version 3.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+MIT License for more details.
+You should have received a copy of the MIT License
+along with this program.  If not, see <https://opensource.org/licenses/MIT>.
+
+------------------------------------------------------------------------------
+"""
+
+import os
+
+
+def remove_non_preseed_files(directory):
+    """
+    Remove all files in the given directory except for 'preseed.p'.
+
+    :param directory: Path to the directory to clean up.
+    """
+    try:
+        for filename in os.listdir(directory):
+            file_path = os.path.join(directory, filename)
+            if os.path.isfile(file_path) and "preseed" not in filename:
+                os.remove(file_path)
+                print(f"Removed: {file_path}")
+    except Exception as e:
+        print(f"An error occurred: {e}")

--- a/LDAR_Sim/testing/end_to_end_testing/testing_utils/remove_generator.py
+++ b/LDAR_Sim/testing/end_to_end_testing/testing_utils/remove_generator.py
@@ -32,6 +32,5 @@ def remove_non_preseed_files(directory):
             file_path = os.path.join(directory, filename)
             if os.path.isfile(file_path) and "preseed" not in filename:
                 os.remove(file_path)
-                print(f"Removed: {file_path}")
     except Exception as e:
         print(f"An error occurred: {e}")


### PR DESCRIPTION
# Pull Request Key Information

## Reason for change

Pregenerated emissions and infrastructure files can be counterproductive when trying to test for changes. Especially when emissions or infrastructure generation was changed. This change is to allow for the testing of emissions/infrastructure generation while maintaining the random number generator seeds. 

## What was changed

- Pregenerated infrastructure and emissions are deleted with the end-to-end testing scripts.

## Intended Purpose

Add to the script to remove the generated infrastructure and emissions files. This forces the generation of new infrastructure and emissions based on the random preseeds, which should result in the same emissions.

## Level of version change required

N/A

## Testing Completed

Manual testing was done to ensure that the correct files are deleted with the E2E test scripts.

Main code base was not affected. 

All Unit tests pass:
[results.txt](https://github.com/user-attachments/files/16430765/results.txt)
E2E tests pass:
[V4_simple_non_repairable_emissions_f67490e60a0a79b1733c2d5e5bb39bbaa9ec69c3.log](https://github.com/user-attachments/files/16430788/V4_simple_non_repairable_emissions_f67490e60a0a79b1733c2d5e5bb39bbaa9ec69c3.log)
[V4-simple_repairable_emissions_f67490e60a0a79b1733c2d5e5bb39bbaa9ec69c3.log](https://github.com/user-attachments/files/16430789/V4-simple_repairable_emissions_f67490e60a0a79b1733c2d5e5bb39bbaa9ec69c3.log)

