### PR TITLE
Emissions creation typerror fix

### DIFF
--- a/LDAR_Sim/src/virtual_world/sources.py
+++ b/LDAR_Sim/src/virtual_world/sources.py
@@ -174,7 +174,7 @@ class Source:
             sys.exit()
         self._emis_rate_source = prop_params[IC.Sources_File_Constants.EMIS_ERS]
         self._emis_prod_rate = prop_params[IC.Sources_File_Constants.EMIS_EPR]
-        self._emis_duration = prop_params[IC.Sources_File_Constants.EMIS_DUR]
+        self._emis_duration = int(prop_params[IC.Sources_File_Constants.EMIS_DUR])
         self._multi_emissions = prop_params[IC.Sources_File_Constants.MULTI_EMISSIONS]
 
         self._meth_spat_covs = prop_params[pdc.Common_Params.METH_SPECIFIC][
@@ -326,7 +326,7 @@ class Source:
             leak_count += 1
             emissions_fifo.append(emission)
             if not self._multi_emissions:
-                last_emis_day = emis_start_date + timedelta(days=int(self._emis_duration))
+                last_emis_day = emis_start_date + timedelta(days=self._emis_duration)
                 # If only one emission is allowed, break the loop
                 break
 
@@ -359,7 +359,7 @@ class Source:
             if not self._multi_emissions:
                 # if only a single emission can be made,
                 # update the last_emis_day based on the new emission
-                last_emis_day = emis_start_date + timedelta(days=int(self._emis_duration))
+                last_emis_day = emis_start_date + timedelta(days=self._emis_duration)
         emissions_fifo.reverse()
         self._generated_emissions[sim_number] = emissions_fifo
         return {self._source_ID: emissions_fifo}


### PR DESCRIPTION
# Pull Request Key Information

## Reason for change

Fix type-error that occur with emissions creation

## What was changed

Add typecasting to avoid type-errors.

## Intended Purpose

Prevent type-errors during runtime

## Level of version change required

Patch

## Testing Completed

Manual testing using modified sites file to produce error (Added emissions duration): 
[facilities_Perm_for_test.csv](https://github.com/user-attachments/files/16605098/facilities_Perm_for_test.csv)

All other input are parameter were sourced from simple_test_case1

All unit tests passing:
[unit_test_results.txt](https://github.com/user-attachments/files/16605164/unit_test_results.txt)

All E2E test passing: 
[V4-simple_repairable_emissions_5f77e95675f2c4286e250f910aac2e7374cafc0c.log](https://github.com/user-attachments/files/16605202/V4-simple_repairable_emissions_5f77e95675f2c4286e250f910aac2e7374cafc0c.log)
[V4_simple_non_repairable_emissions_5f77e95675f2c4286e250f910aac2e7374cafc0c.log](https://github.com/user-attachments/files/16605203/V4_simple_non_repairable_emissions_5f77e95675f2c4286e250f910aac2e7374cafc0c.log)


## Target Issue

N/A

## Additional Information

N/A