### PR TITLE
Add option to prevent pre simulation emissions

### DIFF
--- a/LDAR_Sim/src/constants/param_default_const.py
+++ b/LDAR_Sim/src/constants/param_default_const.py
@@ -81,6 +81,7 @@ class Virtual_World_Params:
     MULTI_EMIS = "multiple_emissions_per_source"
     MAX_RATE = "max_leak_rate"
     UNITS = "units"
+    PRE_SIM_EMIS = "Pre-Simulation Emissions"
 
 
 @dataclass

--- a/LDAR_Sim/src/default_parameters/virtual_world_default.yml
+++ b/LDAR_Sim/src/default_parameters/virtual_world_default.yml
@@ -22,6 +22,7 @@ repairs:
     # or the name of a column in the repair delays file to sample from
 emissions:
   emissions_file: "_placeholder_str_" # File containing sample emissions rates or emissions distributions.
+  Pre-Simulation Emissions: True # True/False of whether to simulate emissions before the start date of the simulation
   repairable_emissions:
     emissions_production_rate: "_placeholder_float_" # The production rate of repairable emissions
     emissions_rate_source: "_placeholder_str_" # The name of a column in the emissions file

--- a/LDAR_Sim/src/initialization/initialize_emissions.py
+++ b/LDAR_Sim/src/initialization/initialize_emissions.py
@@ -40,6 +40,7 @@ def initialize_emissions(
     start_date: date,
     end_date: date,
     generator_dir: Path,
+    pre_simulation_emissions: bool,
     force_remake: bool = False,
 ):
     n_sim_loc = generator_dir / Generator_Files.N_SIM_SAVE_FILE
@@ -58,6 +59,7 @@ def initialize_emissions(
                     sim_start_date=start_date,
                     sim_end_date=end_date,
                     sim_number=i,
+                    pre_simulation_emissions=pre_simulation_emissions,
                 )
             )
             with open(emis_file_loc, "wb") as f:
@@ -93,6 +95,7 @@ def initialize_emissions(
                         sim_start_date=start_date,
                         sim_end_date=end_date,
                         sim_number=i,
+                        pre_simulation_emissions=pre_simulation_emissions,
                     )
                 )
                 with open(emis_file_loc, "wb") as f:

--- a/LDAR_Sim/src/simulation/simulation_manager.py
+++ b/LDAR_Sim/src/simulation/simulation_manager.py
@@ -114,6 +114,9 @@ class SimulationManager:
         self.keep_all_program_outputs: bool = self.output_params[pdc.Output_Params.PROGRAM_OUTPUTS][
             pdc.Output_Params.KEEP_ALL_PROGRAM_OUTPUTS
         ]
+        self.pre_simulation_emissions: bool = self.virtual_world[pdc.Virtual_World_Params.EMIS][
+            pdc.Virtual_World_Params.PRE_SIM_EMIS
+        ]
         self.calc_simulation_years()
 
     def initialize_summary_managers(self) -> None:
@@ -198,6 +201,7 @@ class SimulationManager:
             self.sim_start_date,
             self.sim_end_date,
             self.generator_dir,
+            pre_simulation_emissions=self.pre_simulation_emissions,
         )
 
     def setup_weather(self) -> None:

--- a/LDAR_Sim/src/virtual_world/component.py
+++ b/LDAR_Sim/src/virtual_world/component.py
@@ -155,6 +155,7 @@ class Component:
         sim_number,
         emission_rate_source_dictionary: dict[str, EmissionsSource],
         repair_delay_dataframe: pd.DataFrame,
+        pre_simulation_emissions: bool,
     ) -> dict:
         equip_emissions = {}
         for src in self._sources:
@@ -165,6 +166,7 @@ class Component:
                     sim_number,
                     emission_rate_source_dictionary,
                     repair_delay_dataframe,
+                    pre_simulation_emissions=pre_simulation_emissions,
                 )
             )
 

--- a/LDAR_Sim/src/virtual_world/equipment_groups.py
+++ b/LDAR_Sim/src/virtual_world/equipment_groups.py
@@ -133,6 +133,7 @@ class Equipment_Group:
         sim_number,
         emission_rate_source_dictionary: dict[str, EmissionsSource],
         repair_delay_dataframe: pd.DataFrame,
+        pre_simulation_emissions: bool,
     ) -> dict:
         eqg_emissions = {}
         for eqmt in self._component:
@@ -143,6 +144,7 @@ class Equipment_Group:
                     sim_number,
                     emission_rate_source_dictionary,
                     repair_delay_dataframe,
+                    pre_simulation_emissions=pre_simulation_emissions,
                 )
             )
 

--- a/LDAR_Sim/src/virtual_world/infrastructure.py
+++ b/LDAR_Sim/src/virtual_world/infrastructure.py
@@ -149,7 +149,13 @@ class Infrastructure:
             site.set_pregen_emissions(emissions[site.get_id()], sim_number)
 
     # Generate Emissions for all infrastructure
-    def generate_emissions(self, sim_start_date, sim_end_date, sim_number) -> dict:
+    def generate_emissions(
+        self,
+        sim_start_date,
+        sim_end_date,
+        sim_number,
+        pre_simulation_emissions: bool = True,
+    ) -> dict:
         infrastructure_emissions: dict = {}
         for site in self._sites:
             infrastructure_emissions.update(
@@ -159,6 +165,7 @@ class Infrastructure:
                     sim_number,
                     self.emission_rate_source_dictionary,
                     self.repair_delay_dataframe,
+                    pre_simulation_emissions=pre_simulation_emissions,
                 )
             )
         return {sim_number: infrastructure_emissions}
@@ -273,7 +280,8 @@ class Infrastructure:
             site_measured_df (pd.DataFrame): The DataFrame with site measured data.
 
         Returns:
-            A dictionary: The dictionary with site potential measurement that can be used as a new row.
+            A dictionary: The dictionary with site potential
+            measurement that can be used as a new row.
         """
         for i, site in enumerate(self._sites):
 

--- a/LDAR_Sim/src/virtual_world/sites.py
+++ b/LDAR_Sim/src/virtual_world/sites.py
@@ -312,6 +312,7 @@ class Site:
         sim_number,
         emission_rate_source_dictionary: dict[str, EmissionsSource],
         repair_delay_dataframe: pd.DataFrame,
+        pre_simulation_emissions: bool,
     ) -> dict:
         site_emissions: dict = {}
         for eqg in self._equipment_groups:
@@ -323,6 +324,7 @@ class Site:
                     sim_number,
                     emission_rate_source_dictionary,
                     repair_delay_dataframe,
+                    pre_simulation_emissions=pre_simulation_emissions,
                 )
             )
 

--- a/LDAR_Sim/testing/unit_testing/test_initialization/test_sources/test_generate_emissions.py
+++ b/LDAR_Sim/testing/unit_testing/test_initialization/test_sources/test_generate_emissions.py
@@ -139,6 +139,7 @@ def simple_inputs():
         sim_number,
         emission_rate_source_dictionary,
         repair_delay_dataframe,
+        True,
     )
 
 

--- a/LDAR_Sim/testing/unit_testing/test_virtual_world/test_sites/sites_testing_fixtures.py
+++ b/LDAR_Sim/testing/unit_testing/test_virtual_world/test_sites/sites_testing_fixtures.py
@@ -134,6 +134,7 @@ def mock_site_for_simple_activate_emissions_fix() -> Tuple[Site, date, int]:
             "test": EmissionsSourceSample("test", "gram", "second", [1], 1000)
         },
         repair_delay_dataframe={},
+        pre_simulation_emissions=True,
     )
     activate_date: date = date(*[2017, 1, 1])
     return test_site, activate_date, 1
@@ -189,6 +190,7 @@ def mock_site_for_simple_get_detectable_emissions_fix() -> Tuple[Site, str]:
             "test": EmissionsSourceSample("test", "gram", "second", [1], 1000)
         },
         repair_delay_dataframe={},
+        pre_simulation_emissions=True,
     )
     activate_date: date = date(*[2017, 1, 1])
     test_site.activate_emissions(activate_date, 1)

--- a/LDAR_Sim/testing/unit_testing/test_virtual_world/test_sites/test_generate_emissions.py
+++ b/LDAR_Sim/testing/unit_testing/test_virtual_world/test_sites/test_generate_emissions.py
@@ -21,5 +21,6 @@ def test_000_generate_emissions_properly_generates_emissions_for_simple_site(
             "test": EmissionsSourceSample("test", "gram", "second", [1], 1000)
         },
         repair_delay_dataframe={},
+        pre_simulation_emissions=True,
     )
     assert emissions is not None

--- a/LDAR_Sim/testing/unit_testing/test_virtual_world/test_sources/test_generate_emissions.py
+++ b/LDAR_Sim/testing/unit_testing/test_virtual_world/test_sources/test_generate_emissions.py
@@ -78,6 +78,7 @@ def test_001_validate_date_randomness(mocker) -> None:
         sim_number,
         emission_rate_source_dictionary,
         repair_delay_dataframe,
+        True,
     )
 
     # Extract the dates of the emissions for testing randomness
@@ -129,6 +130,7 @@ def test_001_test_single_emission_creation(mocker) -> None:
         sim_number,
         emission_rate_source_dictionary,
         repair_delay_dataframe,
+        True,
     )
     assert len(emissions_dict["test"]) == 3
     assert emissions_dict["test"][2]._start_date == date(2022, 1, 1)
@@ -167,5 +169,6 @@ def test_001_test_multi_emission_creation(mocker) -> None:
         sim_number,
         emission_rate_source_dictionary,
         repair_delay_dataframe,
+        True,
     )
     assert len(emissions_dict["test"]) == 730

--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -639,6 +639,18 @@ See the following files for examples on setting this value at a more granular le
 
 **Notes of caution:** N/A
 
+#### &lt;Pre-Simulation Emissions&gt;
+
+**Data Type:** Boolean
+
+**Default input:** None
+
+**Description:** This parameter specifies if LDAR-Sim should generate emissions existing before the start date of the simulation. If "True", emissions beginning up to duration days before the start of the simulation will be generated. This essentially initializes the system from a state of no LDAR.
+
+**Notes on acquisition:** N/A
+
+**Notes of caution:** N/A
+
 ### repairable_emissions / non_repairable_emissions
 
 **Description:** These parameters do not require user-defined input. Its purpose is to provide a broader categorization for parameters that define the emission characteristics of the virtual world. The following sub-parameters:  `emissions_production_rate`, `emissions_rate_source`, `duration` and `multiple_emissions_per_source`, can be set for either repairable emissions and/or non-repairable emissions.

--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -643,9 +643,9 @@ See the following files for examples on setting this value at a more granular le
 
 **Data Type:** Boolean
 
-**Default input:** None
+**Default input:** True
 
-**Description:** This parameter specifies if LDAR-Sim should generate emissions existing before the start date of the simulation. If "True", emissions beginning up to duration days before the start of the simulation will be generated. This essentially initializes the system from a state of no LDAR.
+**Description:** This parameter specifies if LDAR-Sim should generate emissions existing before the start date of the simulation. When set to 'False,' emissions are not generated before the simulation's start date. By default, emissions are produced leading up to this date, based on their durations, enabling the system to model a state without LDAR.
 
 **Notes on acquisition:** N/A
 


### PR DESCRIPTION
# Pull Request Key Information

## Reason for change

In some cases, it is incorrect to simulate emissions beginning from
a state of no LDAR.

## What was changed

Added a parameter to the virtual world that allows the user to
specify whether or not to simulate emissions that "begin" before the
start of the simulation.

## Intended Purpose

The user can now specify whether or not to simulate emissions that
"begin" before the start of the simulation.

## Level of version change required

Patch

## Testing Completed

Manually tested the new parameter.

All unit tests pass:
[unit_test_results.txt](https://github.com/user-attachments/files/16852360/unit_test_results.txt)


All E2E tests pass:
[V4_simple_non_repairable_emissions_94605cd505228520195787c6f0f16f66e692d90c.log](https://github.com/user-attachments/files/16852316/V4_simple_non_repairable_emissions_94605cd505228520195787c6f0f16f66e692d90c.log)
[V4-simple_repairable_emissions_94605cd505228520195787c6f0f16f66e692d90c.log](https://github.com/user-attachments/files/16852319/V4-simple_repairable_emissions_94605cd505228520195787c6f0f16f66e692d90c.log)

## Target Issue

Put GitHub keywords to link the pull request to the target issue here. For example: Closes #XX.

## Additional Information

Include any other important information here.
