### PR TITLE
fix: fixed issue with METEC_NoWind_sensor.py

### DIFF
--- a/LDAR_Sim/src/sensors/METEC_NoWind_sensor.py
+++ b/LDAR_Sim/src/sensors/METEC_NoWind_sensor.py
@@ -51,8 +51,14 @@ class METECNWSite(DefaultSiteLevelSensor):
 
 
 class METECNWEquipmentGroup(DefaultEquipmentGroupLevelSensor):
-    def __init__(self, mdl: float, quantification_error: float) -> None:
-        super().__init__(mdl, quantification_error)
+    def __init__(
+        self,
+        mdl: float,
+        quantification_parameters: list[float],
+        quantification_type: str = QuantificationTypes.DEFAULT.value,
+        input_dir: str = None,
+    ) -> None:
+        super().__init__(mdl, quantification_parameters, quantification_type, input_dir)
 
     def _rate_detected(self, emis_rate: float) -> bool:
         prob_detect = 1 / (1 + np.exp(self._mdl[0] - self._mdl[1] * (emis_rate * CC.GS_TO_KGHR)))
@@ -62,8 +68,14 @@ class METECNWEquipmentGroup(DefaultEquipmentGroupLevelSensor):
 
 
 class METECNWComponent(DefaultComponentLevelSensor):
-    def __init__(self, mdl: float, quantification_error: float) -> None:
-        super().__init__(mdl, quantification_error)
+    def __init__(
+        self,
+        mdl: float,
+        quantification_parameters: list[float],
+        quantification_type: str = QuantificationTypes.DEFAULT.value,
+        input_dir: str = None,
+    ) -> None:
+        super().__init__(mdl, mdl, quantification_parameters, quantification_type, input_dir)
 
     def _rate_detected(self, emis_rate: float) -> bool:
         prob_detect = 1 / (1 + np.exp(self._mdl[0] - self._mdl[1] * (emis_rate * CC.GS_TO_KGHR)))


### PR DESCRIPTION
# Pull Request Key Information

## Reason for change

The METEC_NoWind_sensor was out of date for the current version of the LDAR-Sim, resulting in a runtime error when using it at the equipment or component level.

## What was changed

The METEC_NoWind_sensor was updated to the current version of the LDAR-Sim, allowing it to be used at the equipment or component level.

## Intended Purpose

The METEC_NoWind_sensor can now be used at the equipment or component level without causing a runtime error.

## Level of version change required

Patch

## Testing Completed

All unit tests pass:
[unit_test_results.txt](https://github.com/user-attachments/files/17000320/unit_test_results.txt)

All E2E tests pass:
[V4_simple_non_repairable_emissions_a706ce6ec48c54cc7e83ba17edf74727e5dd863a.log](https://github.com/user-attachments/files/17000321/V4_simple_non_repairable_emissions_a706ce6ec48c54cc7e83ba17edf74727e5dd863a.log)
[V4-simple_repairable_emissions_a706ce6ec48c54cc7e83ba17edf74727e5dd863a.log](https://github.com/user-attachments/files/17000322/V4-simple_repairable_emissions_a706ce6ec48c54cc7e83ba17edf74727e5dd863a.log)

Manually tested a very simple simulation using the plugin at both component and equipment level.

## Target Issue

N/A

## Additional Information

N/A
