### PR TITLE
Ldar 52 update the e2 e run script

### DIFF
--- a/LDAR_Sim/src/simulation/end_to_end_test_simulation_manager.py
+++ b/LDAR_Sim/src/simulation/end_to_end_test_simulation_manager.py
@@ -1,0 +1,80 @@
+import os
+from pathlib import Path
+from typing import Any, override
+
+from constants import param_default_const as pdc
+from constants.output_messages import RuntimeMessages as rm
+from file_processing.input_processing.input_manager import InputManager
+from file_processing.output_processing.summary_output_helpers import get_non_baseline_prog_names
+from initialization.args import get_abs_path
+from initialization.preseed import gen_seed_emis
+from simulation.simulation_helpers import remove_non_preseed_files
+from simulation.simulation_manager import SimulationManager
+
+
+class EndToEndTestSimulationManager(SimulationManager):
+    def __init__(self, input_manager: InputManager, parameter_filenames: list[str], test_dir: Path):
+        self.GLOBAL_PARAMS_TO_REP: "dict[str, Any]" = {
+            pdc.Sim_Setting_Params.SIMS: 2,
+            pdc.Sim_Setting_Params.PRESEED: True,
+            pdc.Sim_Setting_Params.INPUT: "./inputs",
+            pdc.Sim_Setting_Params.OUTPUT: "./outputs",
+        }
+
+        self.GLOBAL_OUTPUT_PARAMS: "dict[str, Any]" = {
+            pdc.Output_Params.PROGRAM_VISUALIZATIONS: {
+                pdc.Output_Params.SINGLE_PROGRAM_TIMESERIES: False
+            }
+        }
+        self.test_dir: Path = test_dir
+
+        super().__init__(input_manager=input_manager, parameter_filenames=parameter_filenames)
+        self.overwrite_test_params()
+        self.expected_results: Path = test_dir / "expected_outputs"
+
+    def overwrite_test_params(self):
+        for key, value in self.GLOBAL_PARAMS_TO_REP.items():
+            self.sim_params[key] = value
+
+        for key, value in self.GLOBAL_OUTPUT_PARAMS.items():
+            self.output_params[key] = value
+
+    @override
+    def _read_in_parameters(
+        self, input_manager: InputManager, parameter_filenames: list[str]
+    ) -> None:
+        self.sim_params: dict = input_manager.read_and_validate_parameters(parameter_filenames)
+        self.out_dir: Path = get_abs_path(
+            self.sim_params[pdc.Sim_Setting_Params.OUTPUT], self.test_dir
+        )
+
+        self._set_parameters(self.test_dir)
+
+    @override
+    def _set_parameters(self, test_dir: Path) -> None:
+        super()._set_parameters()
+
+        self.in_dir = get_abs_path(self.sim_params[pdc.Sim_Setting_Params.INPUT], test_dir)
+
+    @override
+    def check_generator_files(self) -> bool:
+        remove_non_preseed_files(self.generator_dir)
+
+        print(rm.INIT_INFRA)
+
+        if self.preseed_random:
+            self.emis_preseed_val, self.force_remake_gen = gen_seed_emis(
+                self.simulation_count, self.generator_dir
+            )
+
+    @override
+    def run_simulations(self, DEBUG) -> None:
+        self._run_simulation_multiprocessing(sim_counts=[self.simulation_count])
+
+    @override
+    def generate_summary_results(self) -> None:
+        non_baseline_progs = get_non_baseline_prog_names(self.programs, self.base_program)
+        self.summary_stats_manager.gen_cost_summary_outputs(non_baseline_progs)
+
+    def validate_outputs(self, test: os.DirEntry, comparison_function: callable) -> None:
+        comparison_function(test.name, self.out_dir, self.expected_results)

--- a/LDAR_Sim/testing/end_to_end_testing/e2e_suite_runner.py
+++ b/LDAR_Sim/testing/end_to_end_testing/e2e_suite_runner.py
@@ -18,14 +18,10 @@
 #
 # ------------------------------------------------------------------------------
 
-import multiprocessing as mp
+
 import os
-import shutil
 import sys
-import gc
-import pandas as pd
 from pathlib import Path
-from datetime import date
 from testing_utils.result_verification import compare_outputs
 
 # Get directories and set up root
@@ -38,214 +34,42 @@ os.chdir(root_dir)
 sys.path.insert(1, str(src_dir))
 
 if __name__ == "__main__":
-    from constants.error_messages import Runtime_Error_Messages as rem
-    from constants.file_name_constants import Output_Files, Generator_Files
-    from constants.output_messages import RuntimeMessages as rm
-    import constants.param_default_const as pdc
+
     from file_processing.input_processing.input_manager import InputManager
-    from file_processing.output_processing.summary_output_helpers import get_non_baseline_prog_names
-    from file_processing.output_processing.summary_output_manager import SummaryOutputManager
-    from file_processing.output_processing.summary_visualization_manager import (
-        SummaryVisualizationManager,
-    )
-    from initialization.args import files_from_path, get_abs_path
-    from initialization.initialize_emissions import initialize_emissions, read_in_emissions
-    from initialization.initialize_infrastructure import initialize_infrastructure
-    from initialization.preseed import gen_seed_emis
-    from simulation.simulation_helpers import simulate
-    from utils.generic_functions import check_ERA5_file
-    from utils.prog_method_measured_func import (
-        set_up_tf_method_deployed_df,
-        filter_deployment_tf_by_program_methods,
-    )
-    from simulation.simulation_helpers import remove_non_preseed_files
-    from virtual_world.infrastructure import Infrastructure
-    from weather.daylight_calculator import DaylightCalculatorAve
-    from weather.weather_lookup import WeatherLookup as WL
+    from initialization.args import files_from_path
+    from simulation.end_to_end_test_simulation_manager import EndToEndTestSimulationManager
 
-    GLOBAL_PARAMS_TO_REP: "dict[str, Any]" = {
-        pdc.Sim_Setting_Params.SIMS: 2,
-        pdc.Sim_Setting_Params.PRESEED: True,
-        pdc.Sim_Setting_Params.INPUT: "./inputs",
-        pdc.Sim_Setting_Params.OUTPUT: "./outputs",
-    }
-
-    GLOBAL_OUTPUT_PARAMS: "dict[str, Any]" = {
-        pdc.Output_Params.PROGRAM_VISUALIZATIONS: {
-            pdc.Output_Params.SINGLE_PROGRAM_TIMESERIES: False
-        }
-    }
-
-    # Get root directory , which is parent folder of ldar_sim_main file
-    # Set current working directory directory to root directory
-    # --- Retrieve input parameters and parse ---
     for test in os.scandir(tests_dir):
+
         if test.is_dir():
             print(f"Running test: {test.name}")
             test_dir: Path = Path(os.path.normpath(test))
             params_dir = test_dir / "params"
             parameter_filenames = files_from_path(params_dir)
             input_manager = InputManager()
-            sim_params = input_manager.read_and_validate_parameters(parameter_filenames)
-            # --- Overwrite certain parameters for end-to-end testing ---
-            for key, value in GLOBAL_PARAMS_TO_REP.items():
-                sim_params[key] = value
-            # --- Assign local variabls
-            in_dir = get_abs_path(sim_params[pdc.Sim_Setting_Params.INPUT], test_dir)
-            out_dir = get_abs_path(sim_params[pdc.Sim_Setting_Params.OUTPUT], test_dir)
-            base_program = sim_params[pdc.Sim_Setting_Params.BASELINE]
-            programs = sim_params.pop(pdc.Levels.PROGRAM)
-            virtual_world = sim_params.pop(pdc.Levels.VIRTUAL)
-            output_params = sim_params.pop(pdc.Levels.OUTPUTS)
-            preseed_random = sim_params[pdc.Sim_Setting_Params.PRESEED]
-            expected_results = test_dir / "expected_outputs"
 
-            # -- Overwrite certain output params for end-to-end testing --
-            for key, value in GLOBAL_OUTPUT_PARAMS.items():
-                output_params[key] = value
-
-            methods = {
-                method: programs[program][pdc.Levels.METHOD][method]
-                for program in programs
-                for method in programs[program][pdc.Program_Params.METHODS]
-            }
-
-            # --- Run Checks ----
-            check_ERA5_file(in_dir, virtual_world)
-            has_base: bool = base_program in programs
-
-            if not (has_base):
-                print(rem.NO_BASE_PROG_ERROR)
-                sys.exit()
-
-            # -- Setup Output folder --
-            if os.path.exists(out_dir):
-                shutil.rmtree(out_dir)
-            os.makedirs(out_dir)
-            input_manager.write_parameters(out_dir / Output_Files.PARAMETER_FILE)
-
-            generator_dir = in_dir / Generator_Files.GENERATOR_FOLDER
-            remove_non_preseed_files(generator_dir)
-            print(rm.INIT_INFRA)
-            simulation_count: int = sim_params[pdc.Sim_Setting_Params.SIMS]
-            emis_preseed_val: list[int] = None
-            force_remake_gen: bool = False
-            if preseed_random:
-                emis_preseed_val, force_remake_gen = gen_seed_emis(simulation_count, generator_dir)
-            infrastructure: Infrastructure
-            hash_file_exist: bool
-            site_measured: pd.DataFrame = set_up_tf_method_deployed_df(
-                methods, virtual_world[pdc.Virtual_World_Params.N_SITES]
+            simulation_manager: EndToEndTestSimulationManager = EndToEndTestSimulationManager(
+                input_manager=input_manager,
+                parameter_filenames=parameter_filenames,
+                test_dir=test_dir,
             )
-            infrastructure, hash_file_exist = initialize_infrastructure(
-                methods,
-                programs,
-                virtual_world,
-                generator_dir,
-                in_dir,
-                preseed_random,
-                emis_preseed_val,
-                force_remake_gen,
-            )
-            infrastructure.gen_site_measured_tf_data(
-                methods,
-                site_measured,
-            )
-            print(rm.INIT_EMISS)
-            # Pregenerate emissions
-            seed_timeseries = initialize_emissions(
-                simulation_count,
-                preseed_random,
-                emis_preseed_val,
-                hash_file_exist,
-                infrastructure,
-                date(*virtual_world[pdc.Virtual_World_Params.START_DATE]),
-                date(*virtual_world[pdc.Virtual_World_Params.END_DATE]),
-                generator_dir,
-            )
-            # Initialize objects
-            print(rm.INIT_WEATHER)
-            weather = WL(virtual_world, in_dir)
-            infrastructure.set_weather_index(weather)
-            print(rm.INIT_DAYLIGHT)
-            daylight = DaylightCalculatorAve(
-                infrastructure.get_site_avrg_lat_lon(),
-                date(*virtual_world[pdc.Virtual_World_Params.START_DATE]),
-                date(*virtual_world[pdc.Virtual_World_Params.END_DATE]),
-            )
-            # Calculate the simulation years
-            simulation_years: list[int] = [
-                year
-                for year in range(
-                    virtual_world[pdc.Virtual_World_Params.START_DATE][0],
-                    virtual_world[pdc.Virtual_World_Params.END_DATE][0] + 1,
-                )
-            ]
-            # Initialize output managers
-            summary_stats_manager: SummaryOutputManager = SummaryOutputManager(
-                output_path=out_dir,
-                output_config=output_params,
-                sim_years=simulation_years,
-                programs=programs,
-            )
-            summary_visualization_manager: SummaryVisualizationManager = (
-                SummaryVisualizationManager(
-                    output_config=output_params,
-                    output_dir=out_dir,
-                    baseline_program=base_program,
-                    site_count=virtual_world[pdc.Virtual_World_Params.N_SITES],
-                )
-            )
-            n_process = sim_params[pdc.Sim_Setting_Params.PROCESS]
-            if len(programs) < sim_params[pdc.Sim_Setting_Params.PROCESS]:
-                n_process = len(programs)
-            with mp.Manager() as manager:
-                lock = manager.Lock()
-                for simulation_number in range(simulation_count):
-                    print(rm.SIM_SET.format(simulation_number=simulation_number))
-                    # read in pregen emissions
-                    infra = read_in_emissions(infrastructure, generator_dir, simulation_number)
-                    # -- Run simulations --
-                    prog_data = []
-                    for program in programs:
-                        meth_params = {}
-                        prog_measured_df = filter_deployment_tf_by_program_methods(
-                            site_measured, programs[program][pdc.Program_Params.METHODS]
-                        )
-                        for meth in programs[program][pdc.Program_Params.METHODS]:
-                            meth_params[meth] = methods[meth]
-                        prog_data.append(
-                            (
-                                daylight,
-                                weather,
-                                simulation_number,
-                                program,
-                                meth_params,
-                                programs[program],
-                                sim_params,
-                                virtual_world,
-                                output_params,
-                                infra,
-                                in_dir,
-                                out_dir,
-                                seed_timeseries,
-                                lock,
-                                prog_measured_df,
-                            )
-                        )
 
-                    with mp.Pool(processes=n_process) as p:
-                        _ = p.starmap(
-                            simulate,
-                            prog_data,
-                        )
-                    gc.collect()
-                    print(rm.FIN_SIM_SET.format(simulation_number=simulation_number))
+            simulation_manager.check_inputs()
 
-                # -- Batch Report --
-                print(rm.BATCH_CLEAN.format(batch_count=0))
-                summary_stats_manager.gen_summary_outputs(False)
-                non_baseline_progs = get_non_baseline_prog_names(programs, base_program)
-                summary_stats_manager.gen_cost_summary_outputs(non_baseline_progs)
-            # Compare results to expected
-            compare_outputs(test.name, out_dir, expected_results)
+            simulation_manager.initialize_outputs(input_manager)
+
+            simulation_manager.check_generator_files()
+
+            simulation_manager.setup_infrastructure()
+
+            simulation_manager.setup_emissions()
+
+            simulation_manager.setup_weather()
+
+            simulation_manager.setup_daylight()
+
+            simulation_manager.run_simulations(DEBUG=False)
+
+            simulation_manager.generate_summary_results()
+
+            simulation_manager.validate_outputs(test=test, comparison_function=compare_outputs)

--- a/LDAR_Sim/testing/end_to_end_testing/e2e_suite_runner.py
+++ b/LDAR_Sim/testing/end_to_end_testing/e2e_suite_runner.py
@@ -37,7 +37,7 @@ if __name__ == "__main__":
 
     from file_processing.input_processing.input_manager import InputManager
     from initialization.args import files_from_path
-    from simulation.end_to_end_test_simulation_manager import EndToEndTestSimulationManager
+    from end_to_end_test_simulation_manager import EndToEndTestSimulationManager
 
     for test in os.scandir(tests_dir):
 

--- a/LDAR_Sim/testing/end_to_end_testing/e2e_suite_runner.py
+++ b/LDAR_Sim/testing/end_to_end_testing/e2e_suite_runner.py
@@ -22,7 +22,6 @@
 import os
 import sys
 from pathlib import Path
-from testing_utils.result_verification import compare_outputs
 
 # Get directories and set up root
 e2e_test_dir: Path = Path(os.path.dirname(os.path.realpath(__file__)))
@@ -72,4 +71,4 @@ if __name__ == "__main__":
 
             simulation_manager.generate_summary_results()
 
-            simulation_manager.validate_outputs(test=test, comparison_function=compare_outputs)
+            simulation_manager.validate_outputs(test=test)

--- a/LDAR_Sim/testing/end_to_end_testing/end_to_end_test_simulation_manager.py
+++ b/LDAR_Sim/testing/end_to_end_testing/end_to_end_test_simulation_manager.py
@@ -1,9 +1,31 @@
+# ------------------------------------------------------------------------------
+# Program:     The LDAR Simulator (LDAR-Sim)
+# File:        end_to_end_test_simulation_manager.py
+# Purpose:     Manager for running end-to-end tests for LDAR-Sim.
+#              Manages the state of simulation artifacts.
+#
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the MIT License as published
+# by the Free Software Foundation, version 3.
+
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# MIT License for more details.
+
+# You should have received a copy of the MIT License
+# along with this program.  If not, see <https://opensource.org/licenses/MIT>.
+#
+# ------------------------------------------------------------------------------
+
 import os
 from pathlib import Path
 from typing import Any, override
 
 from constants import param_default_const as pdc
 from constants.output_messages import RuntimeMessages as rm
+from constants.file_processing_const import IOLocationConstants as io_loc
 from file_processing.input_processing.input_manager import InputManager
 from file_processing.output_processing.summary_output_helpers import get_non_baseline_prog_names
 from initialization.args import get_abs_path
@@ -17,8 +39,8 @@ class EndToEndTestSimulationManager(SimulationManager):
         self.GLOBAL_PARAMS_TO_REP: "dict[str, Any]" = {
             pdc.Sim_Setting_Params.SIMS: 2,
             pdc.Sim_Setting_Params.PRESEED: True,
-            pdc.Sim_Setting_Params.INPUT: "./inputs",
-            pdc.Sim_Setting_Params.OUTPUT: "./outputs",
+            pdc.Sim_Setting_Params.INPUT: io_loc.TESTING_INPUTS_FOLDER,
+            pdc.Sim_Setting_Params.OUTPUT: io_loc.TESTING_OUTPUTS_FOLDER,
         }
 
         self.GLOBAL_OUTPUT_PARAMS: "dict[str, Any]" = {
@@ -30,7 +52,7 @@ class EndToEndTestSimulationManager(SimulationManager):
 
         super().__init__(input_manager=input_manager, parameter_filenames=parameter_filenames)
         self.overwrite_test_params()
-        self.expected_results: Path = test_dir / "expected_outputs"
+        self.expected_results: Path = test_dir / io_loc.EXPECTED_OUTPUTS_FOLDER
 
     def overwrite_test_params(self):
         for key, value in self.GLOBAL_PARAMS_TO_REP.items():

--- a/LDAR_Sim/testing/end_to_end_testing/end_to_end_test_simulation_manager.py
+++ b/LDAR_Sim/testing/end_to_end_testing/end_to_end_test_simulation_manager.py
@@ -32,6 +32,7 @@ from initialization.args import get_abs_path
 from initialization.preseed import gen_seed_emis
 from simulation.simulation_helpers import remove_non_preseed_files
 from simulation.simulation_manager import SimulationManager
+from testing_utils.result_verification import compare_outputs
 
 
 class EndToEndTestSimulationManager(SimulationManager):
@@ -98,5 +99,5 @@ class EndToEndTestSimulationManager(SimulationManager):
         non_baseline_progs = get_non_baseline_prog_names(self.programs, self.base_program)
         self.summary_stats_manager.gen_cost_summary_outputs(non_baseline_progs)
 
-    def validate_outputs(self, test: os.DirEntry, comparison_function: callable) -> None:
-        comparison_function(test.name, self.out_dir, self.expected_results)
+    def validate_outputs(self, test: os.DirEntry) -> None:
+        compare_outputs(test.name, self.out_dir, self.expected_results)

--- a/LDAR_Sim/testing/end_to_end_testing/testing_utils/result_verification.py
+++ b/LDAR_Sim/testing/end_to_end_testing/testing_utils/result_verification.py
@@ -24,9 +24,9 @@ import os
 
 import subprocess
 from datetime import datetime
-from typing import Any, Literal
+from typing import Literal
 import pandas as pd
-import yaml
+
 
 DEFAULT_TEST_DIR: str = "testing/end_to_end_testing/test_results/"
 


### PR DESCRIPTION
# Pull Request Key Information

## Reason for change

The end-to-end test runner script was long, hard to maintain and did not share code with other scripts that "run" LDAR-Sim.

## What was changed

Refactored the end-to-end test runner script to use an end-to-end test runner simulation manager that inherits core functionality from the base simulation manager. 

## Intended Purpose

This allows the end-to-end test runner simulation manager to inherit changes made to LDAR-Sim run functionality.

## Level of version change required

N/A

## Testing Completed

All E2E tests pass: 
[V4_simple_non_repairable_emissions_b9494d55c4654f1f1128c498423dcee712564eca.log](https://github.com/user-attachments/files/16516250/V4_simple_non_repairable_emissions_b9494d55c4654f1f1128c498423dcee712564eca.log)
[V4-simple_repairable_emissions_b9494d55c4654f1f1128c498423dcee712564eca.log](https://github.com/user-attachments/files/16516251/V4-simple_repairable_emissions_b9494d55c4654f1f1128c498423dcee712564eca.log)


All unit tests pass: 
[unit_test_results.txt](https://github.com/user-attachments/files/16516246/unit_test_results.txt)


## Target Issue

N/A

## Additional Information

N/A
