### PR TITLE
feat: Add logging for runtime errors

### DIFF
--- a/LDAR_Sim/src/constants/output_messages.py
+++ b/LDAR_Sim/src/constants/output_messages.py
@@ -69,6 +69,8 @@ class RuntimeMessages:
     GEN_PRESEED_EMISS = "Generating Random Seed values for emissions..."
     GEN_ADD_PRESEED_EMISS = "Generating additional Random Seed values for emissions..."
 
+    SIMULATION_ERROR = "An error occurred during the simulation run."
+
 
 class InputHelpText:
     INPUT_FILE_HELP_TEXT = (

--- a/LDAR_Sim/src/ldar_sim_run.py
+++ b/LDAR_Sim/src/ldar_sim_run.py
@@ -19,6 +19,7 @@
 #
 # ------------------------------------------------------------------------------
 import cProfile
+import logging
 import os
 import sys
 from datetime import datetime
@@ -33,30 +34,36 @@ from simulation.simulation_manager import SimulationManager
 
 
 def run_ldar_sim(parameter_filenames, DEBUG=False):
+    try:
 
-    input_manager = InputManager()
+        input_manager = InputManager()
 
-    simulation_manager: SimulationManager = SimulationManager(
-        input_manager=input_manager, parameter_filenames=parameter_filenames
-    )
+        simulation_manager: SimulationManager = SimulationManager(
+            input_manager=input_manager, parameter_filenames=parameter_filenames
+        )
 
-    simulation_manager.check_inputs()
+        simulation_manager.check_inputs()
 
-    simulation_manager.initialize_outputs(input_manager, setup_output_logging=True)
+        simulation_manager.initialize_outputs(input_manager, setup_output_logging=True)
 
-    simulation_manager.check_generator_files()
+        simulation_manager.check_generator_files()
 
-    simulation_manager.setup_infrastructure()
+        simulation_manager.setup_infrastructure()
 
-    simulation_manager.setup_emissions()
+        simulation_manager.setup_emissions()
 
-    simulation_manager.setup_weather()
+        simulation_manager.setup_weather()
 
-    simulation_manager.setup_daylight()
+        simulation_manager.setup_daylight()
 
-    simulation_manager.run_simulations(DEBUG=DEBUG)
+        simulation_manager.run_simulations(DEBUG=DEBUG)
 
-    simulation_manager.generate_summary_results()
+        simulation_manager.generate_summary_results()
+
+    except Exception as e:
+        logger: logging.Logger = logging.getLogger(__name__)
+        logger.exception("An error occurred during the simulation run.")
+        raise e
 
 
 def setup_logging(root_dir: Path) -> None:

--- a/LDAR_Sim/src/ldar_sim_run.py
+++ b/LDAR_Sim/src/ldar_sim_run.py
@@ -62,7 +62,7 @@ def run_ldar_sim(parameter_filenames, DEBUG=False):
 
     except Exception as e:
         logger: logging.Logger = logging.getLogger(__name__)
-        logger.exception("An error occurred during the simulation run.")
+        logger.exception(rm.SIMULATION_ERROR)
         raise e
 
 


### PR DESCRIPTION
# Pull Request Key Information

## Reason for change

LDAR-Sim runtime error messages are not logged, making it difficult to debug issues that occur during runtime.

## What was changed

This change adds logging for runtime errors to make it easier to identify and resolve issues.

## Intended Purpose

Runtime errors will be logged to the error file.

## Level of version change required

N/A

## Testing Completed

Manually tested using parameters and inputs from simple test case1. An alteration was made to the virtual world: infrastructure parameters such that the sites file pointed to a file that did not exist so the simulation would encounter a FileNotFoundError. Manually verified the error was logged to the error log.

All unit tests pass:
[unit_test_results.txt](https://github.com/user-attachments/files/16617631/unit_test_results.txt)


All E2E tests pass: 
[V4_simple_non_repairable_emissions_2d531627e50dc78d9d44ef8e70224b36abc25722.log](https://github.com/user-attachments/files/16617744/V4_simple_non_repairable_emissions_2d531627e50dc78d9d44ef8e70224b36abc25722.log)
[V4-simple_repairable_emissions_2d531627e50dc78d9d44ef8e70224b36abc25722.log](https://github.com/user-attachments/files/16617745/V4-simple_repairable_emissions_2d531627e50dc78d9d44ef8e70224b36abc25722.log)


## Target Issue

N/A

## Additional Information

N/A
