### PR TITLE
feat: Add parameter to keep all program outputs

### DIFF
--- a/LDAR_Sim/src/constants/param_default_const.py
+++ b/LDAR_Sim/src/constants/param_default_const.py
@@ -160,6 +160,7 @@ class Method_Params:
 @dataclass
 class Output_Params:
     PROGRAM_OUTPUTS = "Program Outputs"
+    KEEP_ALL_PROGRAM_OUTPUTS = "Keep All Program Outputs"
     PROGRAM_EMISSIONS = "Program Emissions"
     PROGRAM_TIMESERIES = "Program Timeseries"
     SUMMARY_OUTPUTS = "Summary Outputs"

--- a/LDAR_Sim/src/default_parameters/outputs_default.yml
+++ b/LDAR_Sim/src/default_parameters/outputs_default.yml
@@ -1,6 +1,7 @@
 parameter_level: "outputs"
 version: "4.0"
 Program Outputs:
+  Keep All Program Outputs: false
   Program Emissions: true
   Program Timeseries: true
 Program Visualizations:

--- a/LDAR_Sim/src/file_processing/output_processing/summary_output_helpers.py
+++ b/LDAR_Sim/src/file_processing/output_processing/summary_output_helpers.py
@@ -154,6 +154,10 @@ def mark_outputs_to_keep(dir: Path):
     with os.scandir(dir) as entries:
         for entry in entries:
             if entry.is_file():
+                if re.search(
+                    file_processing_const.Multi_Sim_Output_Const.OUTPUT_KEEP_REGEX, entry.name
+                ):
+                    continue
                 old_file_path = entry.path
                 new_name = file_processing_const.Multi_Sim_Output_Const.OUTPUT_KEEP_STR + entry.name
                 new_file_path = os.path.join(dir, new_name)

--- a/LDAR_Sim/src/simulation/simulation_manager.py
+++ b/LDAR_Sim/src/simulation/simulation_manager.py
@@ -111,6 +111,9 @@ class SimulationManager:
         self.sim_end_date: date = date(*self.virtual_world[pdc.Virtual_World_Params.END_DATE])
         self.seed_timeseries: dict[date, int] = None
         self.weather: WL = None
+        self.keep_all_program_outputs: bool = self.output_params[pdc.Output_Params.PROGRAM_OUTPUTS][
+            pdc.Output_Params.KEEP_ALL_PROGRAM_OUTPUTS
+        ]
         self.calc_simulation_years()
 
     def initialize_summary_managers(self) -> None:
@@ -234,7 +237,9 @@ class SimulationManager:
                     simulate(*program)
                 print(rm.FIN_SIM_SET.format(simulation_number=simulation_number))
             print(rm.BATCH_CLEAN.format(batch_count=batch_count))
-            self.summary_stats_manager.gen_summary_outputs(batch_count != 0)
+            self.summary_stats_manager.gen_summary_outputs(
+                batch_count != 0 and (not self.keep_all_program_outputs)
+            )
 
     def _run_simulation_multiprocessing(self, sim_counts: list[int]) -> None:
         n_processes: int = self.sim_params[pdc.Sim_Setting_Params.PROCESS]
@@ -257,7 +262,9 @@ class SimulationManager:
                     gc.collect()
                     print(rm.FIN_SIM_SET.format(simulation_number=simulation_number))
                 print(rm.BATCH_CLEAN.format(batch_count=batch_count))
-                self.summary_stats_manager.gen_summary_outputs(batch_count != 0)
+                self.summary_stats_manager.gen_summary_outputs(
+                    batch_count != 0 and (not self.keep_all_program_outputs)
+                )
 
     def _setup_programs(
         self,

--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -374,6 +374,14 @@ It is strongly recommended to use the default settings provided. These settings 
 
 It is important to understand that certain outputs are interdependent. Disabling an output that serves as a dependency for another may cause errors or unexpected behavior. Therefore, users should be cautious and ensure they have a thorough understanding of these dependencies before making changes.
 
+### Output Settings of Note
+
+#### Keep All Program Outputs
+
+By default, LDAR-Sim only keep the results of the first 5 simulations for each program. Changing this setting to true will result in LDAR-Sim keeping program results for all simulations.
+
+**Warning** It is not recommended to run a large number of simulations with this setting set to true as this will result in a significant amount of output files being kept, potentially filling up a users filesystem.
+
 --------------------------------------------------------------------------------
 
 ## 7\. Virtual World Setting


### PR DESCRIPTION
# Pull Request Key Information

## Reason for change

Sometimes users may want to keep all program outputs

## What was changed

Added a new parameter to the outputs parameters file to allow users to keep all program outputs.

## Intended Purpose

Users can now keep all program outputs

## Level of version change required

Patch

## Testing Completed

All unit tests pass:
[unit_test_results.txt](https://github.com/user-attachments/files/16631301/unit_test_results.txt)


All E2E tests pass:
[V4_simple_non_repairable_emissions_db0e4f1349ce51b027dd0b7974c9cf5951c05e42.log](https://github.com/user-attachments/files/16631292/V4_simple_non_repairable_emissions_db0e4f1349ce51b027dd0b7974c9cf5951c05e42.log)
[V4-simple_repairable_emissions_db0e4f1349ce51b027dd0b7974c9cf5951c05e42.log](https://github.com/user-attachments/files/16631293/V4-simple_repairable_emissions_db0e4f1349ce51b027dd0b7974c9cf5951c05e42.log)


Manually tested: Tested scenario with parameter set as default to false and parameter set as default to true with simple_test_case1 with simulation count modified to be 6.

## Target Issue

N/A

## Additional Information

N/A
