### PR TITLE
fix: Fix failure to keep program outputs

### DIFF
--- a/LDAR_Sim/src/simulation/simulation_manager.py
+++ b/LDAR_Sim/src/simulation/simulation_manager.py
@@ -257,7 +257,7 @@ class SimulationManager:
                     gc.collect()
                     print(rm.FIN_SIM_SET.format(simulation_number=simulation_number))
                 print(rm.BATCH_CLEAN.format(batch_count=batch_count))
-            self.summary_stats_manager.gen_summary_outputs(batch_count != 0)
+                self.summary_stats_manager.gen_summary_outputs(batch_count != 0)
 
     def _setup_programs(
         self,


### PR DESCRIPTION
# Pull Request Key Information

## Reason for change

When running simulations, no programs outputs were being kept, which made it difficult to debug and understand the simulation results.

## What was changed

The simulation manager now correctly keeps the outputs of the programs.

## Intended Purpose

First 5 Program outputs are now properly kept

## Level of version change required

Patch

## Testing Completed

Manual testing.

All E2E tests pass:
[V4_simple_non_repairable_emissions_9cd3397da018723e0a7ec09ad2486988f39d8497.log](https://github.com/user-attachments/files/16618956/V4_simple_non_repairable_emissions_9cd3397da018723e0a7ec09ad2486988f39d8497.log)
[V4-simple_repairable_emissions_9cd3397da018723e0a7ec09ad2486988f39d8497.log](https://github.com/user-attachments/files/16618957/V4-simple_repairable_emissions_9cd3397da018723e0a7ec09ad2486988f39d8497.log)

All unit tests pass: 
[unit_test_results.txt](https://github.com/user-attachments/files/16618968/unit_test_results.txt)


## Target Issue

N/A

## Additional Information

N/A
