### PR TITLE
<BUG>Unit conversion fix

### DIFF
--- a/LDAR_Sim/src/file_processing/input_processing/emissions_source_processing.py
+++ b/LDAR_Sim/src/file_processing/input_processing/emissions_source_processing.py
@@ -71,7 +71,7 @@ class EmissionsSource:
                     input_increment=unit_time,
                 )
                 converted_list.append(converted_val)
-            return for_conversion
+            return converted_list
 
     def get_a_rate(self) -> float:
         return 0.0

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 2025-09-18 - Version 4.2.4
+
+1. Bugfix - Fixed the unit conversion for emissions sampling (previously always assumed g/s when sampling emission rates)
+
 ## 2025-08-19 - Version 4.2.3
 
 1. Bugfix - Updated Daylight Calculator to handle extreme daylight conditions.


### PR DESCRIPTION
# Pull Request Key Information

## Reason for change

Unit conversion was not working when emissions had a sample as input. 

## What was changed

Fixed bug

## Intended Purpose

Allow users to use different units for providing emission rate samples

## Level of version change required

Patch

## Testing Completed

Manually tested with using simple-test-case where all emissions were 10 kg/hr and looked at the emissions_summary file
<img width="2205" height="582" alt="image" src="https://github.com/user-attachments/assets/8e650f44-fc36-4daa-8367-060316136fb4" />


## Target Issue

Put GitHub keywords to link the pull request to the target issue here. For example: Closes #XX.

## Additional Information

Include any other important information here.
